### PR TITLE
Use new and awesome itertools 0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ rand="*"
 byteorder="*"
 
 [dependencies]
-itertools="*"
+itertools="0.4"
 time = "*"
 fnv="*"
 # timely="*"

--- a/src/operators/group.rs
+++ b/src/operators/group.rs
@@ -284,7 +284,7 @@ where G::Timestamp: LeastUpperBound {
                         for (val, wgt) in Coalesce::coalesce(unsafe { result.get_collection_using(&key, &index, &mut heap2) }
                                                                    .map(|(v, w)| (v,-w))
                                                                    .merge_by(buffer.iter().map(|&(ref v, w)| (v, w)), |x,y| {
-                                                                        x.0.cmp(&y.0)
+                                                                        x.0 <= y.0
                                                                    }))
                         {
                             session.give((reduc(&key, val), wgt));


### PR DESCRIPTION
Use new and awesome itertools 0.4.0

Pin version to `0.4.x` and update for `.merge_by()` change.