### PR TITLE
Make `Collection` into an abstract wrapper type and use it everywhere possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ let start = roots.map(|(x, w)| ((x, 0), w));
 let limit = start.iterate(|dists| {
 
     // bring the invariant edges into the loop
-    let edges = dists.builder().enter(&edges);
+    let edges = edges.enter(&dists.scope());
 
     // join current distances with edges to get +1 distances,
     // include the current distances in the set as well,

--- a/examples/bc.rs
+++ b/examples/bc.rs
@@ -8,6 +8,7 @@ use rand::{Rng, SeedableRng, StdRng};
 use timely::dataflow::*;
 use timely::dataflow::operators::*;
 
+use differential_dataflow::Collection;
 use differential_dataflow::collection::LeastUpperBound;
 use differential_dataflow::operators::*;
 use differential_dataflow::operators::join::JoinBy;
@@ -78,9 +79,9 @@ fn main() {
 
 // returns pairs (n, (r, b, s)) indicating node n can be reached from root r by b in s steps.
 // one pair for each shortest path (so, this number can get quite large, but it is in binary)
-fn bc<G: Scope>(edges: &Stream<G, ((u32, u32), i32)>,
-                       roots: &Stream<G, (u32 ,i32)>)
-                            -> Stream<G, ((u32, u32, u32, u32), i32)>
+fn bc<G: Scope>(edges: &Collection<G, (u32, u32)>,
+                       roots: &Collection<G, u32>)
+                            -> Collection<G, (u32, u32, u32, u32)>
 where G::Timestamp: LeastUpperBound {
 
     // initialize roots as reaching themselves at distance 0

--- a/examples/bc.rs
+++ b/examples/bc.rs
@@ -92,8 +92,8 @@ where G::Timestamp: LeastUpperBound {
 
     let dists = nodes.iterate(|dists| {
 
-        let edges = edges.enter_into(&dists.scope());
-        let nodes = nodes.enter_into(&dists.scope());
+        let edges = edges.enter(&dists.scope());
+        let nodes = nodes.enter(&dists.scope());
 
         dists.join_by_u(&edges, |(n,r,_,s)| (n, (r,s)), |e| e, |&n, &(r,s), &d| (d, r, n, s+1))
              .concat(&nodes)

--- a/examples/bfs.rs
+++ b/examples/bfs.rs
@@ -33,7 +33,7 @@ fn main() {
 
             let roots = vec![(0,1)].into_iter().to_stream(scope);
             let (edge_input, graph) = scope.new_input();
-            let probe = bfs(&graph, &roots).probe().0;
+            let probe = bfs(&Collection::new(graph), &Collection::new(roots)).probe().0;
 
             (edge_input, probe)
         });
@@ -93,15 +93,15 @@ fn bfs<G: Scope>(edges: &Collection<G, Edge>, roots: &Collection<G, Node>) -> Co
 where G::Timestamp: LeastUpperBound {
 
     // initialize roots as reaching themselves at distance 0
-    let nodes = roots.map(|(x,w)| ((x, 0), w));
+    let nodes = roots.map(|x| (x, 0));
     // let edges = edges.map_in_place(|x| x.0 = ((x.0).1, (x.0).0))
     //                  .concat(&edges);
 
     // repeatedly update minimal distances each node can be reached from each root
     nodes.iterate(|inner| {
 
-        let edges = inner.scope().enter(&edges);
-        let nodes = inner.scope().enter(&nodes);
+        let edges = edges.enter_into(&inner.scope());
+        let nodes = nodes.enter_into(&inner.scope());
 
         inner.join_map_u(&edges, |_k,l,d| (*d, l+1))
              .concat(&nodes)

--- a/examples/bfs.rs
+++ b/examples/bfs.rs
@@ -100,8 +100,8 @@ where G::Timestamp: LeastUpperBound {
     // repeatedly update minimal distances each node can be reached from each root
     nodes.iterate(|inner| {
 
-        let edges = edges.enter_into(&inner.scope());
-        let nodes = nodes.enter_into(&inner.scope());
+        let edges = edges.enter(&inner.scope());
+        let nodes = nodes.enter(&inner.scope());
 
         inner.join_map_u(&edges, |_k,l,d| (*d, l+1))
              .concat(&nodes)

--- a/examples/bfs.rs
+++ b/examples/bfs.rs
@@ -9,6 +9,7 @@ use timely::progress::timestamp::RootTimestamp;
 
 use rand::{Rng, SeedableRng, StdRng};
 
+use differential_dataflow::Collection;
 use differential_dataflow::operators::*;
 use differential_dataflow::operators::join::JoinUnsigned;
 use differential_dataflow::operators::group::GroupUnsigned;
@@ -88,7 +89,7 @@ fn main() {
 }
 
 // returns pairs (n, s) indicating node n can be reached from a root in s steps.
-fn bfs<G: Scope>(edges: &Stream<G, (Edge, i32)>, roots: &Stream<G, (Node, i32)>) -> Stream<G, ((Node, u32), i32)>
+fn bfs<G: Scope>(edges: &Collection<G, Edge>, roots: &Collection<G, Node>) -> Collection<G, (Node, u32)>
 where G::Timestamp: LeastUpperBound {
 
     // initialize roots as reaching themselves at distance 0

--- a/examples/cc.rs
+++ b/examples/cc.rs
@@ -65,8 +65,8 @@ where G::Timestamp: LeastUpperBound+Hash {
     // don't actually use these labels, just grab the type
     nodes.filter(|_| false)
          .iterate(|inner| {
-             let edges = edges.enter_into(&inner.scope());
-             let nodes = nodes.enter_into_at(&inner.scope(), |r| 256 * (64 - (r.0).0.leading_zeros() as u64));
+             let edges = edges.enter(&inner.scope());
+             let nodes = nodes.enter_at(&inner.scope(), |r| 256 * (64 - (r.0).0.leading_zeros() as u64));
 
             inner.join_map_u(&edges, |_k,l,d| (*d,*l))
                  .concat(&nodes)

--- a/examples/cc.rs
+++ b/examples/cc.rs
@@ -6,6 +6,7 @@ extern crate graph_map;
 extern crate differential_dataflow;
 
 use std::hash::Hash;
+use std::mem;
 use timely::dataflow::*;
 use timely::dataflow::operators::*;
 
@@ -42,7 +43,7 @@ fn main() {
                 })
                 .to_stream(scope);
 
-            connected_components(&edges);
+            connected_components(&Collection::new(edges));
         });
     });
 }
@@ -52,20 +53,20 @@ where G::Timestamp: LeastUpperBound+Hash {
 
     // each edge (x,y) means that we need at least a label for the min of x and y.
     let nodes = edges.map_in_place(|pair| {
-                        let min = std::cmp::min((pair.0).0, (pair.0).1);
-                        pair.0 = (min, min);
+                        let min = std::cmp::min(pair.0, pair.1);
+                        *pair = (min, min);
                      })
                      .consolidate_by(|x| x.0);
 
     // each edge should exist in both directions.
-    let edges = edges.map_in_place(|x| x.0 = ((x.0).1, (x.0).0))
+    let edges = edges.map_in_place(|x| mem::swap(&mut x.0, &mut x.1))
                      .concat(&edges);
 
     // don't actually use these labels, just grab the type
     nodes.filter(|_| false)
          .iterate(|inner| {
-             let edges = inner.scope().enter(&edges);
-             let nodes = inner.scope().enter_at(&nodes, |r| 256 * (64 - (r.0).0.leading_zeros() as u64));
+             let edges = edges.enter_into(&inner.scope());
+             let nodes = nodes.enter_into_at(&inner.scope(), |r| 256 * (64 - (r.0).0.leading_zeros() as u64));
 
             inner.join_map_u(&edges, |_k,l,d| (*d,*l))
                  .concat(&nodes)

--- a/examples/cc.rs
+++ b/examples/cc.rs
@@ -9,6 +9,7 @@ use std::hash::Hash;
 use timely::dataflow::*;
 use timely::dataflow::operators::*;
 
+use differential_dataflow::Collection;
 use differential_dataflow::collection::LeastUpperBound;
 use differential_dataflow::operators::*;
 use differential_dataflow::operators::join::JoinUnsigned;
@@ -46,7 +47,7 @@ fn main() {
     });
 }
 
-fn connected_components<G: Scope>(edges: &Stream<G, (Edge, i32)>) -> Stream<G, ((Node, Node), i32)>
+fn connected_components<G: Scope>(edges: &Collection<G, Edge>) -> Collection<G, (Node, Node)>
 where G::Timestamp: LeastUpperBound+Hash {
 
     // each edge (x,y) means that we need at least a label for the min of x and y.

--- a/examples/reachability.rs
+++ b/examples/reachability.rs
@@ -9,7 +9,7 @@ use timely::dataflow::*;
 use timely::dataflow::operators::*;
 use timely::progress::timestamp::RootTimestamp;
 
-use differential_dataflow::Data;
+use differential_dataflow::{Collection, Data};
 use differential_dataflow::operators::*;
 use differential_dataflow::collection::LeastUpperBound;
 use differential_dataflow::collection::robin_hood::RHHMap;
@@ -101,7 +101,7 @@ fn main() {
 }
 
 // returns pairs (n, s) indicating node n can be reached from a root in s steps.
-fn reach<G: Scope>(edges: &Stream<G, (Edge, i32)>, roots: &Stream<G, (Node, i32)>) -> Stream<G, ((Node, Node), i32)>
+fn reach<G: Scope>(edges: &Collection<G, Edge>, roots: &Collection<G, Node>) -> Collection<G, (Node, Node)>
 where G::Timestamp: LeastUpperBound {
 
     let roots = roots.map(|(x,w)| ((x,x),w));

--- a/examples/reachability.rs
+++ b/examples/reachability.rs
@@ -33,7 +33,7 @@ fn main() {
         let (mut graph, mut roots, probe) = computation.scoped(|scope| {
             let (root_input, roots) = scope.new_input();
             let (edge_input, graph) = scope.new_input();
-            let probe = reach(&graph, &roots).probe().0;
+            let probe = reach(&Collection::new(graph), &Collection::new(roots)).probe().0;
             (edge_input, root_input, probe)
         });
 
@@ -104,12 +104,12 @@ fn main() {
 fn reach<G: Scope>(edges: &Collection<G, Edge>, roots: &Collection<G, Node>) -> Collection<G, (Node, Node)>
 where G::Timestamp: LeastUpperBound {
 
-    let roots = roots.map(|(x,w)| ((x,x),w));
+    let roots = roots.map(|x| (x,x));
 
     roots.iterate(|inner| {
 
-        let edges = inner.scope().enter(&edges);
-        let roots = inner.scope().enter(&roots);
+        let edges = edges.enter_into(&inner.scope());
+        let roots = roots.enter_into(&inner.scope());
 
         inner.join_map(&edges, |_k,&l,&d| (d, l))
              .concat(&roots)

--- a/examples/reachability.rs
+++ b/examples/reachability.rs
@@ -108,8 +108,8 @@ where G::Timestamp: LeastUpperBound {
 
     roots.iterate(|inner| {
 
-        let edges = edges.enter_into(&inner.scope());
-        let roots = roots.enter_into(&inner.scope());
+        let edges = edges.enter(&inner.scope());
+        let roots = roots.enter(&inner.scope());
 
         inner.join_map(&edges, |_k,&l,&d| (d, l))
              .concat(&roots)

--- a/examples/scc.rs
+++ b/examples/scc.rs
@@ -92,7 +92,7 @@ fn main() {
 fn _trim_and_flip<G: Scope>(graph: &Collection<G, Edge>) -> Collection<G, Edge>
 where G::Timestamp: LeastUpperBound {
         graph.iterate(|edges| {
-            let inner = graph.enter_into(&edges.scope());
+            let inner = graph.enter(&edges.scope());
             edges.map(|(x,_)| x)
             //   .threshold(|&x| x, |i| (Vec::new(), i), |_, w| if w > 0 { 1 } else { 0 })
                  .group_by_u(|x|(x,()), |&x,_| x, |_,_,target| target.push(((),1)))
@@ -103,7 +103,7 @@ where G::Timestamp: LeastUpperBound {
 fn _strongly_connected<G: Scope>(graph: &Collection<G, Edge>) -> Collection<G, Edge>
 where G::Timestamp: LeastUpperBound+Hash {
     graph.iterate(|inner| {
-        let edges = graph.enter_into(&inner.scope());
+        let edges = graph.enter(&inner.scope());
         let trans = edges.map_in_place(|x| mem::swap(&mut x.0, &mut x.1));
         _trim_edges(&_trim_edges(inner, &edges), &trans)
     })
@@ -129,8 +129,8 @@ where G::Timestamp: LeastUpperBound+Hash {
 
     edges.filter(|_| false)
          .iterate(|inner| {
-             let edges = edges.enter_into(&inner.scope());
-             let nodes = nodes.enter_into_at(&inner.scope(), |r| 256 * (64 - ((r.0).0 as u64).leading_zeros() as u64));
+             let edges = edges.enter(&inner.scope());
+             let nodes = nodes.enter_at(&inner.scope(), |r| 256 * (64 - ((r.0).0 as u64).leading_zeros() as u64));
 
              _improve_labels(inner, &edges, &nodes)
          })

--- a/examples/scc.rs
+++ b/examples/scc.rs
@@ -4,6 +4,7 @@ extern crate timely;
 extern crate differential_dataflow;
 
 use std::hash::Hash;
+use std::mem;
 use rand::{Rng, SeedableRng, StdRng};
 
 use timely::dataflow::*;
@@ -30,7 +31,8 @@ fn main() {
 
         let mut input = computation.scoped::<u64,_,_>(|scope| {
 
-            let (input, mut edges) = scope.new_input();
+            let (input, edges) = scope.new_input();
+            let mut edges = Collection::new(edges);
 
             edges = _trim_and_flip(&edges);
             edges = _trim_and_flip(&edges);
@@ -90,20 +92,19 @@ fn main() {
 fn _trim_and_flip<G: Scope>(graph: &Collection<G, Edge>) -> Collection<G, Edge>
 where G::Timestamp: LeastUpperBound {
         graph.iterate(|edges| {
-                 let inner = edges.scope().enter(&graph);
-                 edges.map(|((x,_),w)| (x,w))
-                    //   .threshold(|&x| x, |i| (Vec::new(), i), |_, w| if w > 0 { 1 } else { 0 })
-                      .group_by_u(|x|(x,()), |&x,_| x, |_,_,target| target.push(((),1)))
-                      .join_by_u(&inner, |x| (x,()), |(s,d)| (d,s), |&d,_,&s| (s,d))
-             })
-             .map_in_place(|x| x.0 = ((x.0).1, (x.0).0))
+            let inner = graph.enter_into(&edges.scope());
+            edges.map(|(x,_)| x)
+            //   .threshold(|&x| x, |i| (Vec::new(), i), |_, w| if w > 0 { 1 } else { 0 })
+                 .group_by_u(|x|(x,()), |&x,_| x, |_,_,target| target.push(((),1)))
+                 .join_by_u(&inner, |x| (x,()), |(s,d)| (d,s), |&d,_,&s| (s,d))
+        }).map_in_place(|x| mem::swap(&mut x.0, &mut x.1))
 }
 
 fn _strongly_connected<G: Scope>(graph: &Collection<G, Edge>) -> Collection<G, Edge>
 where G::Timestamp: LeastUpperBound+Hash {
     graph.iterate(|inner| {
-        let edges = inner.scope().enter(&graph);
-        let trans = edges.map_in_place(|x| x.0 = ((x.0).1, (x.0).0));
+        let edges = graph.enter_into(&inner.scope());
+        let trans = edges.map_in_place(|x| mem::swap(&mut x.0, &mut x.1));
         _trim_edges(&_trim_edges(inner, &edges), &trans)
     })
 }
@@ -111,16 +112,16 @@ where G::Timestamp: LeastUpperBound+Hash {
 fn _trim_edges<G: Scope>(cycle: &Collection<G, Edge>, edges: &Collection<G, Edge>)
     -> Collection<G, Edge> where G::Timestamp: LeastUpperBound+Hash {
 
-    let nodes = edges.map_in_place(|x| (x.0).0 = (x.0).1)
+    let nodes = edges.map_in_place(|x| mem::swap(&mut x.0, &mut x.1))
                      .consolidate_by(|&x| x.0);
 
     let labels = _reachability(&cycle, &nodes);
 
     edges.join_map_u(&labels, |&e1,&e2,&l1| (e2,(e1,l1)))
          .join_map_u(&labels, |&e2,&(e1,l1),&l2| ((e1,e2),(l1,l2)))
-         .filter(|&((_,(l1,l2)), _)| l1 == l2)
-         .map(|(((x1,x2),_),d)| ((x2,x1),d))
-        //  .consolidate_by(|x| x.0)
+         .filter(|&(_,(l1,l2))| l1 == l2)
+         .map(|((x1,x2),_)| (x2,x1))
+    //   .consolidate_by(|x| x.0)
 }
 
 fn _reachability<G: Scope>(edges: &Collection<G, Edge>, nodes: &Collection<G, (Node, Node)>) -> Collection<G, Edge>
@@ -128,8 +129,8 @@ where G::Timestamp: LeastUpperBound+Hash {
 
     edges.filter(|_| false)
          .iterate(|inner| {
-             let edges = inner.scope().enter(&edges);
-             let nodes = inner.scope().enter_at(&nodes, |r| 256 * (64 - ((r.0).0 as u64).leading_zeros() as u64));
+             let edges = edges.enter_into(&inner.scope());
+             let nodes = nodes.enter_into_at(&inner.scope(), |r| 256 * (64 - ((r.0).0 as u64).leading_zeros() as u64));
 
              _improve_labels(inner, &edges, &nodes)
          })

--- a/examples/traffic.rs
+++ b/examples/traffic.rs
@@ -8,6 +8,7 @@ use rand::{Rng, SeedableRng, StdRng};
 use timely::dataflow::*;
 use timely::dataflow::operators::*;
 
+use differential_dataflow::Collection;
 use differential_dataflow::operators::*;
 
 type Node = u32;
@@ -20,7 +21,8 @@ fn main() {
         // define BFS dataflow; return handles to roots and edges inputs
         let mut graph = computation.scoped(|builder| {
             let (input, edges) = builder.new_input();
-            edges.consolidate()
+            Collection::new(edges)
+                 .consolidate()
                  .inspect_batch(move |t,b|
                      println!("epoch: {:?}, length: {}, processing: {}",
                         t, b.len(), (time::precise_time_s() - start) - (t.inner as f64))

--- a/in_progress/minimal.rs
+++ b/in_progress/minimal.rs
@@ -39,12 +39,12 @@ fn main() {
     //     edges.filter(|_| false)
     //          .iterate(u32::max_value(), |x| x.0, |x| x.0, |inner| {
     //
-    //              let edges = inner.builder.enter(&edges);
+    //              let edges = edges.enter(&inner.scope());
     //
     //              // prep the same computation using the iterated data
-    //              let degrs_o = inner.builder.enter(&degrs);
-    //              let neigh_o = inner.builder.enter(&neigh);
-    //              let dpdnt_o = inner.builder.enter(&dpdnt);
+    //              let degrs_o = degrs.enter(&inner.scope());
+    //              let neigh_o = neigh.enter(&inner.scope());
+    //              let dpdnt_o = dpdnt.enter(&inner.scope());
     //
     //              let degrs_i = inner.group_by_u(|x| x, |k,v| (*k,*v), |_k, s, t| { t.push((s.count() as u32, 1)); });
     //              let neigh_i = degrs_i.join_u(&inner, |x| x, |y| y, |k,x,y| (*k,*x,*y));

--- a/in_progress/pagerank.rs
+++ b/in_progress/pagerank.rs
@@ -13,6 +13,7 @@
 //
 // use rand::{Rng, SeedableRng, StdRng};
 //
+// use differential_dataflow::Collection;
 // use differential_dataflow::collection_trace::lookup::UnsignedInt;
 // use differential_dataflow::collection_trace::LeastUpperBound;
 //
@@ -109,7 +110,7 @@ fn main() {
 //             computation.step(); // shut down
 }
 //
-// fn pagerank<G: GraphBuilder, U: UnsignedInt>(edges: &Stream<G, ((U, U), i32)>) -> Stream<G, (U, i32)>
+// fn pagerank<G: GraphBuilder, U: UnsignedInt>(edges: &Collection<G, (U, U)>) -> Collection<G, U>
 // where G::Timestamp: LeastUpperBound+Hash {
 //
 //     let degrs = edges.map(|(x,w)| (x.0,w))

--- a/in_progress/pagerank.rs
+++ b/in_progress/pagerank.rs
@@ -123,8 +123,8 @@ fn main() {
 //     edges.group_by_u(|x| (x.0,()), |k,_| *k, |_,_,t| { t.push(((), 10000)) })
 //          .iterate(u32::max_value(), |||x| *x, |ranks| {
 //
-//              let degrs = ranks.builder().enter(&degrs);
-//              let edges = ranks.builder().enter(&edges);
+//              let degrs = degrs.enter(&ranks.scope());
+//              let edges = edges.enter(&ranks.scope());
 //
 //              // pair surfers with the out-degree of their location
 //              ranks.join_u(&degrs, |n| (n,()), |nc| nc, |n,_,c| (*n,*c))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,8 +109,7 @@ use std::fmt::Debug;
 /// A change in count.
 pub type Delta = i32;
 
-/// A mutable collection of values of type `T`.
-pub type Collection<G, T> = timely::dataflow::Stream<G, (T, Delta)>;
+pub use stream::Collection;
 
 /// A composite trait for data types usable in differential dataflow.
 pub trait Data : timely::Data + ::std::hash::Hash + Ord + Debug {
@@ -144,3 +143,4 @@ extern crate timely_communication;
 pub mod collection;
 pub mod operators;
 mod iterators;
+mod stream;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@
 //!         let limit = start.iterate(|dists| {
 //!
 //!             // bring the invariant edges into the loop
-//!             let edges = dists.builder().enter(&edges);
+//!             let edges = edges.enter(&dists.scope());
 //!
 //!             // join current distances with edges to get +1 distances,
 //!             // include the current distances in the set as well,

--- a/src/operators/cogroup.rs
+++ b/src/operators/cogroup.rs
@@ -51,13 +51,8 @@ use iterators::coalesce::Coalesce;
 use radix_sort::{RadixSorter, Unsigned};
 use collection::compact::Compact;
 
-impl<G: Scope, K: Data, V1: Data, S> CoGroupBy<G, K, V1> for S
-where G::Timestamp: LeastUpperBound,
-      S: Binary<G, ((K,V1), i32)>+Map<G, ((K,V1), i32)> { }
-
 /// Extension trait for the `group_by` and `group_by_u` differential dataflow methods.
-pub trait CoGroupBy<G: Scope, K: Data, V1: Data> : Binary<G, ((K,V1), i32)>+Map<G, ((K,V1), i32)>
-where G::Timestamp: LeastUpperBound {
+pub trait CoGroupBy<G: Scope, K: Data, V1: Data> where G::Timestamp: LeastUpperBound {
 
     /// A primitive binary version of `group_by`, which acts on a `Collection<G, (K, V1)>` and a `Collection<G, (K, V2)>`.
     ///
@@ -67,6 +62,22 @@ where G::Timestamp: LeastUpperBound {
     /// The right thing to use here, for the moment, is `|_| HashMap::new()`.
     ///
     /// There are better options if you know your key is an unsigned integer, namely `|x| (Vec::new(), x)`.
+    fn cogroup_by_inner<
+        D:     Data,
+        V2:    Data+Default,
+        V3:    Data+Default,
+        U:     Unsigned+Default,
+        KH:    Fn(&K)->U+'static,
+        Look:  Lookup<K, Offset>+'static,
+        LookG: Fn(u64)->Look,
+        Logic: Fn(&K, &mut CollectionIterator<V1>, &mut CollectionIterator<V2>, &mut Vec<(V3, i32)>)+'static,
+        Reduc: Fn(&K, &V3)->D+'static,
+    >
+    (&self, other: &Collection<G, (K, V2)>, key_h: KH, reduc: Reduc, look: LookG, logic: Logic) -> Collection<G, D>;
+}
+
+impl<G: Scope, K: Data, V1: Data> CoGroupBy<G, K, V1> for Collection<G, (K, V1)>
+where G::Timestamp: LeastUpperBound {
     fn cogroup_by_inner<
         D:     Data,
         V2:    Data+Default,
@@ -109,7 +120,7 @@ where G::Timestamp: LeastUpperBound {
         let mut sorter2 = RadixSorter::new();
 
         // fabricate a data-parallel operator using the `unary_notify` pattern.
-        self.binary_notify(other, exch1, exch2, "CoGroupBy", vec![], move |input1, input2, output, notificator| {
+        Collection::new(self.inner.binary_notify(&other.inner, exch1, exch2, "CoGroupBy", vec![], move |input1, input2, output, notificator| {
 
             // 1. read each input, and stash it in our staging area
             while let Some((time, data)) = input1.next() {
@@ -250,6 +261,6 @@ where G::Timestamp: LeastUpperBound {
                     }
                 }
             }
-        })
+        }))
     }
 }

--- a/src/operators/cogroup.rs
+++ b/src/operators/cogroup.rs
@@ -38,7 +38,7 @@ use std::ops::DerefMut;
 
 use itertools::Itertools;
 
-use ::Data;
+use ::{Collection, Data};
 use timely::dataflow::*;
 use timely::dataflow::operators::{Map, Binary};
 use timely::dataflow::channels::pact::Exchange;
@@ -59,7 +59,7 @@ where G::Timestamp: LeastUpperBound,
 pub trait CoGroupBy<G: Scope, K: Data, V1: Data> : Binary<G, ((K,V1), i32)>+Map<G, ((K,V1), i32)>
 where G::Timestamp: LeastUpperBound {
 
-    /// A primitive binary version of `group_by`, which acts on a `Stream<((K,V1),i32)` and a `Stream<((K,V2),i32)`.
+    /// A primitive binary version of `group_by`, which acts on a `Collection<G, (K, V1)>` and a `Collection<G, (K, V2)>`.
     ///
     /// The two streams must already be key-value pairs, which is too bad. Also, in addition to the
     /// normal arguments (another stream, a hash for the key, a reduction function, and per-key logic),
@@ -78,7 +78,7 @@ where G::Timestamp: LeastUpperBound {
         Logic: Fn(&K, &mut CollectionIterator<V1>, &mut CollectionIterator<V2>, &mut Vec<(V3, i32)>)+'static,
         Reduc: Fn(&K, &V3)->D+'static,
     >
-    (&self, other: &Stream<G, ((K,V2),i32)>, key_h: KH, reduc: Reduc, look: LookG, logic: Logic) -> Stream<G, (D, i32)> {
+    (&self, other: &Collection<G, (K, V2)>, key_h: KH, reduc: Reduc, look: LookG, logic: Logic) -> Collection<G, D> {
 
         let mut source1 = Trace::new(look(0));
         let mut source2 = Trace::new(look(0));

--- a/src/operators/consolidate.rs
+++ b/src/operators/consolidate.rs
@@ -48,14 +48,14 @@ impl<G: Scope, D: Ord+Data+Debug> ConsolidateExt<D> for Collection<G, D> {
     fn consolidate(&self) -> Self {
        self.consolidate_by(|x| x.hashed())
     }
-    fn consolidate_by<U: Unsigned, F: Fn(&D)->U+'static>(&self, part: F) -> Self {
 
+    fn consolidate_by<U: Unsigned, F: Fn(&D)->U+'static>(&self, part: F) -> Self {
         let mut inputs = Vec::new();    // Vec<(G::Timestamp, Vec<(D, i32))>
         let part1 = Rc::new(part);
         let part2 = part1.clone();
 
         let exch = Exchange::new(move |&(ref x,_)| (*part1)(x).as_u64());
-        self.unary_notify(exch, "Consolidate", vec![], move |input, output, notificator| {
+        Collection::new(self.inner.unary_notify(exch, "Consolidate", vec![], move |input, output, notificator| {
 
             // input.for_each(|index: &G::Timestamp, data: &mut Content<(D, i32)>| {
             while let Some((index, data)) = input.next() {
@@ -96,6 +96,6 @@ impl<G: Scope, D: Ord+Data+Debug> ConsolidateExt<D> for Collection<G, D> {
                 }
             }
             // });
-        })
+        }))
     }
 }

--- a/src/operators/consolidate.rs
+++ b/src/operators/consolidate.rs
@@ -30,7 +30,7 @@ use collection::Lookup;
 use iterators::coalesce::Coalesce;
 use radix_sort::{RadixSorter, Unsigned};
 
-use ::Data;
+use ::{Collection, Data};
 
 use timely::drain::DrainExt;
 
@@ -44,7 +44,7 @@ pub trait ConsolidateExt<D: Data> {
     fn consolidate_by<U: Unsigned, F: Fn(&D)->U+'static>(&self, part: F) -> Self;
 }
 
-impl<G: Scope, D: Ord+Data+Debug> ConsolidateExt<D> for Stream<G, (D, i32)> {
+impl<G: Scope, D: Ord+Data+Debug> ConsolidateExt<D> for Collection<G, D> {
     fn consolidate(&self) -> Self {
        self.consolidate_by(|x| x.hashed())
     }

--- a/src/operators/iterate.rs
+++ b/src/operators/iterate.rs
@@ -48,17 +48,17 @@ impl<G: Scope, D: Ord+Data+Debug> IterateExt<G, D> for Collection<G, D> {
         where G::Timestamp: LeastUpperBound,
               F: FnOnce(&Collection<Child<G, u64>, D>)->Collection<Child<G, u64>, D> {
 
-        self.scope().scoped(|subgraph| {
+        Collection::new(self.inner.scope().scoped(|subgraph| {
 
             let (feedback, cycle) = subgraph.loop_variable(u64::max(), 1);
-            let ingress = subgraph.enter(&self);
+            let ingress = subgraph.enter(&self.inner);
 
-            let bottom = logic(&ingress.concat(&cycle));
+            let bottom = logic(&Collection::new(ingress.concat(&cycle))).inner;
 
             bottom.concat(&ingress.map_in_place(|x| x.1 = -x.1))
                   .connect_loop(feedback);
 
             bottom.leave()
-        })
+        }))
     }
 }

--- a/src/operators/iterate.rs
+++ b/src/operators/iterate.rs
@@ -51,7 +51,7 @@ impl<G: Scope, D: Ord+Data+Debug> IterateExt<G, D> for Collection<G, D> {
         Collection::new(self.inner.scope().scoped(|subgraph| {
 
             let (feedback, cycle) = subgraph.loop_variable(u64::max(), 1);
-            let ingress = subgraph.enter(&self.inner);
+            let ingress = self.inner.enter(subgraph);
 
             let bottom = logic(&Collection::new(ingress.concat(&cycle))).inner;
 

--- a/src/operators/threshold.rs
+++ b/src/operators/threshold.rs
@@ -16,11 +16,19 @@ use collection::{LeastUpperBound, Lookup};
 use collection::count::{Count, Offset};
 use collection::compact::Compact;
 
-impl<G: Scope, D: Data+Default+'static, S: Unary<G, (D, i32)>> Threshold<G, D> for S where G::Timestamp: LeastUpperBound { }
-
 /// Extension trait for the `group` differential dataflow method
-pub trait Threshold<G: Scope, D: Data+Default+'static> : Unary<G, (D,i32)>
+pub trait Threshold<G: Scope, D: Data+Default+'static>
     where G::Timestamp: LeastUpperBound {
+    fn threshold<
+        F: Fn(&D, i32)->i32+'static,
+        U: Unsigned+Default+'static,
+        KeyH: Fn(&D)->U+'static,
+        Look:  Lookup<D, Offset>+'static,
+        LookG: Fn(u64)->Look+'static,
+        >(&self, key_h: KeyH, look: LookG, function: F) -> Collection<G, D>;
+}
+
+impl<G: Scope, D: Data+Default+'static> Threshold<G, D> for Collection<G, D> where G::Timestamp: LeastUpperBound {
     fn threshold<
         F: Fn(&D, i32)->i32+'static,
         U: Unsigned+Default+'static,
@@ -43,7 +51,7 @@ pub trait Threshold<G: Scope, D: Data+Default+'static> : Unary<G, (D,i32)>
         let key1 = Rc::new(key_h);
         let key2 = key1.clone();
 
-        self.unary_notify(Exchange::new(move |x: &(D, i32)| key1(&x.0).as_u64()), "Count", vec![], move |input, output, notificator| {
+        Collection::new(self.inner.unary_notify(Exchange::new(move |x: &(D, i32)| key1(&x.0).as_u64()), "Count", vec![], move |input, output, notificator| {
 
             while let Some((time, data)) = input.next() {
                 notificator.notify_at(&time);
@@ -125,6 +133,6 @@ pub trait Threshold<G: Scope, D: Data+Default+'static> : Unary<G, (D,i32)>
                 }
             }
 
-        })
+        }))
     }
 }

--- a/src/operators/threshold.rs
+++ b/src/operators/threshold.rs
@@ -4,7 +4,7 @@ use std::default::Default;
 
 use itertools::Itertools;
 
-use ::Data;
+use ::{Collection, Data};
 use timely::dataflow::*;
 use timely::dataflow::operators::{Map, Unary};
 use timely::dataflow::channels::pact::Exchange;
@@ -27,7 +27,7 @@ pub trait Threshold<G: Scope, D: Data+Default+'static> : Unary<G, (D,i32)>
         KeyH: Fn(&D)->U+'static,
         Look:  Lookup<D, Offset>+'static,
         LookG: Fn(u64)->Look+'static,
-        >(&self, key_h: KeyH, look: LookG, function: F) -> Stream<G, (D, i32)> {
+        >(&self, key_h: KeyH, look: LookG, function: F) -> Collection<G, D> {
 
         let mut source = Count::new(look(0));
         let mut result = Count::new(look(0));

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -44,13 +44,13 @@ impl<G: Scope, D: Data> Collection<G, D> {
         }
     }
 
-    pub fn enter_into<T: Timestamp>(&self, child: &Child<G, T>) -> Collection<Child<G, T>, D> {
+    pub fn enter<T: Timestamp>(&self, child: &Child<G, T>) -> Collection<Child<G, T>, D> {
         Collection {
             inner: child.enter(&self.inner)
         }
     }
 
-    pub fn enter_into_at<T: Timestamp, F: Fn(&(D, Delta)) -> T + 'static>(&self, child: &Child<G, T>, initial: F) -> Collection<Child<G, T>, D> where G::Timestamp: Hash, T: Hash {
+    pub fn enter_at<T: Timestamp, F: Fn(&(D, Delta)) -> T + 'static>(&self, child: &Child<G, T>, initial: F) -> Collection<Child<G, T>, D> where G::Timestamp: Hash, T: Hash {
         Collection {
             inner: child.enter_at(&self.inner, initial)
         }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,0 +1,89 @@
+use std::hash::Hash;
+
+use timely::Data;
+use timely::progress::Timestamp;
+use timely::dataflow::scopes::Child;
+use timely::dataflow::{Scope, Stream};
+use timely::dataflow::operators::*;
+
+use ::Delta;
+
+/// A mutable collection of values of type `D`
+pub struct Collection<G: Scope, D: Data> {
+    pub inner: Stream<G, (D, Delta)>
+}
+
+impl<G: Scope, D: Data> Collection<G, D> {
+    pub fn new(inner: Stream<G, (D, Delta)>) -> Collection<G, D> {
+        Collection {
+            inner: inner
+        }
+    }
+
+    pub fn map<D2: Data, L: Fn(D) -> D2 + 'static>(&self, logic: L) -> Collection<G, D2> {
+        Collection {
+            inner: self.inner.map(move |(data, delta)| (logic(data), delta))
+        }
+    }
+
+    pub fn map_in_place<L: Fn(&mut D) + 'static>(&self, logic: L) -> Collection<G, D> {
+        Collection {
+            inner: self.inner.map_in_place(move |&mut (ref mut data, _)| logic(data))
+        }
+    }
+
+    pub fn filter<L: Fn(&D) -> bool + 'static>(&self, logic: L) -> Collection<G, D> {
+        Collection {
+            inner: self.inner.filter(move |&(ref data, _)| logic(data))
+        }
+    }
+
+    pub fn concat(&self, other: &Collection<G, D>) -> Collection<G, D> {
+        Collection {
+            inner: self.inner.concat(&other.inner)
+        }
+    }
+
+    pub fn enter_into<T: Timestamp>(&self, child: &Child<G, T>) -> Collection<Child<G, T>, D> {
+        Collection {
+            inner: child.enter(&self.inner)
+        }
+    }
+
+    pub fn enter_into_at<T: Timestamp, F: Fn(&(D, Delta)) -> T + 'static>(&self, child: &Child<G, T>, initial: F) -> Collection<Child<G, T>, D> where G::Timestamp: Hash, T: Hash {
+        Collection {
+            inner: child.enter_at(&self.inner, initial)
+        }
+    }
+
+    pub fn inspect<F: FnMut(&(D, Delta))+'static>(&self, func: F) -> Collection<G, D> {
+        Collection {
+            inner: self.inner.inspect(func)
+        }
+    }
+
+    pub fn inspect_batch<F: FnMut(&G::Timestamp, &[(D, Delta)])+'static>(&self, func: F) -> Collection<G, D> {
+        Collection {
+            inner: self.inner.inspect_batch(func)
+        }
+    }
+
+    pub fn probe(&self) -> (probe::Handle<G::Timestamp>, Collection<G, D>) {
+        let (handle, stream) = self.inner.probe();
+        (handle, Collection {
+            inner: stream
+        })
+    }
+
+    pub fn scope(&self) -> G {
+        self.inner.scope()
+    }
+}
+
+impl<G: Scope, T: Timestamp, D: Data> Collection<Child<G, T>, D> {
+    pub fn leave(&self) -> Collection<G, D> {
+        Collection {
+            inner: self.inner.leave()
+        }
+    }
+}

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -46,13 +46,13 @@ impl<G: Scope, D: Data> Collection<G, D> {
 
     pub fn enter<T: Timestamp>(&self, child: &Child<G, T>) -> Collection<Child<G, T>, D> {
         Collection {
-            inner: child.enter(&self.inner)
+            inner: self.inner.enter(child)
         }
     }
 
     pub fn enter_at<T: Timestamp, F: Fn(&(D, Delta)) -> T + 'static>(&self, child: &Child<G, T>, initial: F) -> Collection<Child<G, T>, D> where G::Timestamp: Hash, T: Hash {
         Collection {
-            inner: child.enter_at(&self.inner, initial)
+            inner: self.inner.enter_at(child, initial)
         }
     }
 


### PR DESCRIPTION
This partially hides some implementation details from the programmer, making a few APIs nicer. For example, `map` and `filter` now don't expose multiplicities.