### PR TITLE
Use contain-rs' maps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ time = "0.1.34"
 fnv="1.0.2"
 rc="0.1.1"
 linear-map = "0.0.4"
+vec_map = "0.6.0"
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ itertools="0.4"
 time = "0.1.34"
 fnv="1.0.2"
 rc="0.1.1"
+linear-map = "0.0.4"
 
 [features]
 default = []

--- a/examples/scc.rs
+++ b/examples/scc.rs
@@ -2,10 +2,13 @@ extern crate rand;
 extern crate time;
 extern crate timely;
 extern crate differential_dataflow;
+extern crate vec_map;
 
 use std::hash::Hash;
 use std::mem;
 use rand::{Rng, SeedableRng, StdRng};
+
+use vec_map::VecMap;
 
 use timely::dataflow::*;
 use timely::dataflow::operators::*;
@@ -95,7 +98,7 @@ where G::Timestamp: LeastUpperBound {
                          .map_in_place(|x| mem::swap(&mut x.0, &mut x.1));
 
         edges.map(|(x,_)| x)
-             .threshold(|&x| x, |i| (Vec::new(), i), |_,_| 1)
+             .threshold(|&x| x, |i| (VecMap::new(), i), |_,_| 1)
              .map(|x| (x,()))
              .join_map_u(&inner, |&d,_,&s| (s,d))
     })

--- a/src/collection/lookup.rs
+++ b/src/collection/lookup.rs
@@ -14,6 +14,7 @@ use timely_sort::Unsigned;
 
 use collection::robin_hood::RHHMap;
 use linear_map::LinearMap;
+use vec_map::VecMap;
 
 pub trait Lookup<K: Eq, V> {
     fn get_ref<'a>(&'a self, &K)->Option<&'a V>;
@@ -68,27 +69,25 @@ impl<K: Eq, V> Lookup<K, V> for LinearMap<K, V> {
     fn remove_key(&mut self, key: &K) -> Option<V> { self.remove(key) }
 }
 
-impl<V: 'static, U: Unsigned> Lookup<U,V> for (Vec<Option<V>>, u64) {
+impl<V: 'static, U: Unsigned> Lookup<U,V> for (VecMap<V>, u64) {
     #[inline]
     fn get_ref<'a>(&'a self, key: &U) -> Option<&'a V> {
         let key = (key.as_u64() >> self.1) as usize;
-        if self.0.len() > key { self.0[key].as_ref() } else { None }
+        self.0.get(key)
     }
     #[inline]
     fn get_mut<'a>(&'a mut self, key: &U) -> Option<&'a mut V> {
         let key = (key.as_u64() >> self.1) as usize;
-        if self.0.len() > key { self.0[key].as_mut() } else { None }
+        self.0.get_mut(key)
     }
     #[inline]
     fn entry_or_insert<F: FnOnce()->V>(&mut self, key: U, func: F) -> &mut V {
         let key = (key.as_u64() >> self.1) as usize;
-        while self.0.len() <= key { self.0.push(None); }
-        if self.0[key].is_none() { self.0[key] = Some(func()); }
-        self.0[key].as_mut().unwrap()
+        self.0.entry(key).or_insert_with(func)
     }
     #[inline]
     fn remove_key(&mut self, key: &U) -> Option<V> {
         let key = (key.as_u64() >> self.1) as usize;
-        if self.0.len() > key { self.0[key].take() } else { None }
+        self.0.remove(key)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,6 +144,7 @@ extern crate fnv;
 extern crate time;
 extern crate timely;
 extern crate itertools;
+extern crate linear_map;
 extern crate timely_sort;
 extern crate timely_communication;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,6 +143,7 @@ extern crate rc;
 extern crate fnv;
 extern crate time;
 extern crate timely;
+extern crate vec_map;
 extern crate itertools;
 extern crate linear_map;
 extern crate timely_sort;

--- a/src/operators/arrange.rs
+++ b/src/operators/arrange.rs
@@ -9,6 +9,8 @@ use std::cell::RefCell;
 use std::default::Default;
 use std::ops::DerefMut;
 
+use linear_map::LinearMap;
+
 use timely::dataflow::*;
 use timely::dataflow::operators::{Map, Unary};
 use timely::dataflow::channels::pact::Exchange;
@@ -94,7 +96,7 @@ impl<G: Scope, K: Data, V: Data> ArrangeByKey<G, K, V> for Collection<G, (K, V)>
         let source = trace.downgrade();
 
         // A map from times to received (key, val, wgt) triples.
-        let mut inputs = Vec::new();
+        let mut inputs = LinearMap::new();
 
         // create an exchange channel based on the supplied Fn(&D1)->u64.
         let part1 = Rc::new(key_h);
@@ -188,7 +190,7 @@ impl<G: Scope, K: Data> ArrangeBySelf<G, K> for Collection<G, K> where G::Timest
         let source = trace.downgrade();
 
         // A map from times to received (key, val, wgt) triples.
-        let mut inputs = Vec::new();
+        let mut inputs = LinearMap::new();
 
         // create an exchange channel based on the supplied Fn(&D1)->u64.
         let part1 = Rc::new(key_h);

--- a/src/operators/consolidate.rs
+++ b/src/operators/consolidate.rs
@@ -21,6 +21,8 @@
 use std::rc::Rc;
 use std::fmt::Debug;
 
+use linear_map::LinearMap;
+
 use timely::dataflow::*;
 use timely::dataflow::operators::*;
 use timely::dataflow::channels::pact::Exchange;
@@ -47,7 +49,7 @@ impl<G: Scope, D: Ord+Data+Debug> ConsolidateExt<D> for Collection<G, D> {
     }
 
     fn consolidate_by<U: Unsigned, F: Fn(&D)->U+'static>(&self, part: F) -> Self {
-        let mut inputs = Vec::new();    // Vec<(G::Timestamp, Vec<(D, i32))>
+        let mut inputs = LinearMap::new();    // LinearMap<G::Timestamp, Vec<(D, i32)>>
         let part1 = Rc::new(part);
         let part2 = part1.clone();
 

--- a/src/operators/group.rs
+++ b/src/operators/group.rs
@@ -37,6 +37,7 @@ use std::default::Default;
 use std::collections::HashMap;
 
 use itertools::Itertools;
+use linear_map::LinearMap;
 
 use ::{Data, Collection, Delta};
 use timely::dataflow::*;
@@ -152,10 +153,10 @@ where
         let target = result.clone();
 
         // A map from times to received (key, val, wgt) triples.
-        let mut inputs = Vec::new();
+        let mut inputs = LinearMap::new();
 
         // A map from times to a list of keys that need processing at that time.
-        let mut to_do = Vec::new();
+        let mut to_do = LinearMap::new();
 
         // temporary storage for operator implementations to populate
         let mut buffer = vec![];

--- a/src/operators/group.rs
+++ b/src/operators/group.rs
@@ -38,6 +38,7 @@ use std::collections::HashMap;
 
 use itertools::Itertools;
 use linear_map::LinearMap;
+use vec_map::VecMap;
 
 use ::{Data, Collection, Delta};
 use timely::dataflow::*;
@@ -100,8 +101,8 @@ impl<G: Scope, U: Unsigned+Data+Default, V: Data> GroupUnsigned<G, U, V> for Col
 where G::Timestamp: LeastUpperBound {
     fn group_u<L, V2: Data>(&self, logic: L) -> Collection<G, (U, V2)>
         where L: Fn(&U, &mut CollectionIterator<DifferenceIterator<V>>, &mut Vec<(V2, i32)>)+'static {
-            self.arrange_by_key(|k| k.as_u64(), |x| (Vec::new(), x))
-                .group(|k| k.as_u64(), |x| (Vec::new(), x), logic)
+            self.arrange_by_key(|k| k.as_u64(), |x| (VecMap::new(), x))
+                .group(|k| k.as_u64(), |x| (VecMap::new(), x), logic)
                 .as_collection()
         }
 }

--- a/src/operators/join.rs
+++ b/src/operators/join.rs
@@ -4,6 +4,7 @@ use std::default::Default;
 use std::collections::HashMap;
 
 use linear_map::LinearMap;
+use vec_map::VecMap;
 
 use timely::progress::Timestamp;
 use timely::dataflow::Scope;
@@ -88,13 +89,13 @@ pub trait JoinUnsigned<G: Scope, U: Unsigned+Data+Default, V: Data> where G::Tim
 
 impl<G: Scope, U: Unsigned+Data+Default, V: Data> JoinUnsigned<G, U, V> for Collection<G, (U, V)> where G::Timestamp: LeastUpperBound {
     fn join_map_u<V2: Data, D: Data, R: Fn(&U, &V, &V2)->D+'static>(&self, other: &Collection<G, (U,V2)>, logic: R) -> Collection<G, D> {
-        let arranged1 = self.arrange_by_key(|k| k.clone(), |x| (Vec::new(), x));
-        let arranged2 = other.arrange_by_key(|k| k.clone(), |x| (Vec::new(), x));
+        let arranged1 = self.arrange_by_key(|k| k.clone(), |x| (VecMap::new(), x));
+        let arranged2 = other.arrange_by_key(|k| k.clone(), |x| (VecMap::new(), x));
         arranged1.join(&arranged2, logic)
     }
     fn semijoin(&self, other: &Collection<G, U>) -> Collection<G, (U, V)> {
-        let arranged1 = self.arrange_by_key(|k| k.clone(), |x| (Vec::new(), x));
-        let arranged2 = other.arrange_by_self(|k| k.clone(), |x| (Vec::new(), x));
+        let arranged1 = self.arrange_by_key(|k| k.clone(), |x| (VecMap::new(), x));
+        let arranged2 = other.arrange_by_self(|k| k.clone(), |x| (VecMap::new(), x));
         arranged1.join(&arranged2, |k,v,_| (k.clone(), v.clone()))        
     }
 }

--- a/src/operators/join.rs
+++ b/src/operators/join.rs
@@ -3,6 +3,8 @@
 use std::default::Default;
 use std::collections::HashMap;
 
+use linear_map::LinearMap;
+
 use timely::progress::Timestamp;
 use timely::dataflow::Scope;
 use timely::dataflow::operators::Binary;
@@ -133,9 +135,9 @@ impl<TS: Timestamp, G: Scope<Timestamp=TS>, T: Trace<Index=TS>+'static> JoinArra
         let mut trace1 = Some(self.trace.clone());
         let mut trace2 = Some(other.trace.clone());
 
-        let mut inputs1 = Vec::new();
-        let mut inputs2 = Vec::new();
-        let mut outbuf = Vec::new();
+        let mut inputs1 = LinearMap::new();
+        let mut inputs2 = LinearMap::new();
+        let mut outbuf = LinearMap::new();
 
         // upper envelope of notified times; 
         // used to restrict diffs processed.
@@ -233,7 +235,7 @@ impl<TS: Timestamp, G: Scope<Timestamp=TS>, T: Trace<Index=TS>+'static> JoinArra
                 }
 
                 // make sure we hold capabilities for each time still to send at.
-                for &(ref new_time, _) in &outbuf {
+                for (new_time, _) in &outbuf {
                     notificator.notify_at(capability.delayed(new_time));
                 }
             }

--- a/src/operators/threshold.rs
+++ b/src/operators/threshold.rs
@@ -3,6 +3,7 @@ use std::ops::DerefMut;
 use std::default::Default;
 
 use itertools::Itertools;
+use linear_map::LinearMap;
 
 use ::{Collection, Data};
 use timely::dataflow::*;
@@ -41,10 +42,10 @@ impl<G: Scope, D: Data+Default+'static> Threshold<G, D> for Collection<G, D> whe
         let mut result = Count::new(look(0));
 
         // A map from times to received (key, val, wgt) triples.
-        let mut inputs = Vec::new();
+        let mut inputs = LinearMap::new();
 
         // A map from times to a list of keys that need processing at that time.
-        let mut to_do = Vec::new();
+        let mut to_do = LinearMap::new();
 
         let mut sorter = LSBRadixSorter::new();
 


### PR DESCRIPTION
Replacing constructions like `Vec<(K, V)>` and `Vec<Option<V>>` with the equivalent maps provided by @contain-rs makes it more obvious how those structures are being used, allows for a much broader set of operations, and doesn't require in-tree maintenance.