### PR TITLE
Resolution

### DIFF
--- a/examples/bfs.rs
+++ b/examples/bfs.rs
@@ -37,7 +37,7 @@ fn main() {
         // define BFS dataflow; return handles to roots and edges inputs
         let (mut graph, probe) = computation.scoped(|scope| {
 
-            let roots = vec![(0,1)].into_iter().to_stream(scope);
+            let roots = vec![(0,1), (1,1), (2,1)].into_iter().to_stream(scope);
             let (edge_input, graph) = scope.new_input();
             let mut result = bfs(&Collection::new(graph), &Collection::new(roots));
 

--- a/examples/reachability.rs
+++ b/examples/reachability.rs
@@ -81,7 +81,7 @@ fn main() {
         }
 
         let mut changes = Vec::new();
-        for wave in 0..waves {
+        for _wave in 0..waves {
             for _ in 0..batch {
                 changes.push(((rng1.gen_range(0, nodes), rng1.gen_range(0, nodes)), 1));
                 changes.push(((rng2.gen_range(0, nodes), rng2.gen_range(0, nodes)),-1));

--- a/examples/test_alt.rs
+++ b/examples/test_alt.rs
@@ -1,0 +1,126 @@
+extern crate rand;
+extern crate timely;
+extern crate timely_sort;
+extern crate differential_dataflow;
+extern crate vec_map;
+
+use timely::dataflow::*;
+use timely::dataflow::operators::*;
+
+use rand::{Rng, SeedableRng, StdRng};
+
+use differential_dataflow::AsCollection;
+use differential_dataflow::operators::*;
+
+fn main() {
+
+    let nodes: u32 = std::env::args().nth(1).unwrap().parse().unwrap();
+    let edges: usize = std::env::args().nth(2).unwrap().parse().unwrap();
+    let batch: usize = std::env::args().nth(3).unwrap().parse().unwrap();
+
+    let use_old = std::env::args().find(|x| x == "old").is_some();
+    let use_new = std::env::args().find(|x| x == "new").is_some();
+
+
+    timely::execute_from_args(std::env::args().skip(4), move |computation| {
+
+    	let index = computation.index();
+    	let peers = computation.peers();
+
+    	// create a a degree counting differential dataflow
+    	let (mut input, probe) = computation.scoped(|scope| {
+
+    		// create edge input, count a few ways.
+    		let (input, edges) = scope.new_input::<((u32, u32), i32)>();
+
+    		// pull off source, and count.
+    		let edges = edges.as_collection()
+    						 // .inspect(|x| println!("{:?}", x))
+    						 ;
+
+    		let old = if use_old { 
+    			Some(edges.map(|(src,_)| (src, true))
+    					  .group(|_, input, output| { output.push((input.next().unwrap().1, 1)); }))
+    		}
+    		else {
+    			None
+    		};
+
+    		let new = if use_new {
+    			Some(edges.map(|(src,_)| (src, true))
+    					  .group_alt(|_key, input, output| { output.push((input[0].1, 1)); }))
+    		}
+    		else {
+    			None
+    		};
+
+    		let probe = match (old, new) {
+    			(Some(old), Some(new)) => old.negate()
+			    						     .concat(&new)
+			    						     .consolidate()
+			    						     .inspect_batch(|t,xs| panic!("{:?}:\terror: {:?}", t, xs))
+			    						     .probe().0,
+			    (Some(old), None)	   => old.probe().0,
+			    (None, Some(new))	   => new.probe().0,
+			    (None, None)		   => panic!("Specify either 'old' or 'new'"),
+			};
+
+		    (input, probe)
+    	});
+
+        let seed: &[_] = &[1, 2, 3, index];
+        let mut rng1: StdRng = SeedableRng::from_seed(seed);    // rng for edge additions
+        let mut rng2: StdRng = SeedableRng::from_seed(seed);    // rng for edge additions
+
+        // load up graph dataz
+        for edge in 0..edges {
+        	if edge % peers == index {
+        		input.send(((rng1.gen_range(0, nodes), rng1.gen_range(0, nodes)), 1));
+        	}
+
+        	// move the data along a bit
+        	if edge % 10000 == 9999 {
+        		computation.step();
+        	}
+		}
+
+		// let timer = ::std::time::Instant::now();
+
+		input.advance_to(1);
+		computation.step_while(|| probe.lt(input.time()));
+
+		if index == 0 {
+			// let timer = timer.elapsed();
+			// let nanos = timer.as_secs() * 1000000000 + timer.subsec_nanos() as u64;
+			// println!("Loading finished after {:?}", nanos);
+		}
+
+		// change graph, forever
+		if batch > 0 {
+
+			for edge in 0usize .. 5000 {
+				if edge % peers == index {
+	        		input.send(((rng1.gen_range(0, nodes), rng1.gen_range(0, nodes)), 1));
+	        		input.send(((rng2.gen_range(0, nodes), rng2.gen_range(0, nodes)),-1));
+				}
+
+	        	if edge % batch == (batch - 1) {
+
+	        		let timer = ::std::time::Instant::now();
+
+	        		let next = input.epoch() + 1;
+	        		input.advance_to(next);
+					computation.step_while(|| probe.lt(input.time()));
+
+					if index == 0 {
+						let timer = timer.elapsed();
+						let nanos = timer.as_secs() * 1000000000 + timer.subsec_nanos() as u64;
+						// println!("Round {} finished after {:?}", next - 1, nanos);
+						println!("{}", nanos);
+					}
+	        	}
+	        }
+	    }
+
+    }).unwrap();
+}

--- a/src/collection/basic.rs
+++ b/src/collection/basic.rs
@@ -2,7 +2,7 @@
 
 use ::Data;
 use lattice::Lattice;
-use collection::{Trace, TraceRef};
+use collection::{Trace, TraceReference};
 use collection::Lookup;
 use collection::compact::Compact;
 
@@ -87,14 +87,14 @@ impl<K,V,L,T> Trace for BasicTrace<K, T, V, L>
     }
 }
 
-impl<'a,K,V,L,T> TraceRef<'a,K,T,V> for &'a BasicTrace<K,T,V,L> 
+impl<'a,K,V,L,T> TraceReference<'a> for BasicTrace<K,T,V,L> 
 where K: Data+'a, 
       V: Data+'a, 
-      L: Lookup<K, Offset>+'a, 
-      T: Lattice+'a {
+      L: Lookup<K, Offset>+'static, 
+      T: Lattice+'static {
     type VIterator = DifferenceIterator<'a, V>;
     type TIterator = TraceIterator<'a,K,T,V,L>;
-    fn trace(self, key: &K) -> Self::TIterator {
+    fn trace(&'a self, key: &K) -> Self::TIterator {
         TraceIterator {
             trace: self,
             next0: self.keys.get_ref(key).map(|&x|x),

--- a/src/collection/mod.rs
+++ b/src/collection/mod.rs
@@ -11,7 +11,8 @@ pub mod trie;
 pub mod count;
 pub mod robin_hood;
 pub mod basic;
+pub mod naive;
 
 pub use collection::lookup::Lookup;
-pub use collection::trace::{Trace, TraceRef};
+pub use collection::trace::{Trace, TraceReference};
 pub use collection::basic::{BasicTrace, Offset};

--- a/src/collection/naive.rs
+++ b/src/collection/naive.rs
@@ -1,0 +1,149 @@
+//! A naive hash-based collection trace.
+
+use std::collections::HashMap;
+use std::hash::Hash;
+
+use ::Data;
+use lattice::Lattice;
+use collection::{Trace, TraceReference};
+use collection::compact::Compact;
+
+/// A naive trace implementation based on HashMap.
+pub struct HashTrace<K, T, V> {
+    // TODO : the hash val could be a (Vec<(T,u32)>, Vec<(V,i32)>) instead...
+    map: HashMap<K, Vec<(T, Vec<(V, i32)>)>>,
+}
+
+impl<K,V,T> Trace for HashTrace<K, T, V> 
+    where 
+        K: Data+Hash, 
+        V: Data,
+        T: Lattice+Clone+'static {
+
+    type Key = K;
+    type Index = T;
+    type Value = V;
+
+    #[inline(never)]
+    fn set_difference(&mut self, time: T, accumulation: Compact<K, V>) {
+
+        // extract the relevant fields
+        let keys = accumulation.keys;
+        let cnts = accumulation.cnts;
+        let vals = accumulation.vals;
+
+        let mut vals_offset = 0;
+
+        // for each key and count ...
+        for (key, cnt) in keys.into_iter().zip(cnts.into_iter()) {
+
+            let cnt = cnt as usize;
+
+            // clone the next `cnt` values for the key.
+            let new_vals = vals[vals_offset..][..cnt].to_vec();
+
+            // add them and the time to self.map.
+            self.map.entry(key)
+                    .or_insert(Vec::new())
+                    .push((time.clone(), new_vals));
+
+            // advance vals_offset.
+            vals_offset += cnt;
+        }
+    }
+}
+
+impl<'a,K,V,T> TraceReference<'a> for HashTrace<K,T,V> 
+where K: Data+Hash+'a, 
+      V: Data+'a, 
+      T: Lattice+Clone+'static {
+    type VIterator = DifferenceIterator<'a, V>;
+    type TIterator = TraceIterator<'a,T,V>;
+    fn trace(&'a self, key: &K) -> Self::TIterator {
+        if let Some(val) = self.map.get(key) {
+            TraceIterator {
+                slice: val
+            }
+        }
+        else {
+            TraceIterator { 
+                slice: &[] 
+            }
+        }
+    }   
+}
+
+
+/// Enumerates pairs of time `&T` and `DifferenceIterator<V>` of `(&V, i32)` elements.
+pub struct TraceIterator<'a, T: 'a, V: 'a> {
+    slice: &'a [(T, Vec<(V, i32)>)],
+}
+
+impl<'a, T, V> Iterator for TraceIterator<'a, T, V>
+where T: Lattice+'a,
+      V: Data {
+
+    type Item = (&'a T, DifferenceIterator<'a, V>);
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.slice.len() > 0 {
+            let result = (&self.slice[0].0, DifferenceIterator::new(&self.slice[0].1));
+            self.slice = &self.slice[1..];
+            Some(result)
+        }
+        else {
+            None
+        }
+    }
+}
+
+impl<'a, T, V> Clone for TraceIterator<'a, T, V> 
+where T: Lattice+'a,
+      V: Data {
+    fn clone(&self) -> TraceIterator<'a, T, V> {
+        TraceIterator {
+            slice: self.slice
+        }
+    }
+}
+
+/// Enumerates `(&V,i32)` elements of a difference.
+///
+/// Morally equivalent to a `&[(V,i32)]` slice iterator, except it returns a `(&V,i32)` rather than a `&(V,i32)`.
+/// This is important for consolidate and merge.
+pub struct DifferenceIterator<'a, V: 'a> {
+    vals: &'a [(V, i32)],
+}
+
+impl<'a, V: 'a> DifferenceIterator<'a, V> {
+    fn new(vals: &'a [(V, i32)]) -> DifferenceIterator<'a, V> {
+        DifferenceIterator {
+            vals: vals,
+        }
+    }
+}
+
+impl<'a, V: 'a> Clone for DifferenceIterator<'a, V> {
+    fn clone(&self) -> Self {
+        DifferenceIterator {
+            vals: self.vals,
+        }
+    }
+}
+
+impl<'a, V: 'a> Iterator for DifferenceIterator<'a, V> {
+    type Item = (&'a V, i32);
+
+    #[inline]
+    fn next(&mut self) -> Option<(&'a V, i32)> {
+        if self.vals.len() > 0 {
+            let result = (&self.vals[0].0, self.vals[0].1);
+            self.vals = &self.vals[1..];
+            Some(result)
+        }
+        else {
+            None
+        }
+    }
+}

--- a/src/collection/robin_hood.rs
+++ b/src/collection/robin_hood.rs
@@ -1,5 +1,14 @@
 //! A Robin Hood hash map.
 
+
+#[derive(Eq, PartialEq)]
+enum SearchStatus {
+    Searching,
+    Found(usize),
+    Missing(usize),
+}
+
+
 /// A Robin Hood hash map.
 ///
 /// The hash map is parameterized by a supplied function acting as the hash function,
@@ -117,13 +126,6 @@ pub fn get_mut<'a, K: Eq, V, F: Fn(&K)->usize>(slice: &'a mut [Option<(K,V)>], q
     }
 
     return None;
-}
-
-#[derive(Eq, PartialEq)]
-enum SearchStatus {
-    Searching,
-    Found(usize),
-    Missing(usize),
 }
 
 /// Returns either the previous `(key,val)` pair for `key`, or `Err((key,val))` if `slice` does not have enough room to insert it.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,6 +151,8 @@ extern crate linear_map;
 extern crate timely_sort;
 extern crate timely_communication;
 
+// pub mod trace;
+
 pub mod collection;
 pub mod operators;
 pub mod lattice;

--- a/src/operators/arrange.rs
+++ b/src/operators/arrange.rs
@@ -18,7 +18,7 @@ use timely_sort::{LSBRadixSorter, Unsigned};
 
 use ::{Data, Collection};
 use lattice::Lattice;
-use collection::{Lookup, Trace, TraceRef};
+use collection::{Lookup, Trace, TraceReference};
 use collection::basic::{BasicTrace, Offset};
 use collection::count::Count;
 use collection::compact::Compact;
@@ -31,12 +31,13 @@ use collection::compact::Compact;
 /// in writing differential operators: each must pay enough care to signals
 /// from the `stream` field to know the subset of `trace` it has logically 
 /// received.
-pub struct Arranged<G: Scope, T: Trace<Index=G::Timestamp>> 
+pub struct Arranged<G: Scope, T: Trace> 
     where 
+        for<'a> T: TraceReference<'a>,
         T::Key: Data, 
         T::Value: Data, 
         G::Timestamp: Lattice ,
-        for<'a> &'a T: TraceRef<'a, T::Key, T::Index, T::Value> 
+        // for<'a> &'a T: TraceRef<'a, T::Key, T::Index, T::Value> 
         {
     /// A stream containing arranged updates.
     ///
@@ -48,12 +49,13 @@ pub struct Arranged<G: Scope, T: Trace<Index=G::Timestamp>>
     pub trace: Rc<RefCell<T>>,
 }
 
-impl<G: Scope, T: Trace<Index=G::Timestamp>> Arranged<G, T> 
+impl<G: Scope, T: Trace> Arranged<G, T> 
     where 
+        for<'a> T: TraceReference<'a>,
         T::Key: Data, 
         T::Value: Data, 
         G::Timestamp: Lattice ,
-        for<'a> &'a T: TraceRef<'a, T::Key, T::Index, T::Value> 
+        // for<'a> &'a T: TraceRef<'a, T::Key, T::Index, T::Value> 
     {
     
     /// Flattens the stream into a `Collection`.

--- a/src/operators/group.rs
+++ b/src/operators/group.rs
@@ -14,6 +14,7 @@
 //! elements are required.
 //!
 //! #Examples
+
 //!
 //! This example groups a stream of `(key,val)` pairs by `key`, and yields only the most frequently
 //! occurring value for each key.
@@ -35,6 +36,8 @@ use std::rc::Rc;
 use std::cell::RefCell;
 use std::default::Default;
 use std::collections::HashMap;
+// use std::hash::BuildHasherDefault;
+// use fnv::FnvHasher;
 
 use itertools::Itertools;
 use linear_map::LinearMap;
@@ -45,6 +48,8 @@ use timely::dataflow::*;
 use timely::dataflow::operators::Unary;
 use timely::dataflow::channels::pact::Pipeline;
 use timely_sort::Unsigned;
+
+// use collection::basic::Offset;
 
 use lattice::Lattice;
 use collection::{Lookup, Trace, BasicTrace, Offset};
@@ -87,6 +92,8 @@ where G::Timestamp: Lattice
 {
     fn group<L, V2: Data>(&self, logic: L) -> Collection<G, (K,V2)>
         where L: Fn(&K, &mut CollectionIterator<DifferenceIterator<V>>, &mut Vec<(V2, Delta)>)+'static {
+            // self.arrange_by_key(|k| k.hashed(), |_| { let map: HashMap<K, Offset, 
+                // BuildHasherDefault<FnvHasher>> = ::std::default::Default::default(); map })
             self.arrange_by_key(|k| k.hashed(), |_| HashMap::new())
                 .group(|k| k.hashed(), |_| HashMap::new(), logic)
                 .as_collection()

--- a/src/operators/group.rs
+++ b/src/operators/group.rs
@@ -14,7 +14,6 @@
 //! elements are required.
 //!
 //! #Examples
-
 //!
 //! This example groups a stream of `(key,val)` pairs by `key`, and yields only the most frequently
 //! occurring value for each key.
@@ -36,8 +35,6 @@ use std::rc::Rc;
 use std::cell::RefCell;
 use std::default::Default;
 use std::collections::HashMap;
-// use std::hash::BuildHasherDefault;
-// use fnv::FnvHasher;
 
 use itertools::Itertools;
 use linear_map::LinearMap;
@@ -48,8 +45,6 @@ use timely::dataflow::*;
 use timely::dataflow::operators::Unary;
 use timely::dataflow::channels::pact::Pipeline;
 use timely_sort::Unsigned;
-
-// use collection::basic::Offset;
 
 use lattice::Lattice;
 use collection::{Lookup, Trace, BasicTrace, Offset};

--- a/src/operators/group_alt.rs
+++ b/src/operators/group_alt.rs
@@ -1,0 +1,495 @@
+//! Group records by a key, and apply a reduction function.
+
+use std::collections::HashMap;
+
+use std::hash::Hash;
+
+use linear_map::LinearMap;
+
+use ::{Data, Collection, Delta};
+use ::lattice::close_under_join;
+use stream::AsCollection;
+
+use timely::progress::Antichain;
+use timely::dataflow::*;
+use timely::dataflow::operators::Unary;
+use timely::dataflow::channels::pact::Pipeline;
+use timely::dataflow::operators::Capability;
+
+use lattice::Lattice;
+use collection::Lookup;
+
+/// Extension trait for the `group` differential dataflow method
+pub trait GroupAlt<G: Scope, K: Data+Hash, V: Data+Hash> where G::Timestamp: Lattice+Ord {
+
+    /// Groups records by their first field, and applies reduction logic to the associated values.
+    fn group_alt<L, V2: Data+Hash>(&self, logic: L) -> Collection<G, (K,V2)>
+        where L: Fn(&K, &[(V, Delta)], &mut Vec<(V2, Delta)>)+'static;
+}
+
+impl<G: Scope, K: Data+Hash, V: Data+Hash> GroupAlt<G, K, V> for Collection<G, (K,V)>
+where G::Timestamp: Lattice+Ord
+{
+    fn group_alt<L, V2: Data+Hash>(&self, logic: L) -> Collection<G, (K,V2)>
+        where L: Fn(&K, &[(V, Delta)], &mut Vec<(V2, Delta)>)+'static {
+
+        let mut state = HashMap::new();     // key -> (input_trace, output_trace)
+        let mut inputs = LinearMap::new();  // A map from times to received (key, val, wgt) triples.
+        let mut to_do = LinearMap::new();   // A map from times to a list of keys that need processing at that time.
+        let mut capabilities = Vec::new();  // notificator replacement (for capabilitiesS)
+
+        // fabricate a data-parallel operator using the `unary_notify` pattern.
+        self.inner.unary_notify(Pipeline, "GroupAlt", vec![], move |input, output, notificator| {
+
+            // 1. read each input, and stash it in our staging area.
+            input.for_each(|time, data| {
+                let updates = inputs.entry_or_insert(time.time(), || {
+                    if !capabilities.iter().any(|c: &Capability<G::Timestamp>| c.time() == time.time()) {
+                        capabilities.push(time);
+                    }
+                    HashMap::new()
+                });
+
+                for ((key, val), diff) in data.drain(..) {
+                    updates.entry(key)
+                           .or_insert(Vec::new())
+                           .push((val, diff));
+                }
+            });
+
+            // 2. go through each time of interest that has reached completion
+            // times are interesting either because we received data, or because we conclude
+            // in the processing of a time that a future time will be interesting.
+            capabilities.sort_by(|x,y| x.time().cmp(&y.time()));
+            if let Some(position) = capabilities.iter().position(|c| !notificator.frontier(0).iter().any(|t| t.le(&c.time()))) {
+
+                // form frontier for compaction purposes.
+                let mut frontier = Antichain::new();
+                for capability in capabilities.iter() {
+                    frontier.insert(capability.time());
+                }
+
+                let capability = capabilities.swap_remove(position);
+                let time = capability.time();
+
+                // 2a. If we received any keys, determine the interesting times for each.
+                //     We then enqueue the keys at the corresponding time, for use later.
+                if let Some(mut queue) = inputs.remove_key(&time) {
+
+                    let mut stash = Vec::new();
+                    for (key, mut updates) in queue.drain() {
+
+                        // consolidate updates
+                        updates.sort_by(|x,y| x.0.cmp(&y.0));
+                        for index in 1 .. updates.len() {
+                            if updates[index].0 == updates[index-1].0 {
+                                updates[index].1 += updates[index-1].1;
+                                updates[index-1].1 = 0;
+                            }
+                        }
+                        updates.retain(|x| x.1 != 0);
+
+                        // only continue if updates exist
+                        if updates.len() > 0 {
+
+                            let state = state.entry(key.clone())
+                                             .or_insert((HashMap::new(), HashMap::new()));
+
+                            // determine new interesting times
+                            stash.push(capability.time());
+                            for (_, times) in state.0.iter() {
+                                for &(ref time2,_) in times {
+                                    let joined = time.join(time2);
+                                    if joined != time && !stash.contains(&joined) {
+                                        stash.push(joined);
+                                    }
+                                }
+                            }
+                            close_under_join(&mut stash);
+
+                            // notificate for times, add key to todo list.
+                            for new_time in &stash {
+                                to_do.entry_or_insert(new_time.clone(), || {
+                                    let delayed = capability.delayed(new_time);
+                                    if !capabilities.iter().any(|c| c.time() == delayed.time()) {
+                                        capabilities.push(delayed);
+                                    }
+                                    Vec::new()
+                                })
+                                .push(key.clone());
+                            }
+                            stash.clear();
+
+                            // commit updates
+                            for (val, diff) in updates.drain(..) {
+                                state.0.entry(val).or_insert(Vec::new()).push((time.clone(), diff));
+                            }
+
+                            // advance times, consolidate inputs
+                            for (_, times) in state.0.iter_mut() {
+                                for time_diff in times.iter_mut() {
+                                    let mut advanced = time_diff.0.join(&frontier.elements()[0]);
+                                    for index in 1 .. frontier.elements().len() {
+                                        advanced = advanced.meet(&time_diff.0.join(&frontier.elements()[index])); 
+                                    }
+                                    time_diff.0 = advanced;
+                                }
+                                times.sort_by(|x,y| x.0.cmp(&y.0));
+                                for index in 1 .. times.len() {
+                                    if times[index].0 == times[index-1].0 {
+                                        times[index].1 += times[index-1].1;
+                                        times[index-1].1 = 0;
+                                    }
+                                }
+                                times.retain(|x| x.1 != 0);
+                            }
+                        }
+                    }
+                }
+
+                // 2b. Process any interesting keys at this time.
+                if let Some(mut keys) = to_do.remove_key(&time) {
+
+                    // We would like these keys in a particular order.
+                    // We also want to de-duplicate them, in case there are dupes.
+                    keys.sort();
+                    keys.dedup();
+
+                    // staging areas for input and output of user code.
+                    let mut input_stage = Vec::new();
+                    let mut output_stage = Vec::new();
+
+                    // session for sending produced output.
+                    let mut session = output.session(&capability);
+
+                    for key in keys {
+
+                        if let Some(mut entry) = state.get_mut(&key) {
+
+                            input_stage.clear();
+                            output_stage.clear();
+
+                            // println!("key: {:?}, entry: {:?}", key, entry);
+
+                            // 1. form the input collection
+                            for (val, times) in entry.0.iter() {
+                                let sum = times.iter()
+                                               .filter(|td| td.0.le(&time))
+                                               .map(|td| td.1)
+                                               .sum();
+                                if sum > 0 { input_stage.push((val.clone(), sum)); }
+                            }
+                            input_stage.sort();
+
+                            // println!("key: {:?}, input: {:?}", key, input_stage);
+
+                            // 2. apply user logic
+                            if input_stage.len() > 0 {
+                                logic(&key, &input_stage[..], &mut output_stage);
+                            }
+
+                            // 3. subtract existing output differences
+                            for (val, times) in entry.1.iter() {
+                                let val: &V2 = val;
+                                let times: &Vec<(G::Timestamp, i32)> = times;
+                                let sum: i32 = times.iter()
+                                                    .filter(|td| td.0.le(&time))
+                                                    .map(|td| td.1)
+                                                    .sum();
+                                output_stage.push((val.clone(), -sum));
+                            }
+                            output_stage.sort();
+                            for index in 1 .. output_stage.len() {
+                                if output_stage[index].0 == output_stage[index-1].0 {
+                                    output_stage[index].1 += output_stage[index-1].1;
+                                    output_stage[index-1].1 = 0;
+                                }
+                            }
+                            output_stage.retain(|x| x.1 != 0);
+
+                            // 4. commit and send output differences
+                            for (val, diff) in output_stage.drain(..) {
+                                entry.1.entry(val.clone()).or_insert(Vec::new()).push((time.clone(), diff));
+                                session.give(((key.clone(), val), diff));
+                            }
+
+                            // consolidate output (it might need it too!)
+                            for (_, times) in entry.1.iter_mut() {
+                                for time_diff in times.iter_mut() {
+                                    let mut advanced = time_diff.0.join(&frontier.elements()[0]);
+                                    for index in 1 .. frontier.elements().len() {
+                                        advanced = advanced.meet(&time_diff.0.join(&frontier.elements()[index])); 
+                                    }
+                                    time_diff.0 = advanced;
+                                }
+                                times.sort_by(|x,y| x.0.cmp(&y.0));
+                                for index in 1 .. times.len() {
+                                    if times[index].0 == times[index-1].0 {
+                                        times[index].1 += times[index-1].1;
+                                        times[index-1].1 = 0;
+                                    }
+                                }
+                                times.retain(|x| x.1 != 0);
+                            }
+                        }
+                    }
+                }
+            }
+        })
+        .as_collection()
+    }
+}
+
+
+// /// Extension trait for the `group` differential dataflow method
+// pub trait GroupMulti<G: Scope, K: Data, V: Data> where G::Timestamp: Lattice {
+
+//     /// Groups records by their first field, and applies reduction logic to the associated values.
+//     fn group_multi<L, V2: Data>(&self, logic: L) -> Collection<G, (K,V2)>
+//         where L: Fn(&K, &[(V, Delta)], &mut Vec<(V2, Delta)>)+'static;
+// }
+
+// impl<G: Scope, K: Data+Default, V: Data+Default> GroupMulti<G, K, V> for Collection<G, (K,V)>
+// where G::Timestamp: Lattice
+// {
+//     fn group_multi<L, V2: Data>(&self, logic: L) -> Collection<G, (K,V2)>
+//         where L: Fn(&K, &[(V, Delta)], &mut Vec<(V2, Delta)>)+'static {
+
+//             let mut updates = Vec::new();       // stash for input differences.
+//             let mut interest = Vec::new();      // list of (key, time) pairs to re-process.
+//             let mut capabilities = Vec::new():  // lower envelope of times we should process.
+//             let mut state = HashMap::new();     // state by key, then by val, then list of times.
+
+//             let mut input_stage = Vec::new();   // staging input collection
+//             let mut output_stage = Vec::new();  // staging output collection
+
+//             let mut to_send = Vec::new();       // output diffs here, before shipping them.
+
+//             let exchange = Exchange::new(|&((ref key, _),_)| key.hashed());
+//             self.unary_notify(exchange, "GroupAlt", Vec::new(), |input, output, notificator| {
+
+//                 // stash each update with its time
+//                 input.for_each(|time, data| {
+//                     for ((key, val), diff) in data {
+//                         updates.push((key, val, time.time(), diff));
+//                     }
+//                 });
+
+//                 // establish lower and upper frontiers.
+//                 // we can optimize the frontiers by discarding common elements.
+//                 let mut lower = Vec::new();
+//                 for cap in capabilities.iter() {
+//                     if !notificator.frontier(0).contains(cap.time()) {
+//                         lower.push(cap.time());
+//                     }
+//                 }
+//                 let mut upper = Vec::new();
+//                 for time in notificator.frontier(0).iter() {
+//                     if !capabilities.any(|cap| cap.time() == time) {
+//                         upper.push(time.clone());
+//                     }
+//                 }
+
+//                 let mut now_updates = Vec::new();
+//                 extract(&mut updates, &mut now_updates, |&(_,_,ref time,_)| lower.any(|t| t.le(time)) && !upper.any(|t| t.le(time)));
+//                 now_updates.sort_by(|x,y| x.0.cmp(&y.0));
+
+//                 let mut now_interest = Vec::new();
+//                 extract(&mut interest, &mut now_interest, |&(_,ref time)| lower.any(|t| t.le(time)) && !upper.any(|t| t.le(time)));
+//                 now_interest.sort_by(|x,y| x.0.cmp(&y.0));
+
+//                 let mut updates_index = 0;
+//                 let mut interest_index = 0;
+
+//                 // walk through the updates and interesting times, key by key.
+//                 while updates_index < now_updates.len() || interest_index < now_interest.len() {
+
+//                     // 1. pick out the next key
+//                     let key = match (updates_index < now_updates.len(), interest_index < now_interest.len()) {
+//                         (true, true)    => ::std::cmp::min(now_updates[updates_index].0, now_interest[interest_index].0),
+//                         (true, false)   => now_updates[updates_index].0,
+//                         (false, true)   => now_interest[interest_index].0,
+//                         (false, false)  => unreachable!(),
+//                     };
+
+//                     let state = state.entry(key.clone()).or_insert((HashMap::new(), HashMap::new()));
+
+//                     // 2. determine ranges of updates and interesting times.
+//                     let mut updates_upper = updates_index;
+//                     while updates_upper < now_updates.len() && now_updates[updates_upper].0 == key {
+//                         updates_upper += 1;
+//                     }
+
+//                     let mut interest_upper = interest_index;
+//                     while interest_upper < now_interest.len() && now_interest[interest_upper].0 == key {
+//                         interest_upper += 1;
+//                     }
+
+//                     let updates = &mut updates[updates_index .. updates_upper];
+//                     let interest = &interest[interest_index .. interest_upper];
+//                     updates_index = updates_upper;
+//                     interest_index = interest_upper;
+
+//                     // 3. determine new interesting times, incorporate updates
+//                     let mut times = BatchDistinct::new();
+//                     updates.sort_by(|x,y| x.2.cmp(&y.2));
+//                     for index in 0 .. updates.len() {
+//                         // consider new interesting times if time changes.
+//                         if index == 0 || updates[index].2 != updates[index-1].2 {
+//                             let time = updates[index].2;
+//                             for old_time in state.0.iter().flat_map(|(_,times)| times.iter().map(|&(ref time,_)| time)) {
+//                                 let new_time = time.join(old_time);
+//                                 if new_time != old_time {
+//                                     times.push(new_time);
+//                                 }
+//                             }
+//                         }
+//                     }
+
+//                     let mut times = times.done();
+//                     close_under_join(&mut times);
+//                     for time in interest.iter().map(|kt| kt.1) {
+//                         times.push(time);
+//                     }
+
+//                     times.sort();
+//                     times.dedup();
+
+//                     // 4. merge in updates.
+//                     for &(_, val, time, diff) in updates {
+//                         state.0.entry(val).or_insert(Vec::new()).push((time, diff));
+//                     }
+
+//                     // 5. compact representation (optional?).
+//                     for (_, times) in state.0.iter_mut() {
+//                         for time_diff in times.iter_mut() {
+//                             time_diff.0 = advance(&time_diff.0, lower);
+//                         }
+//                         times.sort_by(|x,y| x.0.cmp(&y.0));
+//                         for index in 1 .. times.len() {
+//                             if times[index].0 == times[index-1].0 {
+//                                 times[index].1 += times[index-1].1
+//                                 times[index-1].0 = 0;
+//                             }
+//                         }
+//                         times.retain(|x| x.1 != 0);
+//                         // TODO : if the list has length zero, delete I guess?
+//                     }
+
+//                     // 6. swing through times, acting on those between lower and upper.
+//                     let mut left_over = Vec::new();
+//                     for time in times.drain(..) {
+//                         if lower.any(|t| t.le(time)) && !upper.any(|t| t.le(time)) {
+
+//                             input_stage.clear();
+//                             output_stage.clear();
+
+//                             // assemble collection 
+//                             for (val, times) in state.0.iter() {
+//                                 let sum = times.filter(|(t,_)| t.le(time))
+//                                                .map(|(t,d)| d)
+//                                                .sum();
+//                                 if sum > 0 {
+//                                     input_stage.push((val, sum));
+//                                 }
+//                             }
+//                             input_stage.sort();
+
+//                             // run the user logic (if input data exist)
+//                             if input_stage.len() > 0 {
+//                                 logic(&key, &mut input_stage, &mut output_stage);
+//                             }
+
+//                             // subtract output diffs
+//                             for (val, times) in state.1.iter() {
+//                                 let sum = times.filter(|(t,_)| t.le(time))
+//                                                .map(|(t,d)| d)
+//                                                .sum();
+
+//                                 output_stage.push((val, -sum));
+//                             }
+//                             output_stage.sort();
+//                             for index in 1 .. output_stage.len() {
+//                                 if output_stage[index].0 == output_stage[index-1].0 {
+//                                     output_stage[index].1 += output_stage[index-1].1;
+//                                     output_stage[index-1].1 = 0;
+//                                 }
+//                             }
+//                             output_stage.retain(|x| x.1 != 0);
+
+//                             // commit output corrections
+//                             for (val, diff) in output_stage.drain(..) {
+//                                 state.1.entry(val)
+//                                        .or_insert(Vec::new())
+//                                        .push((time, diff));
+
+//                                 // need to send, but must find capability first!
+//                                 to_send.push((key, val, time, wgt));
+//                             }
+//                         }
+//                         else {
+//                             left_over.push(time);
+//                         }
+//                     }
+//                 }
+
+//                 // sort output to co-locate like timestamps.
+//                 to_send.sort_by(|x,y| x.2.cmp(&y.2));
+
+//             }).as_collection()
+
+
+//     }
+// }
+
+// /// Advances a time to the largest time equivalent under all comparisons to other times in the future of frontier.
+// fn advance<T: Lattice>(time: &T, frontier: &[T]) -> T {
+//     let mut result = time.join(&frontier[0]);
+//     for index in 1 .. frontier.len() {
+//         result = result.meet(&time.join(&frontier[index]));
+//     }
+//     result
+// }
+
+// fn extract<T, L: Fn(&T)->bool>(source: &mut Vec<T>, target: &mut Vec<T>, logic: L) {
+//     let mut index = 0;
+//     while index < source.len() {
+//         if logic(&source[index]) {
+//             target.push(source.swap_remove(index));
+//         }
+//         else {
+//             index += 1;
+//         }
+//     }
+// }
+
+// struct BatchDistinct<T: Ord> {
+//     sorted: usize,
+//     buffer: Vec<T>,
+// }
+
+// impl<T: Ord> BatchDistinct<T> {
+//     fn new() -> BatchDistinct<T> {
+//         BatchDistinct {
+//             sorted: 0,
+//             buffer: Vec::new(),
+//         }
+//     }
+//     fn push(&mut self, element: T) {
+//         self.buffer.push(element);
+//         if self.buffer.len() > self.sorted * 2 {
+//             self.buffer.sort();
+//             self.buffer.dedup();
+//             self.sorted = self.buffer.len();
+//         }
+//     }
+
+//     fn done(self) -> Vec<T> {
+//         if self.buffer.len() > self.sorted {
+//             self.buffer.sort();
+//             self.buffer.dedup();
+//             self.sorted = self.buffer.len();
+//         }
+//         self.buffer
+//     }
+// }

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -9,6 +9,7 @@
 //! their timely dataflow analogues are sufficient (e.g. `map`, `filter`, `concat`).
 
 pub use self::group::Group;
+pub use self::group_alt::GroupAlt;
 // pub use self::cogroup::CoGroupBy;
 pub use self::consolidate::ConsolidateExt;
 pub use self::iterate::IterateExt;
@@ -19,6 +20,7 @@ pub use self::arrange::{ArrangeByKey, ArrangeBySelf};
 pub mod arrange;
 pub mod threshold;
 pub mod group;
+pub mod group_alt;
 // pub mod cogroup;
 pub mod consolidate;
 pub mod iterate;


### PR DESCRIPTION
Tracking changes to the high-resolution fork. This merge introduces the `group_alt` operator which (i) is horrible memory inefficient, but (ii) which compacts the memory representation for long-running operators. This operator is in place to test functionality; its performance and implementation should be improved and merged with the forthcoming high-resolution group implementation.