### PR TITLE
Support for general rings instead of just counts

### DIFF
--- a/examples/bfs.rs
+++ b/examples/bfs.rs
@@ -40,7 +40,7 @@ fn main() {
             }
 
             let probe = result.map(|(_,l)| l)
-                              .consolidate_by(|&x| x)
+                              .consolidate()
                               .inspect(|x| println!("\t{:?}", x))
                               .probe();
 

--- a/examples/cc.rs
+++ b/examples/cc.rs
@@ -52,7 +52,7 @@ where G::Timestamp: Lattice+Hash+Ord {
                         let min = std::cmp::min(pair.0, pair.1);
                         *pair = (min, min);
                      })
-                     .consolidate_by(|x| x.0);
+                     .consolidate();
 
     // each edge should exist in both directions.
     let edges = edges.map_in_place(|x| mem::swap(&mut x.0, &mut x.1))
@@ -66,7 +66,6 @@ where G::Timestamp: Lattice+Hash+Ord {
 
             inner.join_map(&edges, |_k,l,d| (*d,*l))
                  .concat(&nodes)
-                 // .consolidate()
                  .group(|_, s, t| { t.push((s[0].0, 1)); } )
          })
 }

--- a/examples/dataflow.rs
+++ b/examples/dataflow.rs
@@ -68,7 +68,7 @@ fn main() {
                 query_topics = query_topics.filter(|_| false);
             }
 
-            let probe = query_topics.consolidate_by(|&(_,q,_)| q)
+            let probe = query_topics.consolidate()
                                     .inspect(|&((l,q,t),_,w)| println!("\t(query: {},\tlabel: {},\ttopic:{}\t(weight: {})", q, l, t, w))
                                     .probe();
 
@@ -157,7 +157,7 @@ fn connected_components<G: Scope>(edges: &Collection<G, Edge>) -> Collection<G, 
                         let min = std::cmp::min(pair.0, pair.1);
                         *pair = (min, min);
                      })
-                     .consolidate_by(|x| x.0);
+                     .consolidate();
 
     // each edge should exist in both directions.
     let edges = edges.map_in_place(|x| ::std::mem::swap(&mut x.0, &mut x.1))

--- a/examples/deals.rs
+++ b/examples/deals.rs
@@ -162,7 +162,7 @@ where G::Timestamp: Lattice+Hash+Ord {
                         let min = std::cmp::min(pair.0, pair.1);
                         *pair = (min, min);
                      })
-                     .consolidate_by(|x| x.0);
+                     .consolidate();
 
     // each edge should exist in both directions.
     let edges = edges.map_in_place(|x| mem::swap(&mut x.0, &mut x.1))

--- a/examples/ring.rs
+++ b/examples/ring.rs
@@ -1,0 +1,53 @@
+extern crate timely;
+extern crate timely_sort;
+extern crate differential_dataflow;
+
+use timely::dataflow::*;
+use timely::dataflow::operators::*;
+
+use differential_dataflow::ring::RingPair;
+use differential_dataflow::AsCollection;
+use differential_dataflow::operators::Consolidate;
+
+fn main() {
+
+    let keys: usize = std::env::args().nth(1).unwrap().parse().unwrap();
+    let batch: usize = std::env::args().nth(2).unwrap().parse().unwrap();
+
+    // This computation demonstrates in-place accumulation of arbitrarily large 
+    // volumes of input data, so long as the number of distinct keys is moderate.
+    // 
+    // Specifically, the program aims to accumulate (key, val) pairs where we are
+    // interested in the sum of values for each key, as well as the count of the
+    // number of records, so that we can produce the average.
+    timely::execute_from_args(std::env::args().skip(4), move |computation| {
+
+        let mut input = computation.scoped::<(), _, _>(|scope| {
+
+            let (input, data) = scope.new_input::<((usize, isize), isize)>();
+
+            // move `val` into the ring component.
+            data.map(|((x,y),d)| (x, Default::default(), RingPair::new(y,d)))
+				.as_collection()
+                .consolidate();
+
+            input
+        });
+
+        let timer = ::std::time::Instant::now();
+
+        for val in 0 .. {
+        	// introduce some data with bounded key.
+        	input.send(((val % keys, (val as isize) % 100), 1 as isize));
+
+        	// we must still give the computation the opportunity to act.
+        	if val > 0 && val % batch == 0 { 
+        		computation.step(); 
+        		let elapsed = timer.elapsed();
+        		let secs = elapsed.as_secs() as f64 + (elapsed.subsec_nanos() as f64)/1000000000.0;
+        		println!("tuples: {:?},\telts/sec: {:?}", val, val as f64 / secs);
+        	}
+        }
+
+    }).unwrap();
+}

--- a/examples/scc.rs
+++ b/examples/scc.rs
@@ -47,7 +47,7 @@ fn main() {
 
             if inspect {
                 let mut counter = 0;
-                edges = edges.consolidate_by(|x| x.0)
+                edges = edges.consolidate()
                              .inspect_batch(move |t, xs| {
                                  counter += xs.len();
                                  println!("{:?}:\tobserved at {:?}: {:?} changes", timer.elapsed(), t, counter)
@@ -167,7 +167,7 @@ fn _trim_edges<G: Scope>(cycle: &Collection<G, Edge>, edges: &Collection<G, Edge
     -> Collection<G, Edge> where G::Timestamp: Lattice+Ord+Hash {
 
     let nodes = edges.map_in_place(|x| x.0 = x.1)
-                     .consolidate_by(|&x| x.0);
+                     .consolidate();
 
     let labels = _reachability(&cycle, &nodes);
 

--- a/examples/sequential.rs
+++ b/examples/sequential.rs
@@ -62,7 +62,7 @@ where G::Timestamp: Lattice+Hash+Ord {
 
     // need some bogus initial values.
     let start = edges.map(|(x,_y)| (x,u32::max_value()))
-                     .consolidate_by(|x| x.0);
+                     .consolidate();
 
     // repeatedly apply color-picking logic.
     sequence(&start, &edges, |_node, vals| {
@@ -84,7 +84,7 @@ where G::Timestamp: Lattice+Hash+Ord {
 
     // need some bogus initial values.
     let start = edges.map(|(x,_y)| (x, x < 10))
-                     .consolidate_by(|x| x.0);
+                     .consolidate();
 
     // repeatedly apply color-picking logic.
     sequence(&start, &edges, |_node, vals| {

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -10,6 +10,11 @@ use timely::dataflow::operators::*;
 use ::Ring;
 
 /// A mutable collection of values of type `D`
+///
+/// The collection is additionally parameterized by a type `R` implementing the `Ring` trait.
+/// This `R` defaults to `isize`, and most often can be thought of as "the change in count". 
+/// However, this can be more general, which is useful when one wants to accumulate values 
+/// other than counts, for example the sums of various quantities (e.g. computing an average).
 #[derive(Clone)]
 pub struct Collection<G: Scope, D, R: Ring = isize> {
     /// Underlying timely dataflow stream.

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -7,53 +7,53 @@ use timely::dataflow::scopes::Child;
 use timely::dataflow::{Scope, Stream};
 use timely::dataflow::operators::*;
 
-use ::Delta;
+use ::Ring;
 
 /// A mutable collection of values of type `D`
 #[derive(Clone)]
-pub struct Collection<G: Scope, D> {
+pub struct Collection<G: Scope, D, R: Ring = isize> {
     /// Underlying timely dataflow stream.
-    pub inner: Stream<G, (D, G::Timestamp, Delta)>
+    pub inner: Stream<G, (D, G::Timestamp, R)>
 }
 
-impl<G: Scope, D: Data> Collection<G, D> where G::Timestamp: Data {
+impl<G: Scope, D: Data, R: Ring> Collection<G, D, R> where G::Timestamp: Data {
     /// Creates a new Collection from a timely dataflow stream.
-    pub fn new(stream: Stream<G, (D, G::Timestamp, Delta)>) -> Collection<G, D> {
+    pub fn new(stream: Stream<G, (D, G::Timestamp, R)>) -> Collection<G, D, R> {
         Collection { inner: stream }
     }
     /// Applies the supplied function to each element of the Collection.
-    pub fn map<D2: Data, L: Fn(D) -> D2 + 'static>(&self, logic: L) -> Collection<G, D2> {
+    pub fn map<D2: Data, L: Fn(D) -> D2 + 'static>(&self, logic: L) -> Collection<G, D2, R> {
         self.inner.map(move |(data, time, delta)| (logic(data), time, delta))
                   .as_collection()
     }
     /// Applies the supplied function to each element of the Collection, re-using allocated memory.
-    pub fn map_in_place<L: Fn(&mut D) + 'static>(&self, logic: L) -> Collection<G, D> {
+    pub fn map_in_place<L: Fn(&mut D) + 'static>(&self, logic: L) -> Collection<G, D, R> {
         self.inner.map_in_place(move |&mut (ref mut data, _, _)| logic(data))
                   .as_collection()
     }
     /// Applies the supplied function to each element of the Collection.
-    pub fn flat_map<D2: Data, I: Iterator<Item=D2>, L: Fn(D) -> I + 'static>(&self, logic: L) -> Collection<G, D2> 
+    pub fn flat_map<D2: Data, I: Iterator<Item=D2>, L: Fn(D) -> I + 'static>(&self, logic: L) -> Collection<G, D2, R> 
         where G::Timestamp: Clone {
         self.inner.flat_map(move |(data, time, delta)| logic(data).map(move |x| (x, time.clone(), delta)))
                   .as_collection()
     }
     /// Negates the counts of each element in the Collection.
-    pub fn negate(&self) -> Collection<G, D> {
-        self.inner.map_in_place(|x| x.2 *= -1)
+    pub fn negate(&self) -> Collection<G, D, R> {
+        self.inner.map_in_place(|x| x.2 = -x.2)
                   .as_collection()
     }
     /// Retains only the elements of the Collection satisifying the supplied predicate.
-    pub fn filter<L: Fn(&D) -> bool + 'static>(&self, logic: L) -> Collection<G, D> {
+    pub fn filter<L: Fn(&D) -> bool + 'static>(&self, logic: L) -> Collection<G, D, R> {
         self.inner.filter(move |&(ref data, _, _)| logic(data))
                   .as_collection()
     }
     /// Adds the counts of elements from each Collection.
-    pub fn concat(&self, other: &Collection<G, D>) -> Collection<G, D> {
+    pub fn concat(&self, other: &Collection<G, D, R>) -> Collection<G, D, R> {
         self.inner.concat(&other.inner)
                   .as_collection()
     }
     /// Brings a Collection into a nested scope.
-    pub fn enter<'a, T: Timestamp>(&self, child: &Child<'a, G, T>) -> Collection<Child<'a, G, T>, D> {
+    pub fn enter<'a, T: Timestamp>(&self, child: &Child<'a, G, T>) -> Collection<Child<'a, G, T>, D, R> {
         self.inner.enter(child)
                   .map(|(data, time, diff)| (data, Product::new(time, Default::default()), diff))
                   .as_collection()
@@ -61,7 +61,7 @@ impl<G: Scope, D: Data> Collection<G, D> where G::Timestamp: Data {
     /// Brings a Collection into a nested scope, at varying times.
     ///
     /// The `initial` function indicates the time at which each element of the Collection should appear.
-    pub fn enter_at<'a, T: Timestamp, F>(&self, child: &Child<'a, G, T>, initial: F) -> Collection<Child<'a, G, T>, D> 
+    pub fn enter_at<'a, T: Timestamp, F>(&self, child: &Child<'a, G, T>, initial: F) -> Collection<Child<'a, G, T>, D, R> 
     where F: Fn(&D) -> T + 'static,
           G::Timestamp: Hash, T: Hash {
 
@@ -77,12 +77,12 @@ impl<G: Scope, D: Data> Collection<G, D> where G::Timestamp: Data {
                   .as_collection()
     }
     /// Applies a supplied function to each update. Diagnostic.
-    pub fn inspect<F: FnMut(&(D, G::Timestamp, Delta))+'static>(&self, func: F) -> Collection<G, D> {
+    pub fn inspect<F: FnMut(&(D, G::Timestamp, R))+'static>(&self, func: F) -> Collection<G, D, R> {
         self.inner.inspect(func)
                   .as_collection()
     }
     /// Applies a supplied function to each batch of updates. Diagnostic.
-    pub fn inspect_batch<F: FnMut(&G::Timestamp, &[(D, G::Timestamp, Delta)])+'static>(&self, func: F) -> Collection<G, D> {
+    pub fn inspect_batch<F: FnMut(&G::Timestamp, &[(D, G::Timestamp, R)])+'static>(&self, func: F) -> Collection<G, D, R> {
         self.inner.inspect_batch(func)
                   .as_collection()
     }
@@ -90,7 +90,7 @@ impl<G: Scope, D: Data> Collection<G, D> where G::Timestamp: Data {
     ///
     /// This probe is used to determine when the state of the Collection has stabilized and can
     /// be read out. 
-    pub fn probe(&self) -> (probe::Handle<G::Timestamp>, Collection<G, D>) {
+    pub fn probe(&self) -> (probe::Handle<G::Timestamp>, Collection<G, D, R>) {
         let (handle, stream) = self.inner.probe();
         (handle, stream.as_collection())
     }
@@ -100,9 +100,9 @@ impl<G: Scope, D: Data> Collection<G, D> where G::Timestamp: Data {
     }
 }
 
-impl<'a, G: Scope, T: Timestamp, D: Data> Collection<Child<'a, G, T>, D> {
+impl<'a, G: Scope, T: Timestamp, D: Data, R: Ring> Collection<Child<'a, G, T>, D, R> {
     /// Returns the final value of a Collection from a nested scope to its containing scope.
-    pub fn leave(&self) -> Collection<G, D> {
+    pub fn leave(&self) -> Collection<G, D, R> {
         self.inner.leave()
                   .map(|(data, time, diff)| (data, time.outer, diff))
                   .as_collection()
@@ -110,13 +110,13 @@ impl<'a, G: Scope, T: Timestamp, D: Data> Collection<Child<'a, G, T>, D> {
 }
 
 /// Conversion to a differential dataflow Collection.
-pub trait AsCollection<G: Scope, D: Data> {
+pub trait AsCollection<G: Scope, D: Data, R: Ring> {
     /// Conversion to a differential dataflow Collection.
-    fn as_collection(&self) -> Collection<G, D>;
+    fn as_collection(&self) -> Collection<G, D, R>;
 }
 
-impl<G: Scope, D: Data> AsCollection<G, D> for Stream<G, (D, G::Timestamp, Delta)> {
-    fn as_collection(&self) -> Collection<G, D> {
+impl<G: Scope, D: Data, R: Ring> AsCollection<G, D, R> for Stream<G, (D, G::Timestamp, R)> {
+    fn as_collection(&self) -> Collection<G, D, R> {
         Collection::new(self.clone())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,10 +104,10 @@
 #![forbid(missing_docs)]
 
 use std::fmt::Debug;
-use std::ops::{Add, Sub, Neg, Mul};
 
 pub use collection::{Collection, AsCollection};
 pub use hashable::Hashable;
+pub use ring::Ring;
 
 /// A composite trait for data types usable in differential dataflow.
 ///
@@ -121,24 +121,6 @@ pub use hashable::Hashable;
 pub trait Data : timely::ExchangeData + Ord + Debug { }
 impl<T: timely::ExchangeData + Ord + Debug> Data for T { }
 
-/// A type that can be treated as a mathematical ring.
-pub trait Ring : Add<Self, Output=Self> + Sub<Self, Output=Self> + Neg<Output=Self> + Mul<Self, Output=Self> + std::marker::Sized + Data + Copy {
-	/// Returns true if the element is the additive identity.
-	fn is_zero(&self) -> bool;
-	/// The additive identity.
-	fn zero() -> Self;
-}
-
-impl Ring for isize { 
-	fn is_zero(&self) -> bool { *self == 0 }
-	fn zero() -> Self { 0 }
-}
-
-// impl<R1: Ring, R2: Ring> Ring for (R1, R2) {
-// 	fn is_zero(&self) -> bool { self.0.is_zero() && self.1.is_zero() }
-// 	fn zero() -> Self { (R1::zero(), R2::zero()) }
-// }
-
 extern crate fnv;
 extern crate timely;
 extern crate vec_map;
@@ -146,8 +128,6 @@ extern crate itertools;
 extern crate linear_map;
 extern crate timely_sort;
 extern crate timely_communication;
-
-#[macro_use]
 extern crate abomonation;
 
 pub mod hashable;
@@ -155,5 +135,6 @@ pub mod operators;
 pub mod lattice;
 pub mod trace;
 pub mod input;
+pub mod ring;
 mod collection;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,9 +104,7 @@
 #![forbid(missing_docs)]
 
 use std::fmt::Debug;
-
-/// A change in count.
-pub type Delta = isize;
+use std::ops::{Add, Sub, Neg, Mul};
 
 pub use collection::{Collection, AsCollection};
 pub use hashable::Hashable;
@@ -122,6 +120,24 @@ pub use hashable::Hashable;
 /// efficiently sort data if we know there are fewer bytes in the integer keys.
 pub trait Data : timely::ExchangeData + Ord + Debug { }
 impl<T: timely::ExchangeData + Ord + Debug> Data for T { }
+
+/// A type that can be treated as a mathematical ring.
+pub trait Ring : Add<Self, Output=Self> + Sub<Self, Output=Self> + Neg<Output=Self> + Mul<Self, Output=Self> + std::marker::Sized + Data + Copy {
+	/// Returns true if the element is the additive identity.
+	fn is_zero(&self) -> bool;
+	/// The additive identity.
+	fn zero() -> Self;
+}
+
+impl Ring for isize { 
+	fn is_zero(&self) -> bool { *self == 0 }
+	fn zero() -> Self { 0 }
+}
+
+// impl<R1: Ring, R2: Ring> Ring for (R1, R2) {
+// 	fn is_zero(&self) -> bool { self.0.is_zero() && self.1.is_zero() }
+// 	fn zero() -> Self { (R1::zero(), R2::zero()) }
+// }
 
 extern crate fnv;
 extern crate timely;

--- a/src/operators/arrange.rs
+++ b/src/operators/arrange.rs
@@ -245,15 +245,11 @@ impl<G: Scope, K: Data+Hashable, V: Data, R: Ring> Arrange<G, K, V, R> for Colle
         let exchange = Exchange::new(move |update: &((K,V),G::Timestamp,R)| (update.0).0.hashed().as_u64());
         let stream = self.inner.unary_notify(exchange, "Arrange", vec![], move |input, output, notificator| {
 
-            // println!("arrange: start");
-
             // As we receive data, we need to (i) stash the data and (ii) keep *enough* capabilities.
             // We don't have to keep all capabilities, but we need to be able to form output messages
             // when we realize that time intervals are complete.
 
             input.for_each(|cap, data| {
-
-                // println!("arrange recv");
 
                 // add the capability to our list of capabilities.
                 capabilities.retain(|c| !c.time().gt(&cap.time()));
@@ -263,7 +259,6 @@ impl<G: Scope, K: Data+Hashable, V: Data, R: Ring> Arrange<G, K, V, R> for Colle
 
                 // add the updates to our batcher.
                 for ((key, val), time, diff) in data.drain(..) {
-                    // println!("  - ({:?}, {:?}) : {:?}", key, val, diff);
                     let (key, val) = map(key, val);
                     batcher.push((key, val, time, diff));
                 }
@@ -349,7 +344,6 @@ impl<G: Scope, K: Data+Hashable, V: Data, R: Ring> Arrange<G, K, V, R> for Colle
                 }
                 capabilities = new_capabilities;
             }
-            // println!("arrange: done");
 
         });
 

--- a/src/operators/arrange.rs
+++ b/src/operators/arrange.rs
@@ -36,7 +36,7 @@ use timely_sort::Unsigned;
 
 use hashable::OrdWrapper;
 
-use ::{Data, Collection, AsCollection, Hashable};
+use ::{Data, Ring, Collection, AsCollection, Hashable};
 use lattice::Lattice;
 use trace::{Trace, Batch, Batcher, Cursor};
 // use trace::implementations::trie::Spine as OrdSpine;
@@ -64,14 +64,14 @@ impl<T> ::abomonation::Abomonation for BatchWrapper<T> {
 
 
 /// A wrapper around a trace which tracks the frontiers of all referees.
-pub struct TraceWrapper<K, V, T, Tr: Trace<K,V,T>> where T: Lattice+Ord+Clone+'static {
-    phantom: ::std::marker::PhantomData<(K, V)>,
+pub struct TraceWrapper<K, V, T, R, Tr: Trace<K,V,T,R>> where T: Lattice+Ord+Clone+'static {
+    phantom: ::std::marker::PhantomData<(K, V, R)>,
     frontiers: MutableAntichain<T>,
     /// The wrapped trace.
     pub trace: Tr,
 }
 
-impl<K,V,T,Tr: Trace<K,V,T>> TraceWrapper<K,V,T,Tr> where T: Lattice+Ord+Clone+'static {
+impl<K,V,T,R,Tr: Trace<K,V,T,R>> TraceWrapper<K,V,T,R,Tr> where T: Lattice+Ord+Clone+'static {
     /// Allocates a new trace wrapper.
     fn new(empty: Tr) -> Self {
         TraceWrapper {
@@ -94,13 +94,13 @@ impl<K,V,T,Tr: Trace<K,V,T>> TraceWrapper<K,V,T,Tr> where T: Lattice+Ord+Clone+'
 ///
 /// As long as the handle exists, the wrapped trace should continue to exist and will not advance its 
 /// timestamps past the frontier maintained by the handle.
-pub struct TraceHandle<K,V,T,Tr: Trace<K,V,T>> where T: Lattice+Ord+Clone+'static {
+pub struct TraceHandle<K,V,T,R,Tr: Trace<K,V,T,R>> where T: Lattice+Ord+Clone+'static {
     frontier: Vec<T>,
     /// Wrapped trace. Please be gentle when using.
-    pub wrapper: Rc<RefCell<TraceWrapper<K,V,T,Tr>>>,
+    pub wrapper: Rc<RefCell<TraceWrapper<K,V,T,R,Tr>>>,
 }
 
-impl<K,V,T,Tr: Trace<K,V,T>> TraceHandle<K,V,T,Tr> where T: Lattice+Ord+Clone+'static {
+impl<K,V,T,R,Tr: Trace<K,V,T,R>> TraceHandle<K,V,T,R,Tr> where T: Lattice+Ord+Clone+'static {
     /// Allocates a new handle from an existing wrapped wrapper.
     pub fn new(trace: Tr, frontier: &[T]) -> Self {
 
@@ -127,7 +127,7 @@ impl<K,V,T,Tr: Trace<K,V,T>> TraceHandle<K,V,T,Tr> where T: Lattice+Ord+Clone+'s
     }
 }
 
-impl<K, V, T: Lattice+Ord+Clone, Tr: Trace<K, V, T>> Clone for TraceHandle<K, V, T, Tr> {
+impl<K, V, T: Lattice+Ord+Clone, R, Tr: Trace<K, V, T, R>> Clone for TraceHandle<K, V, T, R, Tr> {
     fn clone(&self) -> Self {
         // increase ref counts for this frontier
         self.wrapper.borrow_mut().adjust_frontier(&[], &self.frontier[..]);
@@ -138,7 +138,7 @@ impl<K, V, T: Lattice+Ord+Clone, Tr: Trace<K, V, T>> Clone for TraceHandle<K, V,
     }
 }
 
-impl<K, V, T, Tr: Trace<K, V, T>> Drop for TraceHandle<K, V, T, Tr> 
+impl<K, V, T, R, Tr: Trace<K, V, T, R>> Drop for TraceHandle<K, V, T, R, Tr> 
     where T: Lattice+Ord+Clone+'static {
     fn drop(&mut self) {
         self.wrapper.borrow_mut().adjust_frontier(&self.frontier[..], &[]);
@@ -154,7 +154,7 @@ impl<K, V, T, Tr: Trace<K, V, T>> Drop for TraceHandle<K, V, T, Tr>
 /// in writing differential operators: each must pay enough care to signals
 /// from the `stream` field to know the subset of `trace` it has logically 
 /// received.
-pub struct Arranged<G: Scope, K, V, T: Trace<K, V, G::Timestamp>> where G::Timestamp: Lattice+Ord {
+pub struct Arranged<G: Scope, K, V, R, T: Trace<K, V, G::Timestamp, R>> where G::Timestamp: Lattice+Ord {
     /// A stream containing arranged updates.
     ///
     /// This stream contains the same batches of updates the trace itself accepts, so there should
@@ -162,15 +162,15 @@ pub struct Arranged<G: Scope, K, V, T: Trace<K, V, G::Timestamp>> where G::Times
     /// the batches in the trace, by key and by value.
     pub stream: Stream<G, BatchWrapper<T::Batch>>,
     /// A shared trace, updated by the `Arrange` operator and readable by others.
-    pub trace: TraceHandle<K, V, G::Timestamp, T>,
+    pub trace: TraceHandle<K, V, G::Timestamp, R, T>,
     // TODO : We might have an `Option<Collection<G, (K, V)>>` here, which `as_collection` sets and
     // returns when invoked, so as to not duplicate work with multiple calls to `as_collection`.
 }
 
-impl<G: Scope, K, V, T: Trace<K, V, G::Timestamp>> Arranged<G, K, V, T> where G::Timestamp: Lattice+Ord {
+impl<G: Scope, K, V, R, T: Trace<K, V, G::Timestamp, R>> Arranged<G, K, V, R, T> where G::Timestamp: Lattice+Ord {
     
     /// Allocates a new handle to the shared trace, with independent frontier tracking.
-    pub fn new_handle(&self) -> TraceHandle<K, V, G::Timestamp, T> {
+    pub fn new_handle(&self) -> TraceHandle<K, V, G::Timestamp, R, T> {
         self.trace.clone()
     }
 
@@ -179,8 +179,9 @@ impl<G: Scope, K, V, T: Trace<K, V, G::Timestamp>> Arranged<G, K, V, T> where G:
     /// The underlying `Stream<G, BatchWrapper<T::Batch>>` is a much more efficient way to access the data,
     /// and this method should only be used when the data need to be transformed or exchanged, rather than
     /// supplied as arguments to an operator using the same key-value structure.
-    pub fn as_collection<D: Data, L>(&self, logic: L) -> Collection<G, D>
+    pub fn as_collection<D: Data, L>(&self, logic: L) -> Collection<G, D, R>
         where
+            R: Ring,
             T::Batch: Clone+'static,
             K: Clone, V: Clone,
             L: Fn(&K, &V) -> D+'static,
@@ -197,7 +198,7 @@ impl<G: Scope, K, V, T: Trace<K, V, G::Timestamp>> Arranged<G, K, V, T> where G:
                         while cursor.val_valid() {
                             let val: V = cursor.val().clone();  // TODO: pass ref in map_times
                             cursor.map_times(|time, diff| {
-                                session.give((logic(&key, &val), time.clone(), diff));
+                                session.give((logic(&key, &val), time.clone(), diff.clone()));
                             });
                             cursor.step_val();
                         }
@@ -211,23 +212,23 @@ impl<G: Scope, K, V, T: Trace<K, V, G::Timestamp>> Arranged<G, K, V, T> where G:
 }
 
 /// Arranges something as `(Key,Val)` pairs according to a type `T` of trace.
-pub trait Arrange<G: Scope, K, V> where G::Timestamp: Lattice+Ord {
+pub trait Arrange<G: Scope, K, V, R: Ring> where G::Timestamp: Lattice+Ord {
     /// Arranges a stream of `(Key, Val)` updates by `Key`. Accepts an empty instance of the trace type.
     ///
     /// This operator arranges a stream of values into a shared trace, whose contents it maintains.
     /// This trace is current for all times completed by the output stream, which can be used to
     /// safely identify the stable times and values in the trace.
-    fn arrange<T, K2:'static, V2:'static, L>(&self, map: L, empty: T) -> Arranged<G, K2, V2, T> 
+    fn arrange<T, K2:'static, V2:'static, L>(&self, map: L, empty: T) -> Arranged<G, K2, V2, R, T> 
         where 
-            T: Trace<K2, V2, G::Timestamp>+'static,
+            T: Trace<K2, V2, G::Timestamp, R>+'static,
             L: Fn(K,V)->(K2,V2)+'static;
 }
 
-impl<G: Scope, K: Data+Hashable, V: Data> Arrange<G, K, V> for Collection<G, (K, V)> where G::Timestamp: Lattice+Ord {
+impl<G: Scope, K: Data+Hashable, V: Data, R: Ring> Arrange<G, K, V, R> for Collection<G, (K, V), R> where G::Timestamp: Lattice+Ord {
 
-    fn arrange<T, K2:'static, V2:'static, L>(&self, map: L, empty: T) -> Arranged<G, K2, V2, T> 
+    fn arrange<T, K2:'static, V2:'static, L>(&self, map: L, empty: T) -> Arranged<G, K2, V2, R, T> 
         where 
-            T: Trace<K2, V2, G::Timestamp>+'static,
+            T: Trace<K2, V2, G::Timestamp, R>+'static,
             L: Fn(K,V)->(K2,V2)+'static {
 
         // create a trace to share with downstream consumers.
@@ -235,13 +236,13 @@ impl<G: Scope, K: Data+Hashable, V: Data> Arrange<G, K, V> for Collection<G, (K,
         let source = Rc::downgrade(&handle.wrapper);
 
         // Where we will deposit received updates, and from which we extract batches.
-        let mut batcher = <T::Batch as Batch<K2,V2,G::Timestamp>>::Batcher::new();
+        let mut batcher = <T::Batch as Batch<K2,V2,G::Timestamp,R>>::Batcher::new();
 
         // Capabilities for the lower envelope of updates in `batcher`.
         let mut capabilities = Vec::<Capability<G::Timestamp>>::new();
 
         // fabricate a data-parallel operator using the `unary_notify` pattern.
-        let exchange = Exchange::new(move |update: &((K,V),G::Timestamp,isize)| (update.0).0.hashed().as_u64());
+        let exchange = Exchange::new(move |update: &((K,V),G::Timestamp,R)| (update.0).0.hashed().as_u64());
         let stream = self.inner.unary_notify(exchange, "Arrange", vec![], move |input, output, notificator| {
 
             // println!("arrange: start");
@@ -361,19 +362,19 @@ impl<G: Scope, K: Data+Hashable, V: Data> Arrange<G, K, V> for Collection<G, (K,
 /// This arrangement requires `Key: Hashable`, and uses the `hashed()` method to place keys in a hashed
 /// map. This can result in many hash calls, and in some cases it may help to first transform `K` to the
 /// pair `(u64, K)` of hash value and key.
-pub trait ArrangeByKey<G: Scope, K: Data+Default+Hashable, V: Data> 
+pub trait ArrangeByKey<G: Scope, K: Data+Default+Hashable, V: Data, R: Ring> 
 where G::Timestamp: Lattice+Ord {
     /// Arranges a collection of `(Key, Val)` records by `Key`.
     ///
     /// This operator arranges a stream of values into a shared trace, whose contents it maintains.
     /// This trace is current for all times completed by the output stream, which can be used to
     /// safely identify the stable times and values in the trace.
-    fn arrange_by_key(&self) -> Arranged<G, OrdWrapper<K>, V, HashSpine<OrdWrapper<K>, V, G::Timestamp>>;
+    fn arrange_by_key(&self) -> Arranged<G, OrdWrapper<K>, V, R, HashSpine<OrdWrapper<K>, V, G::Timestamp, R>>;
 }
 
-impl<G: Scope, K: Data+Default+Hashable, V: Data> ArrangeByKey<G, K, V> for Collection<G, (K,V)>
+impl<G: Scope, K: Data+Default+Hashable, V: Data, R: Ring> ArrangeByKey<G, K, V, R> for Collection<G, (K,V), R>
 where G::Timestamp: Lattice+Ord  {        
-    fn arrange_by_key(&self) -> Arranged<G, OrdWrapper<K>, V, HashSpine<OrdWrapper<K>, V, G::Timestamp>> {
+    fn arrange_by_key(&self) -> Arranged<G, OrdWrapper<K>, V, R, HashSpine<OrdWrapper<K>, V, G::Timestamp, R>> {
         self.arrange(|k,v| (OrdWrapper {item:k},v), HashSpine::new(Default::default()))
     }
 }
@@ -383,20 +384,20 @@ where G::Timestamp: Lattice+Ord  {
 /// This arrangement requires `Key: Hashable`, and uses the `hashed()` method to place keys in a hashed
 /// map. This can result in many hash calls, and in some cases it may help to first transform `K` to the
 /// pair `(u64, K)` of hash value and key.
-pub trait ArrangeBySelf<G: Scope, K: Data+Default+Hashable> 
+pub trait ArrangeBySelf<G: Scope, K: Data+Default+Hashable, R: Ring> 
 where G::Timestamp: Lattice+Ord {
     /// Arranges a collection of `Key` records by `Key`.
     ///
     /// This operator arranges a collection of records into a shared trace, whose contents it maintains.
     /// This trace is current for all times complete in the output stream, which can be used to safely
     /// identify the stable times and values in the trace.
-    fn arrange_by_self(&self) -> Arranged<G, OrdWrapper<K>, (), KeyHashSpine<OrdWrapper<K>, G::Timestamp>>;
+    fn arrange_by_self(&self) -> Arranged<G, OrdWrapper<K>, (), R, KeyHashSpine<OrdWrapper<K>, G::Timestamp, R>>;
 }
 
 
-impl<G: Scope, K: Data+Default+Hashable> ArrangeBySelf<G, K> for Collection<G, K>
+impl<G: Scope, K: Data+Default+Hashable, R: Ring> ArrangeBySelf<G, K, R> for Collection<G, K, R>
 where G::Timestamp: Lattice+Ord {
-    fn arrange_by_self(&self) -> Arranged<G, OrdWrapper<K>, (), KeyHashSpine<OrdWrapper<K>, G::Timestamp>> {
+    fn arrange_by_self(&self) -> Arranged<G, OrdWrapper<K>, (), R, KeyHashSpine<OrdWrapper<K>, G::Timestamp, R>> {
         self.map(|k| (k,()))
             .arrange(|k,v| (OrdWrapper {item:k}, v), KeyHashSpine::new(Default::default()))
     }

--- a/src/operators/consolidate.rs
+++ b/src/operators/consolidate.rs
@@ -21,18 +21,16 @@
 use std::fmt::Debug;
 
 use timely::dataflow::*;
-use timely::dataflow::operators::*;
-use timely::dataflow::channels::pact::Exchange;
-use timely_sort::Unsigned;
 
 use ::{Collection, Data, Ring, Hashable};
-use operators::group::Group;
+use operators::arrange::ArrangeBySelf;
 
 /// An extension method for consolidating weighted streams.
 pub trait Consolidate<D: Data> {
     /// Aggregates the weights of equal records into at most one record.
     ///
-    /// This method uses the type `D`'s `hashed()` method to partition the data.
+    /// This method uses the type `D`'s `hashed()` method to partition the data. The data are 
+    /// accumulated in place, each held back until their timestamp has completed.
     /// 
     /// #Examples
     ///
@@ -46,22 +44,6 @@ pub trait Consolidate<D: Data> {
     ///     .inspect(|x| println!("{:}", x));
     /// ```
     fn consolidate(&self) -> Self where D: Hashable;
-
-    /// Aggregates the weights of equal records into at most one record, partitions the
-    /// data using the supplied partition function.
-    ///
-    /// #Examples
-    ///
-    /// In the following fragment, `result` contains only `(1, 3)`:
-    ///
-    /// ```ignore
-    /// vec![(0,1),(1,1),(0,-1),(1,2)]
-    ///     .to_stream(scope)
-    ///     .as_collection()
-    ///     .consolidate(|&x| x)
-    ///     .inspect(|x| println!("{:}", x));
-    /// ```    
-    fn consolidate_by<U: Unsigned, F: Fn(&D)->U+'static>(&self, part: F) -> Self;
 }
 
 impl<G: Scope, D, R> Consolidate<D> for Collection<G, D, R>
@@ -71,78 +53,6 @@ where
     G::Timestamp: ::lattice::Lattice+Ord,
  {
     fn consolidate(&self) -> Self where D: Hashable {
-       self.consolidate_by(|x| x.hashed())
-    }
-
-    fn consolidate_by<U: Unsigned, F: Fn(&D)->U+'static>(&self, part: F) -> Self {
-
-        // let mut buffer = Vec::new();
-        // let mut capabilities = Vec::new();
-
-        self.map(|x| (x,()))
-            .group(|_,s,t| t.push(((), s[0].1)))
-            .map(|(x,_)| x)
-
-        // let exch = Exchange::new(move |&(ref x,_,_): &(D,G::Timestamp,isize)| part(x).as_u64());
-        // Collection::new(self.inner.unary_notify(exch, "Consolidate", vec![], move |_input, _output, _notificator| {
-
-        //     unimplemented!();
-
-        // }))
+       self.arrange_by_self().as_collection(|d,_| d.item.clone())
     }
 }
-
-
-// /// Compacts `(T, Delta)` pairs lazily.
-// pub struct BatchCompact<T: Ord> {
-//     sorted: usize,
-//     buffer: Vec<(T, Delta)>,
-// }
-
-// impl<T: Ord> BatchCompact<T> {
-//     /// Allocates a new batch compacter.
-//     pub fn new() -> BatchCompact<T> {
-//         BatchCompact {
-//             sorted: 0,
-//             buffer: Vec::new(),
-//         }
-//     }
-
-//     /// Adds an element to the batch compacter.
-//     pub fn push(&mut self, element: (T, Delta)) {
-//         self.buffer.push(element);
-//         if self.buffer.len() > ::std::cmp::max(self.sorted * 2, 1 << 20) {
-//             self.buffer.sort();
-//             for index in 1 .. self.buffer.len() {
-//                 if self.buffer[index].0 == self.buffer[index-1].0 {
-//                     self.buffer[index].1 += self.buffer[index-1].1;
-//                     self.buffer[index-1].1 = 0;
-//                 }
-//             }
-//             self.buffer.retain(|x| x.1 != 0);
-//             self.sorted = self.buffer.len();
-//         }
-//     }
-//     /// Adds several elements to the batch compacted.
-//     pub fn extend<I: Iterator<Item=(T, Delta)>>(&mut self, iter: I) {
-//         for item in iter {
-//             self.push(item);
-//         }
-//     }
-//     /// Finishes compaction, returns results.
-//     pub fn done(mut self) -> Vec<(T, Delta)> {
-//         if self.buffer.len() > self.sorted {
-//             self.buffer.sort();
-//             for index in 1 .. self.buffer.len() {
-//                 if self.buffer[index].0 == self.buffer[index-1].0 {
-//                     self.buffer[index].1 += self.buffer[index-1].1;
-//                     self.buffer[index-1].1 = 0;
-//                 }
-//             }
-//             self.buffer.retain(|x| x.1 != 0);
-//             self.sorted = self.buffer.len();
-//         }
-//         self.buffer
-//     }
-// }
-

--- a/src/operators/group.rs
+++ b/src/operators/group.rs
@@ -343,7 +343,7 @@ where
                         if output_cursor.key_valid() && output_cursor.key() == &key {
                             while output_cursor.val_valid() {
                                 let val: V2 = output_cursor.val().clone();
-                                let mut sum = 0;
+                                // let mut sum = 0;
                                 output_cursor.map_times(|t,d| {
                                     // if t.le(&meet) { sum += d; }
                                     // if !t.le(&meet) {

--- a/src/ring.rs
+++ b/src/ring.rs
@@ -1,0 +1,84 @@
+//! A type that can be treated as a mathematical ring.
+
+use std::ops::{Add, Sub, Neg, Mul};
+
+use abomonation::Abomonation;
+use ::Data;
+
+/// A type that can be treated as a mathematical ring.
+pub trait Ring : Add<Self, Output=Self> + Sub<Self, Output=Self> + Neg<Output=Self> + Mul<Self, Output=Self> + ::std::marker::Sized + Data + Copy {
+	/// Returns true if the element is the additive identity.
+	fn is_zero(&self) -> bool;
+	/// The additive identity.
+	fn zero() -> Self;
+}
+
+impl Ring for isize { 
+	fn is_zero(&self) -> bool { *self == 0 }
+	fn zero() -> Self { 0 }
+}
+
+
+/// The ring defined by a pair of ring elements.
+#[derive(Copy, Ord, PartialOrd, Eq, PartialEq, Debug, Clone)]
+pub struct RingPair<R1: Ring, R2: Ring> {
+	element1: R1,
+	element2: R2,
+}
+
+impl<R1: Ring, R2: Ring> RingPair<R1, R2> {
+	/// Creates a new ring pair from two elements.
+	pub fn new(elt1: R1, elt2: R2) -> Self {
+		RingPair {
+			element1: elt1,
+			element2: elt2,
+		}
+	}
+}
+
+impl<R1: Ring, R2: Ring> Ring for RingPair<R1, R2> {
+	fn is_zero(&self) -> bool { self.element1.is_zero() && self.element2.is_zero() }
+	fn zero() -> Self { RingPair { element1: R1::zero(), element2: R2::zero() } }
+}
+
+impl<R1: Ring, R2: Ring> Add<RingPair<R1, R2>> for RingPair<R1, R2> {
+	type Output = Self;
+	fn add(self, rhs: Self) -> Self {
+		RingPair { 
+			element1: self.element1 + rhs.element1, 
+			element2: self.element2 + rhs.element2,
+		}
+	}
+}
+
+impl<R1: Ring, R2: Ring> Sub<RingPair<R1, R2>> for RingPair<R1, R2> {
+	type Output = RingPair<R1, R2>;
+	fn sub(self, rhs: Self) -> Self {
+		RingPair { 
+			element1: self.element1 - rhs.element1, 
+			element2: self.element2 - rhs.element2,
+		}
+	}
+}
+
+impl<R1: Ring, R2: Ring> Neg for RingPair<R1, R2> {
+	type Output = Self;
+	fn neg(self) -> Self {
+		RingPair {
+			element1: -self.element1,
+			element2: -self.element2,
+		}
+	}
+}
+
+impl<R1: Ring, R2: Ring> Mul<RingPair<R1, R2>> for RingPair<R1, R2> {
+	type Output = Self;
+	fn mul(self, rhs: Self) -> Self {
+		RingPair { 
+			element1: self.element1 * rhs.element1, 
+			element2: self.element2 * rhs.element2,
+		}
+	}
+}
+
+impl<R1: Ring, R2: Ring> Abomonation for RingPair<R1, R2> { }

--- a/src/trace/cursor/mod.rs
+++ b/src/trace/cursor/mod.rs
@@ -10,7 +10,7 @@ pub mod cursor_list;
 // pub mod cursor_pair;
 
 /// A cursor for navigating ordered `(key, val, time, diff)` updates.
-pub trait Cursor<K, V, T> {
+pub trait Cursor<K, V, T, R> {
 	
 	/// Indicates if the current key is valid.
 	///
@@ -26,7 +26,7 @@ pub trait Cursor<K, V, T> {
 	/// A reference to the current value. Asserts if invalid.
 	fn val(&self) -> &V;
 	/// Applies `logic` to each pair of time and difference.
-	fn map_times<L: FnMut(&T, isize)>(&mut self, logic: L);
+	fn map_times<L: FnMut(&T, R)>(&mut self, logic: L);
 
 	/// Advances the cursor to the next key. Indicates if the key is valid.
 	fn step_key(&mut self);


### PR DESCRIPTION
Differential dataflow has previously used `isize` or `i32` for the counts associated with updates. This pull request generalizes this to mathematical rings, which are types supporting addition, subtraction, and multiplication. 

This flexibility allows the user to use `isize` or `i32` as they see fit, but also allows us additional flexibility to accumulate more general quantities. For example, #6 suffers from the inability of differential dataflow to accumulate inputs in-place, maintaining records to sum as different updates instead of accumulating them. We can now write (e.g. in `examples/ring.rs`):

```rust
    let (input, data) = scope.new_input::<((usize, isize), isize)>();

    // move `val` into the ring component.
    data.map(|((key,val),d)| (key, Default::default(), RingPair::new(val,d)))
	.as_collection()
        .consolidate();
```

which allows us to move accumulable data into the ring, where differential dataflow is now able to accumulate the contributions.

Each ring element has an additive identity ("zero"), and accumulated updates can be discarded when their ring element equals this zero. They can not otherwise be discarded, even though individual components may be zero.

Restrictions include the fact that some common types are not rings, for example `f32` and `f64`. Also, the simplest implementation of rings as tuples of other rings does not work, because tuples do not implement `Add`, `Sub`, `Neg`, `Mul`, etc. At the moment we provide a `RingPair` type which acts as a re-implementation of pair supporting `Ring`, but it is worth thinking about whether this is the best we can do.

As part of this PR, trace implementations should (or at least, `rhh_k` does) compact updates as they are accumulated. The in-place updating has no benefits if we just append them all, of course. This can result in a performance hit if the compaction happens when it used to not happen, and may provide no benefit. The point at which compaction happens should be parameterizable, but it is currently just a constant in `rhh_k.rs`. There are some further thoughts on how the data should be store (e.g. as traces, which are tight representations, or as buffers `Vec<(Data, Time, Ring)>` which are easily re-used as the data are manipulated.

There is a new example, `examples/ring.rs`, which demonstrate in-place updating and ring functionality by introducing an unbounded number (`usize::max_value()`) of records with some bounded number of (key, val) pairs with some bounded number of keys (and junk vals to accumulate). It runs and reports the rate at which it consumes inputs, for example:

```
Echidnatron% cargo run --release --example ring -- 1000 10000000
   Compiling differential-dataflow v0.0.4 (file:///Users/mcsherry/Projects/differential-dataflow)
    Finished release [optimized + debuginfo] target(s) in 25.79 secs
     Running `target/release/examples/ring 1000 10000000`
tuples: 10000000,	elts/sec: 5761822.478278253
tuples: 20000000,	elts/sec: 5914238.979648239
tuples: 30000000,	elts/sec: 5828678.981620855
tuples: 40000000,	elts/sec: 5991998.556864298
...
tuples: 990000000,	elts/sec: 7035803.761681548
tuples: 1000000000,	elts/sec: 7033942.504046317
tuples: 1010000000,	elts/sec: 7034213.746759261
...
```

which gives us a sense for the cost of in-place compaction. The benefit is that without it, one billion of these records would have occupied 12GB+, and here it wobbles around 150MB.

The rate without compaction is initially something like 20M elts/sec, and the cost seems to be closely connected to the cost of hashing and radix sorting. If the `hashed()` method (the default hash function) is reduced from 64 to 32 bits, the rate increases to 10M elts/sec, due to fewer radix passes meaning fewer hash invocations. We should experiment with types that have cheaper hash functions to see if it is the passes (and data movement) or the hash evaluation (which we can fix).