### PR TITLE
Group hires

### DIFF
--- a/examples/degrees.rs
+++ b/examples/degrees.rs
@@ -23,13 +23,12 @@ fn main() {
     let nodes: u32 = std::env::args().nth(1).unwrap().parse().unwrap();
     let edges: usize = std::env::args().nth(2).unwrap().parse().unwrap();
     let batch: usize = std::env::args().nth(3).unwrap().parse().unwrap();
-    let k: isize = std::env::args().nth(4).unwrap().parse().unwrap();
 
     let kc1 = std::env::args().find(|x| x == "kcore1").is_some();
     let kc2 = std::env::args().find(|x| x == "kcore2").is_some();
 
     // define a new computational scope, in which to run BFS
-    timely::execute_from_args(std::env::args().skip(5), move |computation| {
+    timely::execute_from_args(std::env::args().skip(4), move |computation| {
 
     	let index = computation.index();
     	let peers = computation.peers();
@@ -40,19 +39,17 @@ fn main() {
     		// create edge input, count a few ways.
     		let (input, edges) = scope.new_input();
 
-    		
     		// pull off source, and count.
     		let mut edges = edges.as_collection();
 
-    		if kc1 { edges = kcore1(&edges, k); }
-    		if kc2 { edges = kcore2(&edges, k); }
+    		if kc1 { edges = kcore1(&edges, std::env::args().nth(4).unwrap().parse().unwrap()); }
+    		if kc2 { edges = kcore2(&edges, std::env::args().nth(4).unwrap().parse().unwrap()); }
 
-    		let degrs = edges//.flat_map(|(src,dst)| Some(src).into_iter().chain(Some(dst).into_iter()))
-    						 .map(|(src,_dst)| src)
+    		let degrs = edges.map(|(src, _dst)| src)
     						 .count();
 
     		// pull of count, and count.
-		    let distr = degrs.map(|(_, cnt)| cnt as u32)
+		    let distr = degrs.map(|(_src, cnt)| cnt)
     						 .count();
 
 			// show us something about the collection, notice when done.
@@ -90,33 +87,31 @@ fn main() {
 			println!("Loading finished after {:?}", nanos);
 		}
 
-		// change graph, forever
 		if batch > 0 {
 
-			for edge in 0usize .. {
-				let &time = input.time();
-				if edge % peers == index {
-	        		input.send(((rng1.gen_range(0, nodes), rng1.gen_range(0, nodes)), time, 1));
-	        		input.send(((rng2.gen_range(0, nodes), rng2.gen_range(0, nodes)), time,-1));
-				}
+			// create a new input session; will batch data for us!
+            let mut session = differential_dataflow::input::InputSession::from(&mut input);
 
-	        	if edge % batch == (batch - 1) {
+            for round in 1 .. {
+
+            	// only do the work of this worker.
+            	if round % peers == index {
+            		session.advance_to(round);
+	        		session.insert((rng1.gen_range(0, nodes), rng1.gen_range(0, nodes)));
+	        		session.remove((rng2.gen_range(0, nodes), rng2.gen_range(0, nodes)));
+            	}
+
+            	if round % batch == 0 {
+            		// all workers indicate they have finished with `round`.
+            		session.advance_to(round + 1);
+					session.flush();
 
 	        		let timer = ::std::time::Instant::now();
-
-	        		let next = input.epoch() + 1;
-	        		input.advance_to(next);
-					computation.step_while(|| probe.lt(input.time()));
-
-					if index == 0 {
-						let timer = timer.elapsed();
-						let nanos = timer.as_secs() * 1000000000 + timer.subsec_nanos() as u64;
-						println!("Round {} finished after {:?}", next - 1, nanos);
-					}
-	        	}
-	        }
-	    }
-
+					computation.step_while(|| probe.lt(session.time()));
+					println!("worker {}, round {} finished after {:?}", index, round, timer.elapsed());
+            	}
+            }
+		}
     }).unwrap();
 }
 

--- a/examples/degrees.rs
+++ b/examples/degrees.rs
@@ -76,16 +76,16 @@ fn main() {
         	}
 		}
 
-		let timer = ::std::time::Instant::now();
+		// let timer = ::std::time::Instant::now();
 
 		input.advance_to(1);
 		computation.step_while(|| probe.lt(input.time()));
 
-		if index == 0 {
-			let timer = timer.elapsed();
-			let nanos = timer.as_secs() * 1000000000 + timer.subsec_nanos() as u64;
-			println!("Loading finished after {:?}", nanos);
-		}
+		// if index == 0 {
+		// 	let timer = timer.elapsed();
+		// 	let nanos = timer.as_secs() * 1000000000 + timer.subsec_nanos() as u64;
+		// 	println!("Loading finished after {:?}", nanos);
+		// }
 
 		if batch > 0 {
 

--- a/src/hashable.rs
+++ b/src/hashable.rs
@@ -94,11 +94,13 @@ pub struct OrdWrapper<T: Ord+Hashable> {
 }
 
 impl<T: Ord+Hashable> PartialOrd for OrdWrapper<T> {
+    #[inline(always)]
     fn partial_cmp(&self, other: &Self) -> Option<::std::cmp::Ordering> {
         (self.item.hashed(), &self.item).partial_cmp(&(other.item.hashed(), &other.item))
     }
 }
 impl<T: Ord+Hashable> Ord for OrdWrapper<T> {
+    #[inline(always)]
     fn cmp(&self, other: &Self) -> ::std::cmp::Ordering {
         (self.item.hashed(), &self.item).cmp(&(other.item.hashed(), &other.item))        
     }
@@ -124,15 +126,18 @@ pub struct HashableWrapper<T: Hashable> {
 
 impl<T: Hashable> Hashable for HashableWrapper<T> {
     type Output = T::Output;
+    #[inline(always)]
     fn hashed(&self) -> T::Output { self.hash }
 }
 
 impl<T: Hashable> Deref for HashableWrapper<T> {
     type Target = T;
+    #[inline(always)]
     fn deref(&self) -> &T { &self.item }
 }
 
 impl<T: Hashable> From<T> for HashableWrapper<T> {
+    #[inline(always)]
     fn from(item: T) -> HashableWrapper<T> { 
         HashableWrapper {
             hash: item.hashed(),
@@ -150,14 +155,17 @@ pub struct UnsignedWrapper<T: Unsigned+Copy> {
 
 impl<T: Unsigned+Copy> Hashable for UnsignedWrapper<T> {
     type Output = T;
+    #[inline(always)]
     fn hashed(&self) -> Self::Output { self.item }
 }
 
 impl<T: Unsigned+Copy> Deref for UnsignedWrapper<T> {
     type Target = T;
+    #[inline(always)]
     fn deref(&self) -> &T { &self.item }
 }
 
 impl<T: Unsigned+Copy> From<T> for UnsignedWrapper<T> {
+    #[inline(always)]
     fn from(item: T) -> Self { UnsignedWrapper { item: item } }
 }

--- a/src/lattice.rs
+++ b/src/lattice.rs
@@ -13,6 +13,7 @@ pub trait Lattice : PartialOrd {
 
     /// Advances self to the largest time indistinguishable under `frontier`.
     // TODO : add an example here demonstrating the result invariant.
+    #[inline(always)]
     fn advance_by(&self, frontier: &[Self]) -> Option<Self> where Self: Sized{
         if frontier.len() > 0 {
             let mut result = self.join(&frontier[0]);
@@ -34,13 +35,14 @@ impl<T1: Lattice, T2: Lattice> Lattice for Product<T1, T2> {
     fn min() -> Self { Product::new(T1::min(), T2::min()) }
     #[inline(always)]
     fn max() -> Self { Product::new(T1::max(), T2::max()) }
-
+    #[inline(always)]
     fn join(&self, other: &Product<T1, T2>) -> Product<T1, T2> {
         Product {
             outer: self.outer.join(&other.outer),
             inner: self.inner.join(&other.inner),
         }
     }
+    #[inline(always)]
     fn meet(&self, other: &Product<T1, T2>) -> Product<T1, T2> {
         Product {
             outer: self.outer.meet(&other.outer),
@@ -52,44 +54,68 @@ impl<T1: Lattice, T2: Lattice> Lattice for Product<T1, T2> {
 use timely::progress::timestamp::RootTimestamp;
 
 impl Lattice for RootTimestamp {
+    #[inline(always)]
     fn min() -> RootTimestamp { RootTimestamp }
+    #[inline(always)]
     fn max() -> RootTimestamp { RootTimestamp }
+    #[inline(always)]
     fn join(&self, _: &RootTimestamp) -> RootTimestamp { RootTimestamp }
+    #[inline(always)]
     fn meet(&self, _: &RootTimestamp) -> RootTimestamp { RootTimestamp }
 }
 
 impl Lattice for usize {
+    #[inline(always)]
     fn min() -> usize { usize::min_value() }
+    #[inline(always)]
     fn max() -> usize { usize::max_value() }
+    #[inline(always)]
     fn join(&self, other: &usize) -> usize { ::std::cmp::max(*self, *other) }
+    #[inline(always)]
     fn meet(&self, other: &usize) -> usize { ::std::cmp::min(*self, *other) }
 }
 
 impl Lattice for u64 {
+    #[inline(always)]
     fn min() -> u64 { u64::min_value() }
+    #[inline(always)]
     fn max() -> u64 { u64::max_value() }
+    #[inline(always)]
     fn join(&self, other: &u64) -> u64 { ::std::cmp::max(*self, *other) }
+    #[inline(always)]
     fn meet(&self, other: &u64) -> u64 { ::std::cmp::min(*self, *other) }
 }
 
 impl Lattice for u32 {
+    #[inline(always)]
     fn min() -> u32 { u32::min_value() }
+    #[inline(always)]
     fn max() -> u32 { u32::max_value() }
+    #[inline(always)]
     fn join(&self, other: &u32) -> u32 { ::std::cmp::max(*self, *other) }
+    #[inline(always)]
     fn meet(&self, other: &u32) -> u32 { ::std::cmp::min(*self, *other) }
 }
 
 impl Lattice for i32 {
+    #[inline(always)]
     fn min() -> i32 { i32::min_value() }
+    #[inline(always)]
     fn max() -> i32 { i32::max_value() }
+    #[inline(always)]
     fn join(&self, other: &i32) -> i32 { ::std::cmp::max(*self, *other) }
+    #[inline(always)]
     fn meet(&self, other: &i32) -> i32 { ::std::cmp::min(*self, *other) }
 }
 
 impl Lattice for () {
+    #[inline(always)]
     fn min() -> () { () }
+    #[inline(always)]
     fn max() -> () { () }
+    #[inline(always)]
     fn join(&self, _other: &()) -> () { () }
+    #[inline(always)]
     fn meet(&self, _other: &()) -> () { () }
 }
 

--- a/tests/bfs.rs
+++ b/tests/bfs.rs
@@ -1,0 +1,209 @@
+extern crate rand;
+extern crate timely;
+extern crate differential_dataflow;
+
+use rand::{Rng, SeedableRng, StdRng};
+
+use std::sync::{Arc, Mutex};
+
+use timely::dataflow::*;
+use timely::dataflow::operators::*;
+use timely::dataflow::operators::Capture;
+use timely::dataflow::operators::capture::Extract;
+
+use differential_dataflow::{Collection, AsCollection};
+
+use differential_dataflow::operators::*;
+use differential_dataflow::lattice::Lattice;
+
+type Node = usize;
+type Edge = (Node, Node);
+
+#[test] fn bfs_10_20_1000() { test_sizes(10, 20, 1000); }
+#[test] fn bfs_100_200_10() { test_sizes(100, 200, 10); }
+#[test] fn bfs_100_2000_1() { test_sizes(100, 2000, 1); }
+
+fn test_sizes(nodes: usize, edges: usize, rounds: usize) {
+
+    let root_list = vec![(1, 0, 1)];
+    let mut edge_list = Vec::new();
+
+    let seed: &[_] = &[1, 2, 3, 4];
+    let mut rng1: StdRng = SeedableRng::from_seed(seed);    // rng for edge additions
+    let mut rng2: StdRng = SeedableRng::from_seed(seed);    // rng for edge deletions
+
+    for _ in 0 .. edges {
+        edge_list.push(((rng1.gen_range(0, nodes), rng1.gen_range(0, nodes)), 0, 1));
+    }
+
+    for round in 1 .. rounds {
+        edge_list.push(((rng1.gen_range(0, nodes), rng1.gen_range(0, nodes)), round, 1));
+        edge_list.push(((rng2.gen_range(0, nodes), rng2.gen_range(0, nodes)), round,-1));        
+    }
+
+    let mut results1 = bfs_sequential(root_list.clone(), edge_list.clone());
+    let mut results2 = bfs_differential(root_list.clone(), edge_list.clone());
+
+    results1.sort();
+    results1.sort_by(|x,y| x.1.cmp(&y.1));
+    results2.sort();
+    results2.sort_by(|x,y| x.1.cmp(&y.1));
+
+    assert_eq!(results1, results2);
+}
+
+
+fn bfs_sequential(
+    root_list: Vec<(usize, usize, isize)>, 
+    edge_list: Vec<((usize, usize), usize, isize)>) 
+-> Vec<((usize, usize), usize, isize)> {
+
+    let mut nodes = 0;
+    for &(root, _, _) in &root_list { 
+        nodes = ::std::cmp::max(nodes, root + 1); 
+    }
+    for &((src,dst), _, _) in &edge_list { 
+        nodes = ::std::cmp::max(nodes, src + 1); 
+        nodes = ::std::cmp::max(nodes, dst + 1); 
+    }
+
+    let mut rounds = 0;
+    for &(_, time, _) in &root_list { rounds = ::std::cmp::max(rounds, time + 1); }
+    for &(_, time, _) in &edge_list { rounds = ::std::cmp::max(rounds, time + 1); }
+
+    let mut counts = vec![0; nodes];
+    let mut results = Vec::new();
+
+    for round in 0 .. rounds {
+
+        let mut roots = ::std::collections::HashMap::new();
+        for &(root, time, diff) in &root_list {
+            if time <= round { *roots.entry(root).or_insert(0) += diff; }
+        }
+
+        let mut edges = ::std::collections::HashMap::new();
+        for &((src, dst), time, diff) in &edge_list {
+            if time <= round { *edges.entry((src, dst)).or_insert(0) += diff; }
+        }
+
+        let mut dists = vec![usize::max_value(); nodes];
+        for (&key, &val) in roots.iter() {
+            if val > 0 { dists[key] = 0; }
+        }
+
+        let mut changes = true; 
+        while changes {
+            changes = false;
+            for (&(src, dst), &cnt) in edges.iter() {
+                if cnt > 0 {
+                    if dists[src] != usize::max_value() && dists[dst] > dists[src] + 1 {
+                        dists[dst] = dists[src] + 1;
+                        changes = true;
+                    }
+                }
+            }
+        }
+
+        let mut new_counts = vec![0; nodes];
+        for &value in dists.iter() {
+            if value != usize::max_value() {
+                new_counts[value] += 1;
+            }
+        }
+
+        for index in 0 .. nodes {
+            if new_counts[index] != counts[index] {
+                if new_counts[index] != 0 { results.push(((index, new_counts[index]), round, 1)); }
+                if counts[index] != 0 { results.push(((index, counts[index]), round,-1)); }
+                counts[index] = new_counts[index];
+            }
+        }
+    }
+
+    results
+}
+
+fn bfs_differential(
+    roots_list: Vec<(usize, usize, isize)>, 
+    edges_list: Vec<((usize, usize), usize, isize)>) 
+-> Vec<((usize, usize), usize, isize)>
+{
+
+    let (send, recv) = ::std::sync::mpsc::channel();
+    let send = Arc::new(Mutex::new(send));
+
+    timely::execute(timely::Configuration::Thread, move |worker| {
+        
+        let mut roots_list = roots_list.clone();
+        let mut edges_list = edges_list.clone();
+
+        // define BFS dataflow; return handles to roots and edges inputs
+        let (mut roots, mut edges) = worker.scoped(|scope| {
+
+            let send = send.lock().unwrap().clone();
+
+            let (root_input, roots) = scope.new_input();
+            let (edge_input, edges) = scope.new_input();
+
+            let roots = roots.as_collection();
+            let edges = edges.as_collection();
+
+            bfs(&edges, &roots).map(|(_, dist)| dist)
+                               .count()
+                               .map(|(x,y)| (x, y as usize))
+                               .inner
+                               .capture_into(send);
+
+            (root_input, edge_input)
+        });
+
+        // sort by decreasing insertion time.
+        roots_list.sort_by(|x,y| y.1.cmp(&x.1));
+        edges_list.sort_by(|x,y| y.1.cmp(&x.1));
+
+        let mut roots = differential_dataflow::input::InputSession::from(&mut roots);
+        let mut edges = differential_dataflow::input::InputSession::from(&mut edges);
+
+        let mut round = 0;
+        while roots_list.len() > 0 || edges_list.len() > 0 {
+
+            while roots_list.last().map(|x| x.1) == Some(round) {
+                let (node, _time, diff) = roots_list.pop().unwrap();                
+                roots.update(node, diff);
+            }
+            while edges_list.last().map(|x| x.1) == Some(round) {
+                let ((src, dst), _time, diff) = edges_list.pop().unwrap();                
+                edges.update((src, dst), diff);
+            }
+
+            round += 1;
+            roots.advance_to(round);
+            edges.advance_to(round);
+        }
+
+    }).unwrap();
+
+    recv.extract()
+        .into_iter()
+        .flat_map(|(_, list)| list.into_iter().map(|((dst,cnt),time,diff)| ((dst,cnt), time.inner, diff)))
+        .collect()
+}
+
+// returns pairs (n, s) indicating node n can be reached from a root in s steps.
+fn bfs<G: Scope>(edges: &Collection<G, Edge>, roots: &Collection<G, Node>) -> Collection<G, (Node, usize)>
+where G::Timestamp: Lattice+Ord {
+
+    // initialize roots as reaching themselves at distance 0
+    let nodes = roots.map(|x| (x, 0));
+
+    // repeatedly update minimal distances each node can be reached from each root
+    nodes.iterate(|inner| {
+
+        let edges = edges.enter(&inner.scope());
+        let nodes = nodes.enter(&inner.scope());
+
+        inner.join_map(&edges, |_k,l,d| (*d, l+1))
+             .concat(&nodes)
+             .group(|_, s, t| t.push((s[0].0, 1)))
+     })
+}


### PR DESCRIPTION
This pull request substantially changes the implementation of `group` in an attempt to perform closer to "linear" in the number of input updates.

The problem observed is that when a batch of updates contains many distinct times for the same key, the logic of (i) computing all synthetic interesting times and (ii) forming the input and output at these times both took time (at least) quadratic in the size of inputs. Some times quadratic is the right answer (rarely in our examples, but it is possible), but in many cases (notably arbitrarily large rounds of updates) the output is linear in the input, and our computation didn't reflect this. This meant that batching input updates resulted in performance *degradation* rather than improvement, opposite of what is desired.

The underlying `group` implementation is changed to perform tasks (i) and (ii) in time that is meant to be linear (plus sorting) in the inputs multiplied by the number of times that are not `lt` their immediate successor in the total order. There is no guarantee that there will be few such times; in a total order there are none, but in the `(round, iteration)` partial order there may be many. In future work, we could more aggressively re-order the updates, if we see this is a problem.

Running times for the `degrees.rs` example, which determines the degrees of a changing random graph and counts the number of nodes with each degree (this last count suffering many changes to the same few keys) now has performance linear in the batch size:

```
worker 0, round 1 finished after Duration { secs: 0, nanos: 90736 }
worker 0, round 10 finished after Duration { secs: 0, nanos: 215832 }
worker 0, round 100 finished after Duration { secs: 0, nanos: 842466 }
worker 0, round 1000 finished after Duration { secs: 0, nanos: 6758881 }
worker 0, round 10000 finished after Duration { secs: 0, nanos: 55910134 }
worker 0, round 100000 finished after Duration { secs: 0, nanos: 500888218 }
worker 0, round 1000000 finished after Duration { secs: 5, nanos: 405282347 }
```

The `bfs.rs` example has substantially improved performance for the small graph reference (1,000 nodes and 2,000 edges), though it still exhibits degrading performance with larger batches, suggesting that for more complex partial orders there is still work to do (though, for general partial orders it isn't clear how much opportunity we really have).

The main interesting changes lie in the `Interestinator` and `Accumulator` structs. Respectively, these two maintain buffers and logic to (i) determine synthetic interesting times, and (ii) maintain and update accumulations of collections. Each implementation intends to exploit the "narrowness" of the partial order, in that there are decompositions into relatively few disjoint chains, and the frontiers (antichains) at any point cannot be too large.

Because the `group` implementation is now sufficiently exotic, there is also a new `tests/bfs.rs` which applies breadth-first distance labeling to a randomly changing random graph, both using differential dataflow and using a very naive sequential implementation, and checks that they produce identical outputs. This test is included in `cargo test` and should error out if we break the `group` implementation for these cases.