### PR TITLE
Descriptions

### DIFF
--- a/src/operators/group.rs
+++ b/src/operators/group.rs
@@ -227,6 +227,12 @@ where
             // stolen some code from there, so if either looks wrong, make sure to check the other
             // as well.
 
+            // lower bound for use in descriptions.
+            let mut lower = Vec::new();
+            for cap in &capabilities {
+                lower.push(cap.time());
+            }
+
             for index in 0 .. capabilities.len() {
 
                 // Only do all of this if the capability is not present in the input frontier.
@@ -398,10 +404,12 @@ where
                     }
 
                     // We have processed all exposed keys and times, and should commit and send the batch.
-                    let output_batch = output_builder.done(&[], &[]);     // TODO: fix this nonsense.
+                    let output_batch = output_builder.done(&lower[..], &upper[..]);
                     output.session(&capabilities[index]).give(BatchWrapper { item: output_batch.clone() });
                     let output_borrow: &mut T2 = &mut output_trace.wrapper.borrow_mut().trace;
                     output_borrow.insert(output_batch);
+
+                    lower = upper;
                 }
             }
 

--- a/src/trace/description.rs
+++ b/src/trace/description.rs
@@ -20,6 +20,9 @@ pub struct Description<Time> {
 impl<Time: Clone> Description<Time> {
 	/// Returns a new description from its component parts.
 	pub fn new(lower: &[Time], upper: &[Time], since: &[Time]) -> Self {
+
+		assert!(lower.len() > 0);	// this should always be true.
+		// assert!(upper.len() > 0);	// this may not always be true.
 		Description {
 			lower: lower.to_vec(),
 			upper: upper.to_vec(),

--- a/src/trace/implementations/rhh.rs
+++ b/src/trace/implementations/rhh.rs
@@ -140,9 +140,17 @@ impl<Key: Clone+Default+HashOrdered, Val: Ord+Clone, Time: Lattice+Ord+Clone+Def
 			assert!(other.desc.upper().iter().any(|t| t.le(time)));
 		}
 
+		// one of self.desc.since or other.desc.since needs to be not behind the other...
+		let since = if self.desc.since().iter().all(|t1| other.desc.since().iter().any(|t2| t2.le(t1))) {
+			other.desc.since()
+		}
+		else {
+			self.desc.since()
+		};
+
 		Layer {
 			layer: self.layer.merge(&other.layer),
-			desc: Description::new(other.desc.lower(), self.desc.upper(), &[]), // TODO: third argument wrong
+			desc: Description::new(other.desc.lower(), self.desc.upper(), since),
 		}
 	}
 	/// Advances times in `layer` and consolidates differences for like times.

--- a/src/trace/implementations/rhh.rs
+++ b/src/trace/implementations/rhh.rs
@@ -61,36 +61,33 @@ where
 	// Note: this does not perform progressive merging; that code is around somewhere though.
 	fn insert(&mut self, layer: Self::Batch) {
 		assert!(!self.done);
-		if layer.layer.keys() > 0 {
-			// while last two elements exist, both less than layer.len()
-			while self.layers.len() >= 2 && self.layers[self.layers.len() - 2].len() < layer.len() {
-				let layer1 = self.layers.pop().unwrap();
-				let layer2 = self.layers.pop().unwrap();
-				let result = Rc::new(Layer::merge(&layer1, &layer2));
-				if result.len() > 0 {
-					self.layers.push(result);
-				}
-			}
 
-			if layer.len() > 0 {
-				self.layers.push(layer);
-			}
-
-		    while self.layers.len() >= 2 && self.layers[self.layers.len() - 2].len() < 2 * self.layers[self.layers.len() - 1].len() {
-				let layer1 = self.layers.pop().unwrap();
-				let layer2 = self.layers.pop().unwrap();
-				let mut result = Rc::new(layer1.merge(&layer2));
-
-				// if we just merged the last layer, `advance_by` it.
-				if self.layers.len() == 0 {
-					result = Rc::new(Layer::<Key, Val, Time, R>::advance_by(&result, &self.frontier[..]));
-				}
-
-				if result.len() > 0 {
-					self.layers.push(result);
-				}
+		// while last two elements exist, both less than layer.len()
+		while self.layers.len() >= 2 && self.layers[self.layers.len() - 2].len() < layer.len() {
+			let layer1 = self.layers.pop().unwrap();
+			let layer2 = self.layers.pop().unwrap();
+			let result = Rc::new(Layer::merge(&layer1, &layer2));
+			if result.len() > 0 {
+				self.layers.push(result);
 			}
 		}
+
+		// assert that the interval added is contiguous (that we aren't missing anything).
+		self.layers.push(layer);
+
+	    while self.layers.len() >= 2 && self.layers[self.layers.len() - 2].len() < 2 * self.layers[self.layers.len() - 1].len() {
+			let layer1 = self.layers.pop().unwrap();
+			let layer2 = self.layers.pop().unwrap();
+			let mut result = Rc::new(layer1.merge(&layer2));
+
+			// if we just merged the last layer, `advance_by` it.
+			if self.layers.len() == 0 {
+				result = Rc::new(Layer::<Key, Val, Time, R>::advance_by(&result, &self.frontier[..]));
+			}
+
+			self.layers.push(result);
+		}
+	
 	}
 	fn cursor(&self) -> Self::Cursor {
 		assert!(!self.done);
@@ -134,9 +131,18 @@ impl<Key: Clone+Default+HashOrdered, Val: Ord+Clone, Time: Lattice+Ord+Clone+Def
 
 	/// Conducts a full merge, right away. Times not advanced.
 	pub fn merge(&self, other: &Self) -> Self {
+
+		// // this may not be true if we leave gaps; a weaker statement would be "<=".
+		// assert!(other.desc.upper() == self.desc.lower());
+
+		// each element of self.desc.lower must be in the future of some element of other.desc.upper
+		for time in self.desc.lower() {
+			assert!(other.desc.upper().iter().any(|t| t.le(time)));
+		}
+
 		Layer {
 			layer: self.layer.merge(&other.layer),
-			desc: Description::new(&[], &[], &[]),
+			desc: Description::new(other.desc.lower(), self.desc.upper(), &[]), // TODO: third argument wrong
 		}
 	}
 	/// Advances times in `layer` and consolidates differences for like times.

--- a/src/trace/implementations/rhh_k.rs
+++ b/src/trace/implementations/rhh_k.rs
@@ -59,36 +59,32 @@ where
 	}
 	// Note: this does not perform progressive merging; that code is around somewhere though.
 	fn insert(&mut self, layer: Self::Batch) {
-		if layer.layer.keys() > 0 {
-			// while last two elements exist, both less than layer.len()
-			while self.layers.len() >= 2 && self.layers[self.layers.len() - 2].len() < layer.len() {
-				let layer1 = self.layers.pop().unwrap();
-				let layer2 = self.layers.pop().unwrap();
-				let result = Rc::new(Layer::merge(&layer1, &layer2));
-				if result.len() > 0 {
-					self.layers.push(result);
-				}
-			}
 
-			if layer.len() > 0 {
-				self.layers.push(layer);
-			}
-
-		    while self.layers.len() >= 2 && self.layers[self.layers.len() - 2].len() < 2 * self.layers[self.layers.len() - 1].len() {
-				let layer1 = self.layers.pop().unwrap();
-				let layer2 = self.layers.pop().unwrap();
-				let mut result = Rc::new(layer1.merge(&layer2));
-
-				// if we just merged the last layer, `advance_by` it.
-				if self.layers.len() == 0 {
-					result = Rc::new(Layer::<Key, Time, R>::advance_by(&result, &self.frontier[..]));
-				}
-
-				if result.len() > 0 {
-					self.layers.push(result);
-				}
+		// while last two elements exist, both less than layer.len()
+		while self.layers.len() >= 2 && self.layers[self.layers.len() - 2].len() < layer.len() {
+			let layer1 = self.layers.pop().unwrap();
+			let layer2 = self.layers.pop().unwrap();
+			let result = Rc::new(Layer::merge(&layer1, &layer2));
+			if result.len() > 0 {
+				self.layers.push(result);
 			}
 		}
+
+		self.layers.push(layer);
+
+	    while self.layers.len() >= 2 && self.layers[self.layers.len() - 2].len() < 2 * self.layers[self.layers.len() - 1].len() {
+			let layer1 = self.layers.pop().unwrap();
+			let layer2 = self.layers.pop().unwrap();
+			let mut result = Rc::new(layer1.merge(&layer2));
+
+			// if we just merged the last layer, `advance_by` it.
+			if self.layers.len() == 0 {
+				result = Rc::new(Layer::<Key, Time, R>::advance_by(&result, &self.frontier[..]));
+			}
+
+			self.layers.push(result);
+		}
+
 	}
 	fn cursor(&self) -> Self::Cursor {
 		let mut cursors = Vec::new();
@@ -129,9 +125,18 @@ impl<Key: Clone+Default+HashOrdered, Time: Lattice+Ord+Clone+Default, R: Ring> L
 
 	/// Conducts a full merge, right away. Times not advanced.
 	pub fn merge(&self, other: &Self) -> Self {
+
+		// // this may not be true if we leave gaps; a weaker statement would be "<=".
+		// assert!(other.desc.upper() == self.desc.lower());
+
+		// each element of self.desc.lower must be in the future of some element of other.desc.upper
+		for time in self.desc.lower() {
+			assert!(other.desc.upper().iter().any(|t| t.le(time)));
+		}
+
 		Layer {
 			layer: self.layer.merge(&other.layer),
-			desc: Description::new(&[], &[], &[]),
+			desc: Description::new(other.desc.lower(), self.desc.upper(), &[]),
 		}
 	}
 	/// Advances times in `layer` and consolidates differences for like times.

--- a/src/trace/implementations/rhh_k.rs
+++ b/src/trace/implementations/rhh_k.rs
@@ -134,9 +134,17 @@ impl<Key: Clone+Default+HashOrdered, Time: Lattice+Ord+Clone+Default, R: Ring> L
 			assert!(other.desc.upper().iter().any(|t| t.le(time)));
 		}
 
+		// one of self.desc.since or other.desc.since needs to be not behind the other...
+		let since = if self.desc.since().iter().all(|t1| other.desc.since().iter().any(|t2| t2.le(t1))) {
+			other.desc.since()
+		}
+		else {
+			self.desc.since()
+		};
+		
 		Layer {
 			layer: self.layer.merge(&other.layer),
-			desc: Description::new(other.desc.lower(), self.desc.upper(), &[]),
+			desc: Description::new(other.desc.lower(), self.desc.upper(), since),
 		}
 	}
 	/// Advances times in `layer` and consolidates differences for like times.


### PR DESCRIPTION
This pull request corrects some (all?) of the bounds in batch descriptions, and introduces a few sanity checks to try and ensure they are used correctly.

To recap, each batch of updates track lower and upper frontiers indicating the times contained in the batch. Specifically, the batch contains any and all times that are greater or equal to some element of the lower frontier but not greater or equal to any element of the upper frontier. In essence, these are the times that are "finalized" as the frontier moves from lower to upper.

The `Description` type now asserts that each `lower` should have non-zero length, as anything else would imply a structurally empty batch. The corresponding assertion for `upper` does not need to hold for the last batch, once the frontier closes.

The two implementations, `rhh.rs` and `rhh_k.rs`, both have instrumented their `merge` methods for merging batches with assertion that ensure that two merged batches have the upper frontier of the first not greater than the lower frontier of the second. It is possible to have gaps in these frontiers when there are empty regions of time; we could insist on filling these but it can be challenging given that they exist in part by the absence of information.