### PR TITLE
Join rewrite

### DIFF
--- a/examples/profile.rs
+++ b/examples/profile.rs
@@ -1,0 +1,30 @@
+extern crate timely;
+extern crate differential_dataflow;
+
+use timely::progress::timestamp::RootTimestamp;
+use timely::dataflow::operators::{ToStream, Capture, Map};
+use timely::dataflow::operators::capture::Extract;
+use differential_dataflow::AsCollection;
+use differential_dataflow::operators::{Join, Count};
+
+
+fn main() {
+
+    let data = timely::example(|scope| {
+
+        let scale = std::env::args().nth(1).unwrap().parse().unwrap();
+
+        let counts = (0 .. 1).to_stream(scope)
+                             .flat_map(move |_| (0..scale).map(|i| ((), RootTimestamp::new(i), 1)))
+                             .as_collection()
+                             .count();
+
+        let odds = counts.filter(|x| x.1 % 2 == 1);
+        let evens = counts.filter(|x| x.1 % 2 == 0);
+
+        odds.join(&evens).inner.capture()
+    });
+
+    let extracted = data.extract();
+    assert_eq!(extracted.len(), 0);
+}

--- a/src/trace/implementations/rhh.rs
+++ b/src/trace/implementations/rhh.rs
@@ -67,12 +67,9 @@ where
 			let layer1 = self.layers.pop().unwrap();
 			let layer2 = self.layers.pop().unwrap();
 			let result = Rc::new(Layer::merge(&layer1, &layer2));
-			if result.len() > 0 {
-				self.layers.push(result);
-			}
+			self.layers.push(result);
 		}
 
-		// assert that the interval added is contiguous (that we aren't missing anything).
 		self.layers.push(layer);
 
 	    while self.layers.len() >= 2 && self.layers[self.layers.len() - 2].len() < 2 * self.layers[self.layers.len() - 1].len() {
@@ -135,11 +132,6 @@ impl<Key: Clone+Default+HashOrdered, Val: Ord+Clone, Time: Lattice+Ord+Clone+Def
 
 		// This may not be true if we leave gaps, so we try hard not to do that.
 		assert!(other.desc.upper() == self.desc.lower());
-
-		// each element of self.desc.lower must be in the future of some element of other.desc.upper
-		for time in self.desc.lower() {
-			assert!(other.desc.upper().iter().any(|t| t.le(time)));
-		}
 
 		// one of self.desc.since or other.desc.since needs to be not behind the other...
 		let since = if self.desc.since().iter().all(|t1| other.desc.since().iter().any(|t2| t2.le(t1))) {

--- a/src/trace/implementations/rhh.rs
+++ b/src/trace/implementations/rhh.rs
@@ -125,6 +125,7 @@ impl<Key: Clone+Default+HashOrdered, Val: Ord+Clone, Time: Lattice+Ord+Clone+Def
 	type Cursor = LayerCursor<Key, Val, Time, R>;
 	fn cursor(&self) -> Self::Cursor {  LayerCursor { cursor: self.layer.cursor() } }
 	fn len(&self) -> usize { self.layer.tuples() }
+	fn description(&self) -> &Description<Time> { &self.desc }
 }
 
 impl<Key: Clone+Default+HashOrdered, Val: Ord+Clone, Time: Lattice+Ord+Clone+Default, R: Ring> Layer<Key, Val, Time, R> {

--- a/src/trace/implementations/rhh_k.rs
+++ b/src/trace/implementations/rhh_k.rs
@@ -119,6 +119,7 @@ impl<Key: Clone+Default+HashOrdered, Time: Lattice+Ord+Clone+Default, R: Ring> B
 		LayerCursor { empty: (), valid: true, cursor: self.layer.cursor() } 
 	}
 	fn len(&self) -> usize { self.layer.tuples() }
+	fn description(&self) -> &Description<Time> { &self.desc }
 }
 
 impl<Key: Clone+Default+HashOrdered, Time: Lattice+Ord+Clone+Default, R: Ring> Layer<Key, Time, R> {

--- a/src/trace/implementations/rhh_k.rs
+++ b/src/trace/implementations/rhh_k.rs
@@ -65,9 +65,7 @@ where
 			let layer1 = self.layers.pop().unwrap();
 			let layer2 = self.layers.pop().unwrap();
 			let result = Rc::new(Layer::merge(&layer1, &layer2));
-			if result.len() > 0 {
-				self.layers.push(result);
-			}
+			self.layers.push(result);
 		}
 
 		self.layers.push(layer);
@@ -129,11 +127,6 @@ impl<Key: Clone+Default+HashOrdered, Time: Lattice+Ord+Clone+Default, R: Ring> L
 
 		// This may not be true if we leave gaps, so we try hard not to do that.
 		assert!(other.desc.upper() == self.desc.lower());
-
-		// each element of self.desc.lower must be in the future of some element of other.desc.upper
-		for time in self.desc.lower() {
-			assert!(other.desc.upper().iter().any(|t| t.le(time)));
-		}
 
 		// one of self.desc.since or other.desc.since needs to be not behind the other...
 		let since = if self.desc.since().iter().all(|t1| other.desc.since().iter().any(|t2| t2.le(t1))) {

--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -14,6 +14,7 @@ pub mod layers;
 
 use ::Ring;
 pub use self::cursor::Cursor;
+pub use self::description::Description;
 
 // 	The traces and batch and cursors want the flexibility to appear as if they manage certain types of keys and 
 // 	values and such, while perhaps using other representations, I'm thinking mostly of wrappers around the keys
@@ -75,6 +76,8 @@ pub trait Batch<K, V, T, R> where Self: ::std::marker::Sized {
 	fn cursor(&self) -> Self::Cursor;
 	/// The number of updates in the batch.
 	fn len(&self) -> usize;
+	/// Describes the times of the updates in the batch.
+	fn description(&self) -> &Description<T>;
 }
 
 /// Functionality for collecting and batching updates.

--- a/tests/join.rs
+++ b/tests/join.rs
@@ -1,10 +1,11 @@
 extern crate timely;
 extern crate differential_dataflow;
 
-use timely::dataflow::operators::{ToStream, Capture};
+use timely::progress::timestamp::RootTimestamp;
+use timely::dataflow::operators::{ToStream, Capture, Map};
 use timely::dataflow::operators::capture::Extract;
 use differential_dataflow::AsCollection;
-use differential_dataflow::operators::{Consolidate, Join};
+use differential_dataflow::operators::{Consolidate, Join, Count};
 
 #[test]
 fn join() {
@@ -74,4 +75,29 @@ fn antijoin() {
     let extracted = data.extract();
     assert_eq!(extracted.len(), 1);
     assert_eq!(extracted[0].1, vec![((1,2), Default::default(),1)]);
+}
+
+#[test] fn join_scale_100() { join_scaling(100); }
+#[test] fn join_scale_1000() { join_scaling(1000); }
+#[test] fn join_scale_10000() { join_scaling(10000); }
+#[test] fn join_scale_100000() { join_scaling(100000); }
+#[test] fn join_scale_1000000() { join_scaling(1000000); }
+
+fn join_scaling(scale: u64) {
+
+    let data = timely::example(move |scope| {
+
+        let counts = (0 .. 1).to_stream(scope)
+                             .flat_map(move |_| (0..scale).map(|i| ((), RootTimestamp::new(i), 1)))
+                             .as_collection()
+                             .count();
+
+        let odds = counts.filter(|x| x.1 % 2 == 1);
+        let evens = counts.filter(|x| x.1 % 2 == 0);
+
+        odds.join(&evens).inner.capture()
+    });
+
+    let extracted = data.extract();
+    assert_eq!(extracted.len(), 0);
 }


### PR DESCRIPTION
This PR rewrites the implementation of `join` in two important ways:

1. It is more correct. The previous implementation should have been buggy when two collections changed at the same time. There are now tests to exercise this (the join scaling tests). 

2. It should be more linear, avoiding quadratic behavior when the histories of the inputs maintain small sizes rather than just joining everything that has ever existed in the timeframe under consideration.

The new join implementation is somewhat sophisticated, and could probably use more testing and documentation. At the same time, all the tests currently pass and it is taking a small fraction of the overall time in the computation.