### PR TITLE
Group v2

### DIFF
--- a/examples/arrange.rs
+++ b/examples/arrange.rs
@@ -11,7 +11,7 @@ use rand::{Rng, SeedableRng, StdRng};
 
 use differential_dataflow::AsCollection;
 use differential_dataflow::operators::arrange::ArrangeByKey;
-use differential_dataflow::trace::{Cursor, Trace};
+use differential_dataflow::trace::Cursor;
 
 fn main() {
 

--- a/src/operators/arrange.rs
+++ b/src/operators/arrange.rs
@@ -316,14 +316,8 @@ impl<G: Scope, K: Data+Hashable, V: Data, R: Ring> Arrange<G, K, V, R> for Colle
                         trace.insert(batch.clone())
                     });
 
-                    // If the batch is non-empty, send it along to downstream consumers.
-                    if batch.len() > 0 {
-                        // TODO: we could plausibly take the meet of times in the batch and downgrade the capability
-                        // first? This would mean downstream consumers only sit on the weakest capability that they
-                        // actually need. On the other hand, it is another scan over updates and work and such. Plus
-                        // these messages will be consumed very quickly, not blocking other workers.
-                        output.session(&capabilities[index]).give(BatchWrapper { item: batch });
-                    }
+                    // send the batch to downstream consumers, empty or not.
+                    output.session(&capabilities[index]).give(BatchWrapper { item: batch });
                 }
             }
 

--- a/src/operators/group.rs
+++ b/src/operators/group.rs
@@ -33,6 +33,7 @@
 
 use std::fmt::Debug;
 use std::default::Default;
+use std::cmp::Ordering;
 
 use hashable::{Hashable, UnsignedWrapper};
 use ::{Data, Collection, Ring};
@@ -66,7 +67,8 @@ impl<G: Scope, K: Data+Default+Hashable, V: Data, R: Ring> Group<G, K, V, R> for
     where G::Timestamp: Lattice+Ord+Debug, <K as Hashable>::Output: Data+Default {
     fn group<L, V2: Data, R2: Ring>(&self, logic: L) -> Collection<G, (K, V2), R2>
         where L: Fn(&K, &[(V, R)], &mut Vec<(V2, R2)>)+'static {
-        self.arrange_by_key_hashed_cached()
+        // self.arrange_by_key_hashed_cached()
+        self.arrange_by_key_hashed()
             .group_arranged(move |k,s,t| logic(&k.item,s,t), HashSpine::new(Default::default()))
             .as_collection(|k,v| (k.item.clone(), v.clone()))
     }
@@ -154,26 +156,17 @@ where
         let mut output_trace = TraceHandle::new(empty, &[Default::default()]);
         let result_trace = output_trace.clone();
 
+        let mut thinker1 = InterestAccumulator::<V, V2, G::Timestamp, R, R2>::new();
+        let mut thinker2 = HistoryReplayer::<V, V2, G::Timestamp, R, R2>::new();
+        let mut temporary = Vec::<G::Timestamp>::new();
+
         // Our implementation maintains a list of outstanding `(key, time)` synthetic interesting times, 
         // as well as capabilities for these times (or their lower envelope, at least).
         let mut interesting = Vec::<(K, G::Timestamp)>::new();
         let mut capabilities = Vec::<Capability<G::Timestamp>>::new();
 
         // buffers and logic for computing per-key interesting times "efficiently".
-        let mut interestinator: Interestinator<G::Timestamp> = Default::default();
         let mut interesting_times = Vec::<G::Timestamp>::new();
-
-        // accumulators for input, output, and output produced as we execute.
-        let mut input_accumulator = Accumulator::<V, G::Timestamp, R>::new();
-        let mut output_accumulator = Accumulator::<V2, G::Timestamp, R2>::new();
-        let mut yielded_accumulator = Accumulator::<V2, G::Timestamp, R2>::new();
-
-        // where the user's logic produces output.
-        let mut output_logic = Vec::<(V2, R2)>::new();
-
-        // where we stash times as we extract from histories.
-        let mut time_buffer1 = Vec::new();
-        let mut time_buffer2 = Vec::new();
 
         // tracks frontiers received from batches, for sanity.
         let mut lower_sanity = vec![<G::Timestamp as Lattice>::min()];
@@ -240,10 +233,10 @@ where
                 // Prepare an output buffer and builder for each capability. 
                 // It would be better if all updates went into one batch, but timely dataflow prevents this as 
                 // long as there is only one capability for each message.
-                let mut buffers = Vec::<Vec<(V2, G::Timestamp, R2)>>::new();
+                let mut buffers = Vec::<(G::Timestamp, Vec<(V2, G::Timestamp, R2)>)>::new();
                 let mut builders = Vec::new();
-                for _ in 0 .. capabilities.len() {
-                    buffers.push(Vec::new());
+                for i in 0 .. capabilities.len() {
+                    buffers.push((capabilities[i].time(), Vec::new()));
                     builders.push(<T2::Batch as Batch<K,V2,G::Timestamp,R2>>::Builder::new());
                 }
 
@@ -293,135 +286,57 @@ where
                     interesting_times.sort();
                     interesting_times.dedup();
 
-                    // Determine the `meet` of times, useful in restricting updates to capture.
-                    let mut meet = interesting_times[0].clone(); 
-                    for index in 1 .. interesting_times.len() {
-                        meet = meet.meet(&interesting_times[index]);
-                    }
+                    // let mut interesting_times2 = interesting_times.clone();
+                    // let mut buffers2 = buffers.clone();
 
-                    // clear accumulators (will now repopulate)
-                    yielded_accumulator.clear();
-                    yielded_accumulator.time = interesting_times[0].clone();
+                    // do the per-key computation.
+                    temporary.clear();
+                    thinker2.compute(
+                        &key, 
+                        &mut source_cursor, 
+                        &mut output_cursor, 
+                        &mut interesting_times, 
+                        &logic, 
+                        &upper_limit[..], 
+                        &mut buffers[..], 
+                        &mut temporary,
+                    );
 
-                    // Accumulate into `input_stage` and populate `input_edits`.
-                    input_accumulator.clear();
-                    input_accumulator.time = interesting_times[0].clone();
-                    source_cursor.seek_key(&key);
-                    if source_cursor.key_valid() && source_cursor.key() == &key {
-                        while source_cursor.val_valid() {
-                            let val: V = source_cursor.val().clone();
-                            let mut sum = R::zero();
 
-                            source_cursor.map_times(|t,d| {
-                                if t.le(&input_accumulator.time) { 
-                                    sum = sum + d; 
-                                }
-                                if !t.le(&meet) {
-                                    time_buffer1.push((t.join(&meet), d));
-                                }
-                            });
-                            consolidate(&mut time_buffer1);
-                            input_accumulator.edits.extend(time_buffer1.drain(..).map(|(t,d)| (val.clone(), t, d)));
-                            if !sum.is_zero() {
-                                input_accumulator.accum.push((val, sum));
-                            }
-                            source_cursor.step_val();
-                        }
-                    }
-                    input_accumulator.shackle();
+                    // source_cursor.rewind_vals();
+                    // output_cursor.rewind_vals();
+                    // // do the per-key computation.
+                    // let mut temp2 = Vec::new();
+                    // thinker1.compute(
+                    //     &key, 
+                    //     &mut source_cursor, 
+                    //     &mut output_cursor, 
+                    //     &mut interesting_times2, 
+                    //     &logic, 
+                    //     &upper_limit[..], 
+                    //     &mut buffers2[..], 
+                    //     &mut temp2,
+                    // );
 
-                    // Accumulate into `output_stage` and populate `output_edits`. 
-                    output_accumulator.clear();
-                    output_accumulator.time = interesting_times[0].clone();
-                    output_cursor.seek_key(&key);
-                    if output_cursor.key_valid() && output_cursor.key() == &key {
-                        while output_cursor.val_valid() {
-                            let val: V2 = output_cursor.val().clone();
-                            let mut sum = R2::zero();
-                            output_cursor.map_times(|t,d| {
-                                if t.le(&output_accumulator.time) {
-                                    sum = sum + d;
-                                }
-                                if !t.le(&meet) {
-                                    time_buffer2.push((t.join(&meet), d));
-                                }
-                            });
-                            consolidate(&mut time_buffer2);
-                            output_accumulator.edits.extend(time_buffer2.drain(..).map(|(t,d)| (val.clone(), t, d)));
-                            if !sum.is_zero() {
-                                output_accumulator.accum.push((val, sum));
-                            }
-                            output_cursor.step_val();
-                        }
-                    }
-                    output_accumulator.shackle();
+                    // assert_eq!(buffers, buffers2);
+                    // assert_eq!(temporary, temp2);
 
-                    // Determine all interesting times: those that are the join of at least one time
-                    // from `interesting_times` and any times from `input_edits`.
-                    interestinator.close_interesting_times(&input_accumulator.edits[..], &mut interesting_times);
+                    for time in temporary.drain(..) { interesting.push((key.clone(), time)); }
 
-                    // println!("interesting_times: {:?}", interesting_times.len());
-
-                    // each interesting time must be considered!
-                    for this_time in interesting_times.drain(..) {
-
-                        // not all times are ready to be finalized. stash them with the key.
-                        if upper_limit.iter().any(|t| t.le(&this_time)) {
-                            interesting.push((key.clone(), this_time));
-                        }
-                        else {
-
-                            // 1. update `input_stage` and `output_stage` to `this_time`.
-                            input_accumulator.update_to(this_time.clone());
-                            output_accumulator.update_to(this_time.clone());
-                            yielded_accumulator.update_to(this_time.clone());
-
-                            // 2. apply user logic (only if non-empty input).
-                            output_logic.clear();
-                            if input_accumulator.accum.len() > 0 {
-                                logic(&key, &input_accumulator.accum[..], &mut output_logic);
-                            }
-
-                            // println!("key: {:?}, input: {:?}, ouput: {:?} @ {:?}", 
-                            //          key, &input_accumulator.accum[..], output_logic, this_time);
-
-                            // 3. subtract existing output differences.
-                            for &(ref val, diff) in &output_accumulator.accum[..] {
-                                output_logic.push((val.clone(), -diff));
-                            }
-                            // incorporate uncommitted output updates.
-                            for &(ref val, diff) in &yielded_accumulator.accum {
-                                output_logic.push((val.clone(), -diff));
-                            }
-                            consolidate(&mut output_logic);
-
-                            // 4. stashed produced updates in capability-indexed buffers, and `yielded_accumulator`.
-                            let idx = capabilities.iter().rev().position(|cap| cap.le(&this_time));
-                            debug_assert!(idx.is_some());
-                            let idx = idx.unwrap();
-                            debug_assert_eq!(capabilities.len(), buffers.len());
-                            debug_assert!(capabilities.len() - idx - 1 < buffers.len());
-                            for (val, diff) in output_logic.drain(..) {
-                                yielded_accumulator.push_edit((val.clone(), this_time.clone(), diff));
-                                buffers[capabilities.len() - idx - 1].push((val, this_time.clone(), diff));
-                            }
-                        }
-                    }
-        
                     // move all updates for this key into corresponding builders.
                     for index in 0 .. buffers.len() {
-                        buffers[index].sort();
-                        for (val, time, diff) in buffers[index].drain(..) {
+                        buffers[index].1.sort();
+                        for (val, time, diff) in buffers[index].1.drain(..) {
                             builders[index].push((key.clone(), val, time, diff));
                         }
                     }
                 }
 
-                // seal up builders, send along with capabilities, downgrade capabilities to track `interesting` pairs.
+            // seal up builders, send along with capabilities, downgrade capabilities to track `interesting` pairs.
 
                 for (index, builder) in builders.drain(..).enumerate() {
 
-                    // this builder captured times not greater or equal to any later capability, nor any element of upper.
+            // this builder captured times not greater or equal to any later capability, nor any element of upper.
                     let mut local_upper = upper_limit.clone();
                     for capability in &capabilities[index + 1 ..] {
                         local_upper.retain(|t| !capability.lt(t));
@@ -448,10 +363,6 @@ where
                         frontier.push(time.clone());
                     }
                 }
-
-                // for time in &frontier {
-                //     debug_assert!(upper_limit.iter().any(|t| t.le(time)));
-                // }
 
                 // update capabilities (readable?)
                 let mut new_capabilities = Vec::new();
@@ -499,7 +410,7 @@ fn segment<T, F: Fn(&T)->bool>(source: &mut Vec<T>, dest1: &mut Vec<T>, dest2: &
     }
 }
 
-// #[inline(never)]
+#[inline(never)]
 fn consolidate<T: Ord, R: Ring>(list: &mut Vec<(T, R)>) {
     list.sort_by(|x,y| x.0.cmp(&y.0));
     for index in 1 .. list.len() {
@@ -511,17 +422,716 @@ fn consolidate<T: Ord, R: Ring>(list: &mut Vec<(T, R)>) {
     list.retain(|x| !x.1.is_zero());
 }
 
-// // #[inline(never)]
-// fn consolidate2<D: Ord, T: Ord, R: Ring>(list: &mut Vec<(D, T, R)>) {
-//     list.sort_by(|x,y| (&y.0, &y.1).cmp(&(&x.0, &x.1)));
-//     for index in 1 .. list.len() {
-//         if list[index].0 == list[index-1].0 && list[index].1 == list[index-1].1 {
-//             list[index].2 = list[index].2 + list[index-1].2;
-//             list[index-1].2 = R::zero();
-//         }
-//     }
-//     list.retain(|x| !x.2.is_zero());
-// }
+/// Scans `vec[off..]` and consolidates differences of adjacent equivalent elements.
+pub fn consolidate_from<T: Ord+Clone, R: Ring>(vec: &mut Vec<(T, R)>, off: usize) {
+    vec[off..].sort();
+    for index in (off + 1) .. vec.len() {
+        if vec[index].0 == vec[index - 1].0 {
+            vec[index].1 = vec[index].1 + vec[index - 1].1;
+            vec[index - 1].1 = R::zero();
+        }
+    }
+    let mut cursor = off;
+    for index in off .. vec.len() {
+        if !vec[index].1.is_zero() {
+            vec[cursor] = vec[index].clone();
+            cursor += 1;
+        }
+    }
+    vec.truncate(cursor);
+}
+
+trait PerKeyCompute<V1, V2, T, R1, R2> 
+where
+    V1: Ord+Clone,
+    V2: Ord+Clone,
+    T: Lattice+Ord+Clone,
+    R1: Ring,
+    R2: Ring,
+{
+    fn new() -> Self;
+    fn compute<K, C1, C2, L>(
+        &mut self,
+        key: &K, 
+        input: &mut C1, 
+        output: &mut C2, 
+        times: &mut Vec<T>, 
+        logic: &L, 
+        upper_limit: &[T],
+        outputs: &mut [(T, Vec<(V2, T, R2)>)],
+        new_interesting: &mut Vec<T>) 
+    where 
+        K: Eq+Clone+Debug,
+        C1: Cursor<K, V1, T, R1>, 
+        C2: Cursor<K, V2, T, R2>, 
+        L: Fn(&K, &[(V1, R1)], &mut Vec<(V2, R2)>);
+}
+
+/// The `HistoryReplayer` is a compute strategy based on moving through existing inputs, interesting times, etc in 
+/// time order, maintaining consolidated representations of updates with respect to future interesting times.
+struct HistoryReplayer<V1, V2, T, R1, R2> 
+where
+    V1: Ord+Clone,
+    V2: Ord+Clone,
+    T: Lattice+Ord+Clone,
+    R1: Ring,
+    R2: Ring,
+{
+    input_history: CollectionHistory<V1, T, R1>,
+    input_actions: Vec<(T, usize)>,
+
+    output_history: CollectionHistory<V2, T, R2>,
+    output_actions: Vec<(T, usize)>,
+
+    input_buffer: Vec<(V1, R1)>,
+    output_buffer: Vec<(V2, R2)>,
+
+    output_produced: Vec<((V2, T), R2)>,
+
+    known_times: Vec<T>,
+    synth_times: Vec<T>,
+
+    meets: Vec<T>,
+
+    times_current: Vec<T>,
+
+    times_temp: Vec<T>,
+}
+
+impl<V1, V2, T, R1, R2> PerKeyCompute<V1, V2, T, R1, R2> for HistoryReplayer<V1, V2, T, R1, R2> 
+where
+    V1: Ord+Clone+Debug,
+    V2: Ord+Clone+Debug,
+    T: Lattice+Ord+Clone+Debug,
+    R1: Ring+Debug,
+    R2: Ring+Debug,
+{
+    fn new() -> Self {
+        HistoryReplayer { 
+            input_history: CollectionHistory::new(),
+            input_actions: Vec::new(),
+
+            output_history: CollectionHistory::new(),
+            output_actions: Vec::new(),
+
+            input_buffer: Vec::new(),
+            output_buffer: Vec::new(),
+
+            output_produced: Vec::new(),
+
+            known_times: Vec::new(),
+            synth_times: Vec::new(),
+
+            meets: Vec::new(),
+
+            times_current: Vec::new(),
+            times_temp: Vec::new(),
+        }
+    }
+    #[inline(never)]
+    fn compute<K, C1, C2, L>(
+        &mut self,
+        key: &K, 
+        source_cursor: &mut C1, 
+        output_cursor: &mut C2, 
+        times: &mut Vec<T>, 
+        logic: &L, 
+        upper_limit: &[T],
+        outputs: &mut [(T, Vec<(V2, T, R2)>)],
+        new_interesting: &mut Vec<T>) 
+    where 
+        K: Eq+Clone+Debug,
+        C1: Cursor<K, V1, T, R1>, 
+        C2: Cursor<K, V2, T, R2>, 
+        L: Fn(&K, &[(V1, R1)], &mut Vec<(V2, R2)>) 
+    {
+        // we use meets[0], and this should be true anyhow (otherwise, don't call).
+        assert!(times.len() > 0);
+
+        // experimenting with meet vs frontiers for advancing (good for distributive lattices).
+        let mut meet = T::max();
+        for time in times.iter() {
+            meet = meet.meet(time);
+        }
+
+        self.known_times.clear();
+
+
+        // The fast-forwarding we are about to do with input and output can result in very weird looking
+        // data. In particular, we can have "old" updates in the future of "new" updates, and even beyond
+        // the frontier of work we can do. We should not take their times as indications of anything other
+        // than whether they should be included in accumulations.
+        //
+        // We extract input and output updates into flat value-indexed arrays, each range of which we sort
+        // by time so that the history for a value is always a prefix of its range. As we proceed through 
+        // time we extend the valid ranges.
+
+        {   // extract input updates, advanced by `meet`.
+
+            self.input_history.clear();
+            self.input_actions.clear();
+
+            source_cursor.seek_key(&key);
+            if source_cursor.key_valid() && source_cursor.key() == key {
+                while source_cursor.val_valid() {
+                    let start = self.input_history.times.len();
+                    source_cursor.map_times(|t, d| self.input_history.times.push((t.join(&meet), d)));
+                    self.input_history.seal_from(source_cursor.val().clone(), start);
+                    source_cursor.step_val();
+                }
+            }
+
+            self.input_actions.reserve(self.input_history.times.len());
+            for (index, history) in self.input_history.values.iter().enumerate() {
+                for offset in history.lower .. history.upper {
+                    self.input_actions.push((self.input_history.times[offset].0.clone(), index));
+                }
+            }
+            // TODO: this could have been a merge; helpful if few values. (perhaps it is with mergesort!)
+            self.input_actions.sort_by(|x,y| x.0.cmp(&y.0));
+        }
+        
+        {   // extract output updates, advanced by `meet`.
+
+            self.output_history.clear();
+            self.output_actions.clear();
+
+            output_cursor.seek_key(&key);
+            if output_cursor.key_valid() && output_cursor.key() == key {
+                while output_cursor.val_valid() {
+                    let start = self.output_history.times.len();
+                    output_cursor.map_times(|t, d| self.output_history.times.push((t.join(&meet), d)));
+                    self.output_history.seal_from(output_cursor.val().clone(), start);
+                    output_cursor.step_val();
+                }
+            }
+
+            self.output_actions.reserve(self.output_history.times.len());
+            for (index, history) in self.output_history.values.iter().enumerate() {
+                for offset in history.lower .. history.upper {
+                    self.output_actions.push((self.output_history.times[offset].0.clone(), index));
+                }
+            }
+            // TODO: this could have been a merge; helpful if few values. (perhaps it is with mergesort!)
+            self.output_actions.sort();        
+        }
+
+        // TODO: We should be able to thin out any updates at times that, advanced, are greater than some
+        //       element of `upper_limit`, as we will never incorporate that update. We should take care 
+        //       to notice these times, if we need to report them as interesting times, but once we have 
+        //       done that we can ditch the updates.
+
+        // TODO: We should be able to restrict our attention down to just those times that are the joins
+        //       of times evident in the input and output. This could be useful in cases like `distinct`,
+        //       where the input updates collapse down to relatively fewer distinct moments.
+
+        self.synth_times.clear();
+        self.times_current.clear();
+        self.output_produced.clear();
+
+        {   // populate `self.known_times` with times from the input, output, and the `times` argument.
+            
+            // TODO: This could be a merge (perhaps it is, if we use mergesort).
+            for &(ref time, _) in &self.input_actions { self.known_times.push(time.clone()); }
+            for &(ref time, _) in &self.output_actions { self.known_times.push(time.clone()); }
+            for time in times.iter() { self.known_times.push(time.clone()); }
+
+            sort_dedup(&mut self.known_times);
+        }
+
+        {   // populate `self.meets` with the meets of suffixes of `self.known_times`.
+
+            self.meets.clear();
+            self.meets.reserve(self.known_times.len());
+            self.meets.extend(self.known_times.iter().cloned());
+            for i in (0 .. self.meets.len() - 1).rev() {
+                self.meets[i] = self.meets[i].meet(&self.meets[i+1]);
+            }
+        }
+
+        // // TODO: We could discard these sorts of updates, if we think they are a problem. 
+        // self.input_updates.retain(|&((ref time, _), _)| !upper_limit.iter().any(|t| t.le(time)));
+        // self.output_updates.retain(|&((ref time, _), _)| !upper_limit.iter().any(|t| t.le(time)));
+
+        // we track out position in each of our lists of actions using slices; 
+        // as we pull work from the front, we advance the slice. we could have
+        // used drain iterators, but we want to peek at the next element and 
+        // this seemed like the simplest way to do that.
+        let mut input_slice = &self.input_actions[..];
+        let mut output_slice = &self.output_actions[..];
+        let mut times_slice = &times[..];
+
+        let mut known_slice = &self.known_times[..];
+        let mut meets_slice = &self.meets[..];
+
+        while known_slice.len() > 0 || self.synth_times.len() > 0 {
+
+            // determine the next time to process.
+            let mut next_time = T::max();
+            if known_slice.len() > 0 && next_time.cmp(&known_slice[0]) == Ordering::Greater {
+                next_time = known_slice[0].clone();
+            }
+            if self.synth_times.len() > 0 && next_time.cmp(&self.synth_times[0]) == Ordering::Greater {
+                next_time = self.synth_times[0].clone();
+            }
+
+            // advance `known_slice` and `synth_times` as appropriate.
+            while known_slice.len() > 0 && known_slice[0] == next_time {
+                known_slice = &known_slice[1..];
+                meets_slice = &meets_slice[1..];
+            }
+            while self.synth_times.len() > 0 && self.synth_times[0] == next_time {
+                self.synth_times.remove(0); // <-- this should really be a min-heap.
+            }
+
+            // advance valid ranges of inputs and outputs for this time.
+            while input_slice.len() > 0 && input_slice[0].0 == next_time {
+                let value_index = input_slice[0].1;
+                self.input_history.step(value_index);
+                input_slice = &input_slice[1..];
+            }
+            while output_slice.len() > 0 && output_slice[0].0 == next_time {
+                let value_index = output_slice[0].1;
+                self.output_history.step(value_index);
+                output_slice = &output_slice[1..];
+            }
+            while times_slice.len() > 0 && times_slice[0] == next_time {
+                times_slice = &times_slice[1..];
+            }
+
+            // we should only process times that are not in the future.
+            if !upper_limit.iter().any(|t| t.le(&next_time)) {
+
+                // assemble input collection (`self.input_buffer` cleared just after use).
+                debug_assert!(self.input_buffer.is_empty());
+                self.input_history.insert(&next_time, &meet, &mut self.input_buffer);
+
+                // apply user logic and see what happens!
+                self.output_buffer.clear();
+                if self.input_buffer.len() > 0 {
+                    logic(key, &self.input_buffer[..], &mut self.output_buffer);
+                    self.input_buffer.clear();
+                }
+        
+                // spill output differences into `self.output_buffer`. 
+                // this could probably be done much better, but we currently produce new output
+                // updates that we cannot (easily) pack into `self.output_history`. so for now we
+                // just have a big pile of output updates and hope that it is painful enough to fix.
+
+                // subtracts pre-existing output updates maintained in `self.output_history`.
+                self.output_history.remove(&next_time, &meet, &mut self.output_buffer);
+                // subtracts newly formed output updates maintained in `self.output_produced`.
+                for &((ref value, ref time), diff) in self.output_produced.iter() {
+                    if time.le(&next_time) {
+                        self.output_buffer.push((value.clone(), -diff));
+                    }
+                }
+
+                // we can't rely on user code to do this (plus it's presently all a mess anyhow).
+                consolidate(&mut self.output_buffer);
+
+                // stash produced updates in capability-indexed buffers, and `output_updates`.
+                if self.output_buffer.len() > 0 {
+
+                    let idx = outputs.iter().rev().position(|&(ref time, _)| time.le(&next_time));
+                    if !idx.is_some() {
+                        println!("PANIC: failed to find capability for {:?} among:", next_time);
+                        for output in outputs.iter() {
+                            println!("  {:?}", output.0);
+                        }
+                        panic!();
+                    }
+                    let idx = outputs.len() - idx.unwrap() - 1;
+                    for (val, diff) in self.output_buffer.drain(..) {
+                        self.output_produced.push(((val.clone(), next_time.clone()), diff));
+                        outputs[idx].1.push((val, next_time.clone(), diff));
+                    }
+
+                    // consolidate `self.output_produced`.
+                    for entry in &mut self.output_produced {
+                        (entry.0).1 = (entry.0).1.join(&meet);
+                    }
+                    consolidate(&mut self.output_produced);
+
+                }
+            }
+            else {  
+                // otherwise we delay the time for the future (and warn about it)
+                new_interesting.push(next_time.clone());
+            }
+
+            // determine synthetic interesting times!
+            // could just join `next_time` with all times in `input_updates` and `output_updates`.
+            // could also just retire to some beach and drink a lot. that is not why we are here!
+
+            for time in &self.times_current {
+                let join = next_time.join(time);
+                if join != next_time {
+                    self.synth_times.push(join.clone()); 
+                }
+            }
+
+            self.times_current.push(next_time);
+
+            // update our view of the meet of remaining times. 
+            // NOTE: this does not advance collections, which can be done value-by-value as appropriate.
+            if meets_slice.len() > 0 || self.synth_times.len() > 0 {
+                meet = T::max();
+                if meets_slice.len() > 0 { meet = meet.meet(&meets_slice[0]); }
+                for time in &self.synth_times { meet = meet.meet(time); }
+
+                for time in &mut self.times_current {
+                    *time = time.join(&meet);
+                }
+                sort_dedup(&mut self.times_current);
+            }
+
+            // again, this should be a min-heap.
+            sort_dedup(&mut self.synth_times);
+        }
+
+        // sort_dedup(new_interesting);
+
+        // new_interesting is populated only from distinct times we considered, in order.
+        for index in 1 .. new_interesting.len() {
+            debug_assert!(new_interesting[index-1].cmp(&new_interesting[index]) == Ordering::Less);
+        }
+    }
+}
+
+// tracks 
+struct ValueHistory<V> {
+    value: V,
+    lower: usize,
+    clean: usize,
+    valid: usize,
+    upper: usize,
+}
+
+struct CollectionHistory<V: Clone, T: Lattice+Ord+Clone, R: Ring> {
+    pub values: Vec<ValueHistory<V>>,
+    pub times: Vec<(T, R)>,
+}
+
+impl<V: Clone, T: Lattice+Ord+Clone+Debug, R: Ring> CollectionHistory<V, T, R> {
+    fn new() -> Self { 
+        CollectionHistory {
+            values: Vec::new(),
+            times: Vec::new(),
+        }
+    }
+    fn clear(&mut self) {
+        self.values.clear();
+        self.times.clear();
+    }
+    /// Advances the indexed value by one, with the ability to compact times by `meet`.
+    fn step(&mut self, value_index: usize) {
+        // we should not have run out of updates to incorporate.
+        debug_assert!(self.values[value_index].valid < self.values[value_index].upper);        
+        self.values[value_index].valid += 1;
+    }
+
+    #[inline(never)]
+    fn collapse(&mut self, value_index: usize, meet: &T) {
+
+        let lower = self.values[value_index].lower;
+        let valid = self.values[value_index].valid;
+
+        for index in lower .. valid {
+            self.times[index].0 = self.times[index].0.join(meet);
+        }
+
+        // consolidating updates with equal times (post-join).
+        self.times[lower .. valid].sort_by(|x,y| x.0.cmp(&y.0));
+
+        // only need to collapse if there are at least two updates.
+        if lower < valid - 1 {
+
+            // now to collapse updates *forward*, to end at `valid`.
+            let mut cursor = valid - 1;
+            for index in (lower .. valid - 1).rev() {
+                if self.times[index].0 == self.times[cursor].0 {
+                    self.times[cursor].1 = self.times[cursor].1 + self.times[index].1;
+                    self.times[index].1 = R::zero();
+                }
+                else {
+                    if !self.times[cursor].1.is_zero() {
+                        cursor -= 1;
+                    }
+                    self.times.swap(cursor, index);
+                }
+            }
+            // if the final element accumulated to zero, advance `cursor`.
+            if self.times[cursor].1.is_zero() {
+                cursor += 1;
+            }
+            
+            // should be a range of zeros, .. 
+            debug_assert!(lower <= cursor);
+            for index in lower .. cursor {
+                debug_assert!(self.times[index].1.is_zero());
+            }
+            // .. followed by a range of non-zeros.
+            debug_assert!(cursor <= valid);
+            for index in cursor .. valid {
+                debug_assert!(!self.times[index].1.is_zero());
+            }
+
+            self.values[value_index].lower = cursor;
+            self.values[value_index].clean = valid;
+        }
+    }
+
+    fn seal_from(&mut self, value: V, start: usize) {
+
+        // collapse down the updates
+        consolidate_from(&mut self.times, start);
+
+        // if non-empty, push range info for value.
+        if self.times.len() > start {
+            self.values.push(ValueHistory {
+                value: value,
+                lower: start,
+                clean: start,
+                valid: start,
+                upper: self.times.len(),
+            });
+        }
+    }
+
+    #[inline(always)]
+    fn insert(&mut self, time: &T, meet: &T, destination: &mut Vec<(V, R)>) {
+
+        for value_index in 0 .. self.values.len() {
+
+            let lower = self.values[value_index].lower;
+            let clean = self.values[value_index].clean;
+            let valid = self.values[value_index].valid;
+
+            // take the time to collapse if there are changes. 
+            // this is not the only reason to collapse, and we may want to be more or less aggressive
+            if clean < valid {
+                self.collapse(value_index, meet);
+            }
+
+            let mut sum = R::zero();
+            for index in lower .. valid {
+                if self.times[index].0.le(time) {
+                    sum = sum + self.times[index].1;
+                }
+            }
+            if !sum.is_zero() {
+                destination.push((self.values[value_index].value.clone(), sum));
+            }
+        }
+    }
+
+    #[inline(always)]
+    fn remove(&mut self, time: &T, meet: &T, destination: &mut Vec<(V, R)>) {
+
+        for value_index in 0 .. self.values.len() {
+
+            let lower = self.values[value_index].lower;
+            let clean = self.values[value_index].clean;
+            let valid = self.values[value_index].valid;
+
+            // take the time to collapse if there are changes. 
+            // this is not the only reason to collapse, and we may want to be more or less aggressive
+            if clean < valid {
+                self.collapse(value_index, meet);
+            }
+
+            let mut sum = R::zero();
+            for index in lower .. valid {
+                if self.times[index].0.le(time) {
+                    sum = sum - self.times[index].1;
+                }
+            }
+            if !sum.is_zero() {
+                destination.push((self.values[value_index].value.clone(), sum));
+            }
+        }
+    }
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+struct InterestAccumulator<V1, V2, T, R1, R2>
+where 
+    V1: Ord+Clone,
+    V2: Ord+Clone,
+    T: Lattice+Ord+Clone,
+    R1: Ring,
+    R2: Ring,
+{
+    interestinator: Interestinator<T>,
+    input_accumulator: Accumulator<V1, T, R1>,
+    output_accumulator: Accumulator<V2, T, R2>,
+    yielded_accumulator: Accumulator<V2, T, R2>,
+    time_buffer1: Vec<(T, R1)>,
+    time_buffer2: Vec<(T, R2)>,
+    output_logic: Vec<(V2, R2)>,
+}
+
+impl<V1, V2, T, R1, R2> PerKeyCompute<V1, V2, T, R1, R2> for InterestAccumulator<V1, V2, T, R1, R2> 
+where 
+    V1: Ord+Clone,
+    V2: Ord+Clone,
+    T: Lattice+Ord+Clone+Debug,
+    R1: Ring,
+    R2: Ring,
+{
+    fn new() -> Self {
+        InterestAccumulator {
+            interestinator: Interestinator::new(),
+            input_accumulator: Accumulator::new(),
+            output_accumulator: Accumulator::new(),
+            yielded_accumulator: Accumulator::new(),
+            time_buffer1: Vec::new(),
+            time_buffer2: Vec::new(),
+            output_logic: Vec::new(),
+        }
+    }
+    fn compute<K, C1, C2, L>(
+        &mut self,
+        key: &K, 
+        source_cursor: &mut C1, 
+        output_cursor: &mut C2, 
+        interesting_times: &mut Vec<T>, 
+        logic: &L,
+        upper_limit: &[T],
+        outputs: &mut [(T, Vec<(V2, T, R2)>)],
+        new_interesting: &mut Vec<T>)
+    where 
+        K: Eq+Clone,
+        C1: Cursor<K, V1, T, R1>, 
+        C2: Cursor<K, V2, T, R2>, 
+        L: Fn(&K, &[(V1, R1)], &mut Vec<(V2, R2)>)
+{
+        // Determine the `meet` of times, useful in restricting updates to capture.
+        let mut meet = interesting_times[0].clone(); 
+        for index in 1 .. interesting_times.len() {
+            meet = meet.meet(&interesting_times[index]);
+        }
+
+        // clear accumulators (will now repopulate)
+        self.yielded_accumulator.clear();
+        self.yielded_accumulator.time = interesting_times[0].clone();
+
+        // Accumulate into `input_stage` and populate `input_edits`.
+        self.input_accumulator.clear();
+        self.input_accumulator.time = interesting_times[0].clone();
+        source_cursor.seek_key(&key);
+        if source_cursor.key_valid() && source_cursor.key() == key {
+            while source_cursor.val_valid() {
+                let val: V1 = source_cursor.val().clone();
+                let mut sum = R1::zero();
+
+                source_cursor.map_times(|t,d| {
+                    if t.le(&self.input_accumulator.time) { 
+                        sum = sum + d; 
+                    }
+                    if !t.le(&meet) {
+                        self.time_buffer1.push((t.join(&meet), d));
+                    }
+                });
+                consolidate(&mut self.time_buffer1);
+                self.input_accumulator.edits.extend(self.time_buffer1.drain(..).map(|(t,d)| (val.clone(), t, d)));
+                if !sum.is_zero() {
+                    self.input_accumulator.accum.push((val, sum));
+                }
+                source_cursor.step_val();
+            }
+        }
+        self.input_accumulator.shackle();
+
+        // Accumulate into `output_stage` and populate `output_edits`. 
+        self.output_accumulator.clear();
+        self.output_accumulator.time = interesting_times[0].clone();
+        output_cursor.seek_key(&key);
+        if output_cursor.key_valid() && output_cursor.key() == key {
+            while output_cursor.val_valid() {
+                let val: V2 = output_cursor.val().clone();
+                let mut sum = R2::zero();
+                output_cursor.map_times(|t,d| {
+                    if t.le(&self.output_accumulator.time) {
+                        sum = sum + d;
+                    }
+                    if !t.le(&meet) {
+                        self.time_buffer2.push((t.join(&meet), d));
+                    }
+                });
+                consolidate(&mut self.time_buffer2);
+                self.output_accumulator.edits.extend(self.time_buffer2.drain(..).map(|(t,d)| (val.clone(), t, d)));
+                if !sum.is_zero() {
+                    self.output_accumulator.accum.push((val, sum));
+                }
+                output_cursor.step_val();
+            }
+        }
+        self.output_accumulator.shackle();
+
+        self.interestinator.close_interesting_times(&self.input_accumulator.edits[..], interesting_times);
+
+        // each interesting time must be considered!
+        for this_time in interesting_times.drain(..) {
+
+            // not all times are ready to be finalized. stash them with the key.
+            if upper_limit.iter().any(|t| t.le(&this_time)) {
+                new_interesting.push(this_time);
+            }
+            else {
+
+                // 1. update `input_stage` and `output_stage` to `this_time`.
+                self.input_accumulator.update_to(this_time.clone());
+                self.output_accumulator.update_to(this_time.clone());
+                self.yielded_accumulator.update_to(this_time.clone());
+
+                // 2. apply user logic (only if non-empty input).
+                self.output_logic.clear();
+                if self.input_accumulator.accum.len() > 0 {
+                    logic(&key, &self.input_accumulator.accum[..], &mut self.output_logic);
+                }
+
+                // println!("key: {:?}, input: {:?}, ouput: {:?} @ {:?}", 
+                //          key, &input_accumulator.accum[..], output_logic, this_time);
+
+                // 3. subtract existing output differences.
+                for &(ref val, diff) in &self.output_accumulator.accum[..] {
+                    self.output_logic.push((val.clone(), -diff));
+                }
+                // incorporate uncommitted output updates.
+                for &(ref val, diff) in &self.yielded_accumulator.accum {
+                    self.output_logic.push((val.clone(), -diff));
+                }
+                consolidate(&mut self.output_logic);
+
+                // 4. stashed produced updates in capability-indexed buffers, and `yielded_accumulator`.
+                let idx = outputs.iter().rev().position(|&(ref time, _)| time.le(&this_time));
+                let idx = idx.unwrap();
+                let idx = outputs.len() - idx - 1;
+                for (val, diff) in self.output_logic.drain(..) {
+                    self.yielded_accumulator.push_edit((val.clone(), this_time.clone(), diff));
+                    outputs[idx].1.push((val, this_time.clone(), diff));
+                }
+            }
+        }
+    }
+}
 
 /// Allocated state and temporary buffers for closing interesting time under join.
 #[derive(Default)]
@@ -540,6 +1150,18 @@ struct Interestinator<T: Ord+Lattice+Clone> {
 }
 
 impl<T: Ord+Lattice+Clone+::std::fmt::Debug> Interestinator<T> {
+    fn new() -> Self {
+        Interestinator {
+            total: Vec::new(),
+            old_accum: Vec::new(),
+            new_accum: Vec::new(),
+            entrance: Vec::new(),
+            frontier: Vec::new(),
+            old_temp: Vec::new(),
+            new_temp: Vec::new(),
+        }
+    }
+
     /// Extends `times` with the join of subsets of `edits` and `times` with at least one element from `times`.
     ///
     /// This method has a somewhat non-standard implementation in the aim of being "more linear", which makes it

--- a/src/ring.rs
+++ b/src/ring.rs
@@ -14,8 +14,8 @@ pub trait Ring : Add<Self, Output=Self> + Sub<Self, Output=Self> + Neg<Output=Se
 }
 
 impl Ring for isize { 
-	fn is_zero(&self) -> bool { *self == 0 }
-	fn zero() -> Self { 0 }
+	#[inline(always)] fn is_zero(&self) -> bool { *self == 0 }
+	#[inline(always)] fn zero() -> Self { 0 }
 }
 
 
@@ -28,7 +28,7 @@ pub struct RingPair<R1: Ring, R2: Ring> {
 
 impl<R1: Ring, R2: Ring> RingPair<R1, R2> {
 	/// Creates a new ring pair from two elements.
-	pub fn new(elt1: R1, elt2: R2) -> Self {
+	#[inline(always)] pub fn new(elt1: R1, elt2: R2) -> Self {
 		RingPair {
 			element1: elt1,
 			element2: elt2,
@@ -37,13 +37,13 @@ impl<R1: Ring, R2: Ring> RingPair<R1, R2> {
 }
 
 impl<R1: Ring, R2: Ring> Ring for RingPair<R1, R2> {
-	fn is_zero(&self) -> bool { self.element1.is_zero() && self.element2.is_zero() }
-	fn zero() -> Self { RingPair { element1: R1::zero(), element2: R2::zero() } }
+	#[inline(always)] fn is_zero(&self) -> bool { self.element1.is_zero() && self.element2.is_zero() }
+	#[inline(always)] fn zero() -> Self { RingPair { element1: R1::zero(), element2: R2::zero() } }
 }
 
 impl<R1: Ring, R2: Ring> Add<RingPair<R1, R2>> for RingPair<R1, R2> {
 	type Output = Self;
-	fn add(self, rhs: Self) -> Self {
+	#[inline(always)] fn add(self, rhs: Self) -> Self {
 		RingPair { 
 			element1: self.element1 + rhs.element1, 
 			element2: self.element2 + rhs.element2,
@@ -53,7 +53,7 @@ impl<R1: Ring, R2: Ring> Add<RingPair<R1, R2>> for RingPair<R1, R2> {
 
 impl<R1: Ring, R2: Ring> Sub<RingPair<R1, R2>> for RingPair<R1, R2> {
 	type Output = RingPair<R1, R2>;
-	fn sub(self, rhs: Self) -> Self {
+	#[inline(always)] fn sub(self, rhs: Self) -> Self {
 		RingPair { 
 			element1: self.element1 - rhs.element1, 
 			element2: self.element2 - rhs.element2,
@@ -63,7 +63,7 @@ impl<R1: Ring, R2: Ring> Sub<RingPair<R1, R2>> for RingPair<R1, R2> {
 
 impl<R1: Ring, R2: Ring> Neg for RingPair<R1, R2> {
 	type Output = Self;
-	fn neg(self) -> Self {
+	#[inline(always)] fn neg(self) -> Self {
 		RingPair {
 			element1: -self.element1,
 			element2: -self.element2,
@@ -73,7 +73,7 @@ impl<R1: Ring, R2: Ring> Neg for RingPair<R1, R2> {
 
 impl<R1: Ring, R2: Ring> Mul<RingPair<R1, R2>> for RingPair<R1, R2> {
 	type Output = Self;
-	fn mul(self, rhs: Self) -> Self {
+	#[inline(always)] fn mul(self, rhs: Self) -> Self {
 		RingPair { 
 			element1: self.element1 * rhs.element1, 
 			element2: self.element2 * rhs.element2,

--- a/src/trace/implementations/rhh.rs
+++ b/src/trace/implementations/rhh.rs
@@ -251,6 +251,8 @@ where Key: Clone+Default+HashOrdered, Val: Ord+Clone, Time: Lattice+Ord+Clone+De
 			lower: vec![Time::min()]
 		} 
 	}
+
+	#[inline(always)]
 	fn push(&mut self, (key, val, time, diff): (Key, Val, Time, R)) {
 
 		// each pushed update should be in the future of the current lower bound.

--- a/src/trace/implementations/rhh_k.rs
+++ b/src/trace/implementations/rhh_k.rs
@@ -300,6 +300,7 @@ where Key: Clone+Default+HashOrdered, Time: Lattice+Ord+Clone+Default {
 		} 
 	}
 
+	#[inline(always)]
 	fn push(&mut self, (key, _, time, diff): (Key, (), Time, R)) {
 
 		// each pushed update should be in the future of the current lower bound.

--- a/src/trace/layers/hashed.rs
+++ b/src/trace/layers/hashed.rs
@@ -324,6 +324,7 @@ impl<K: HashOrdered+Clone+Default, L: TupleBuilder> TupleBuilder for HashedBuild
 			vals: L::with_capacity(cap) 
 		} 
 	}
+	#[inline(always)]
 	fn push_tuple(&mut self, (key, val): (K, L::Item)) {
 
 		// we build up self.temp, and rely on self.boundary() to drain self.temp.

--- a/src/trace/layers/ordered.rs
+++ b/src/trace/layers/ordered.rs
@@ -171,6 +171,7 @@ impl<K: Ord+Clone, L: TupleBuilder> TupleBuilder for OrderedBuilder<K, L> {
 			vals: L::with_capacity(cap),
 		}
 	}
+	#[inline(always)]
 	fn push_tuple(&mut self, (key, val): (K, L::Item)) {
 
 		// if first element, prior element finish, or different element, need to push and maybe punctuate.

--- a/src/trace/layers/unordered.rs
+++ b/src/trace/layers/unordered.rs
@@ -59,7 +59,7 @@ impl<K: Clone> TupleBuilder for UnorderedBuilder<K> {
 	type Item = K;
 	fn new() -> Self { UnorderedBuilder { vals: Vec::new() } }
 	fn with_capacity(cap: usize) -> Self { UnorderedBuilder { vals: Vec::with_capacity(cap) } }
-	fn push_tuple(&mut self, tuple: K) { self.vals.push(tuple) }
+	#[inline(always)] fn push_tuple(&mut self, tuple: K) { self.vals.push(tuple) }
 }
 
 /// A cursor for walking through an unordered sequence of values.


### PR DESCRIPTION
This PR introduces a new implementation of `group` that I find more amenable to future optimization. Functionality has been factored out into a trait, and the previous implementation lives on as a second implementation against which we can compare the first.

The main change in this implementation is a integrated approach to navigating times in the evaluation of `group`. Previously the identification of interesting times and the evaluation of the logic was separated, for algorithmic concerns, which required pessimistic assumptions about which times might be interesting. The interesting times now evolve with the computation, which puts us in a better position to notice when there are opportunities for optimization.

Example optimizations that seem promising, and which seem to work in prototype are:

1. Lazily extract histories of values from the input cursor. The maintained histories are organized by value behind the input cursor, and in the local cached and accumulated view. In fact, we don't even need to collect the values if the operator (e.g. `top_k`) doesn't need to look at them.

2. When evaluating user logic, notice which times are considered and discarded, and use these times as the basis of future warnings. This has the potential to help a great deal with operators like `top_k` which look only at the first `k` values in a collection, and which may not require re-evaluation at future times despite changes in irrelevant values.

3. Collapse values for monotonic operators. Operators like `top_k` do not require precise information about a collections history to know how to respond to a change of value `v`, they only need to know the existing counts of elements less or equal to `v`. Such values can be collapsed down to the value `v` which can substantially reduce moments of variation, result in less re-evaluation.

4. Splice parts of output trace history for the same parts of input trace history. Operators like `top_k` and `distinct`, perhaps with important monotonicity assumptions somewhere, can have some of their input summarized by some of their outputs. For example, in a monotonic `top_k` operator, one doesn't need to see all the variation in the input, but can instead see only the variation in the output. In essence, the output is a reduced summary of the relevant parts of the input, sufficient to determine changes in the output for "later" moments or values.

These optimizations seem smart, but it isn't clear to what extent they belong in a general `group` implementation. However, this PR puts them all in the same conceptual framework, which should let us reason a bit better about them.