### PR TITLE
Group v3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,3 @@
-
 [package]
 
 name = "differential-dataflow"

--- a/src/operators/group.rs
+++ b/src/operators/group.rs
@@ -46,6 +46,7 @@ use timely_sort::Unsigned;
 use operators::arrange::{Arrange, Arranged, ArrangeByKey, ArrangeBySelf, BatchWrapper, TraceHandle};
 use lattice::Lattice;
 use trace::{Batch, Cursor, Trace, Builder};
+use trace::cursor::cursor_list::CursorList;
 // use trace::implementations::hash::HashValSpine as DefaultValTrace;
 // use trace::implementations::hash::HashKeySpine as DefaultKeyTrace;
 use trace::implementations::ord::OrdValSpine as DefaultValTrace;
@@ -156,8 +157,8 @@ where
         let mut output_trace = TraceHandle::new(empty, &[G::Timestamp::min()], &[G::Timestamp::min()]);
         let result_trace = output_trace.clone();
 
-        let mut thinker1 = interest_accumulator::InterestAccumulator::<V, V2, G::Timestamp, R, R2>::new();
-        let mut thinker2 = history_replay::HistoryReplayer::<V, V2, G::Timestamp, R, R2>::new();
+        // let mut thinker1 = history_replay_prior::HistoryReplayer::<V, V2, G::Timestamp, R, R2>::new();
+        let mut thinker = history_replay::HistoryReplayer::<V, V2, G::Timestamp, R, R2>::new();
         let mut temporary = Vec::<G::Timestamp>::new();
 
         // Our implementation maintains a list of outstanding `(key, time)` synthetic interesting times, 
@@ -250,14 +251,6 @@ where
             // We can (and should) advance source and output traces if `upper_limit` indicates this is possible.
             if capabilities.iter().any(|c| !upper_limit.iter().any(|t| t.le(&c.time()))) {
 
-                // println!("upper: {:?}", upper_limit);
-
-                // println!("working in group; advancing from, to:");
-                // println!("  capabilities: {:?}", capabilities);
-                // println!("  upper_limit:  {:?}", upper_limit);
-                // println!("  frontier:     {:?}", notificator.frontier(0));
-                // println!("  received:     {:?}", upper_received);
-
                 // `interesting` contains "warnings" about keys and times that may need to be re-considered.
                 // We first extract those times from this list that lie in the interval we will process.
                 sort_dedup(&mut interesting);
@@ -284,13 +277,28 @@ where
                     builders.push(<T2::Batch as Batch<K,V2,G::Timestamp,R2>>::Builder::new());
                 }
 
-                // cursors for navigating input and output traces.
-                let mut source_cursor: T1::Cursor = source_trace.cursor();
-                let mut output_cursor: T2::Cursor = output_trace.cursor();
 
-                let mut compute_counter = 0;
-                let mut output_counter = 0;
-                let timer = ::std::time::Instant::now();
+                // We no longer need to distinguish between the batches we have received and historical batches,
+                // so we should allow the trace to start merging them.
+                //
+                // Note: We know that there will be no further times through `upper_limit`, but we still use the
+                // earlier `upper_received` to avoid antagonizing the trace which may end up with `upper_limit`
+                // cutting through a single (largely empty, at least near `upper_limit`) batch. 
+                source_trace.distinguish_since(&upper_received[..]);
+                output_trace.distinguish_since(&upper_received[..]);
+
+                // cursors for navigating input and output traces.
+                let mut source_cursor: T1::Cursor = source_trace.cursor_through(&upper_received[..]).unwrap();
+                let mut output_cursor: T2::Cursor = output_trace.cursor(); // TODO: this panicked when as above; WHY???
+                let mut batch_cursor = CursorList::new(batch_cursors);
+
+                // // The only purpose of `lower_received` was to allow slicing off old input.
+                // lower_received = upper_received.clone();
+
+                // let timer = ::std::time::Instant::now();
+                // let mut compute_counter = 0;
+                // let mut output_counter = 0;
+                // let mut key_count = 0;
 
                 // We now march through the keys we must work on, drawing from `batch_cursors` and `exposed`.
                 //
@@ -298,18 +306,17 @@ where
                 // indicates whether more data remain. We move throuh `exposed` using `exposed_position`.
                 // There could perhaps be a less provocative variable name.
                 let mut exposed_position = 0;
-                batch_cursors.retain(|cursor| cursor.key_valid());
-                while batch_cursors.len() > 0 || exposed_position < exposed.len() {
+                while batch_cursor.key_valid() || exposed_position < exposed.len() {
 
                     // Determine the next key we will work on; could be synthetic, could be from a batch.
-                    let mut key = None;
-                    if exposed_position < exposed.len() { key = Some(exposed[exposed_position].0.clone()); }
-                    for batch_cursor in &batch_cursors {
-                        if key == None { key = Some(batch_cursor.key().clone()); }
-                        else           { key = key.map(|k| ::std::cmp::min(k, batch_cursor.key().clone())); }
-                    }
-                    debug_assert!(key.is_some());
-                    let key = key.unwrap();
+                    let key1 = if exposed_position < exposed.len() { Some(exposed[exposed_position].0.clone()) } else { None };
+                    let key2 = if batch_cursor.key_valid() { Some(batch_cursor.key().clone()) } else { None };
+                    let key = match (key1, key2) {
+                        (Some(key1), Some(key2)) => ::std::cmp::min(key1, key2),
+                        (Some(key1), None)       => key1,
+                        (None, Some(key2))       => key2,
+                        (None, None)             => unreachable!(),
+                    };
 
                     // `interesting_times` contains those times between `lower_issued` and `upper_limit` 
                     // that we need to re-consider. We now populate it, but perhaps this should be left
@@ -323,36 +330,20 @@ where
                         exposed_position += 1;
                     }
 
-                    // Populate `interesting_times` with times from newly accepted updates.
-                    // TODO: This work is partially redundant with the traversal of input updates, and 
-                    //       in clever implementations (e.g. min/max/topk) we may want to extract these 
-                    //       updates lazily.
-                    for batch_cursor in &mut batch_cursors {
-                        if batch_cursor.key_valid() && batch_cursor.key() == &key {
-                            while batch_cursor.val_valid() {
-                                batch_cursor.map_times(|time,_| interesting_times.push(time.clone()));
-                                batch_cursor.step_val();
-                            }
-                            batch_cursor.step_key();
-                        }
-                    }
-                    batch_cursors.retain(|cursor| cursor.key_valid());
-
                     // tidy up times, removing redundancy.
                     interesting_times.sort();
                     interesting_times.dedup();
 
                     // let mut interesting_times2 = interesting_times.clone();
                     // let mut buffers2 = buffers.clone();
-                    // let mut temp2 = Vec::new();
+                    // let mut temporary2 = temporary.clone();
 
                     // do the per-key computation.
-                    temporary.clear();
-                    let counters = thinker2.compute(
+                    let _counters = thinker.compute(
                         &key, 
                         &mut source_cursor, 
                         &mut output_cursor, 
-                        &mut batch_cursors[..],
+                        &mut batch_cursor,
                         &mut interesting_times, 
                         &logic, 
                         &upper_limit[..], 
@@ -360,42 +351,39 @@ where
                         &mut temporary,
                     );
 
-                    compute_counter += counters.0;
-                    output_counter += counters.1;
-
                     // source_cursor.rewind_vals();
                     // output_cursor.rewind_vals();
+                    // batch_cursor.rewind_vals();
+
                     // // do the per-key computation.
-                    // thinker1.compute(
+                    // let counters = thinker1.compute(
                     //     &key, 
                     //     &mut source_cursor, 
                     //     &mut output_cursor, 
+                    //     &mut batch_cursor,
                     //     &mut interesting_times2, 
                     //     &logic, 
                     //     &upper_limit[..], 
                     //     &mut buffers2[..], 
-                    //     &mut temp2,
+                    //     &mut temporary2,
                     // );
 
+                    if batch_cursor.key_valid() && batch_cursor.key() == &key {
+                        batch_cursor.step_key();
+                    }
+
+                    // key_count += 1;
+                    // compute_counter += counters.0;
+                    // output_counter += counters.1;
+
+                    // assert!(interesting_times2.iter().all(|t| interesting_times.contains(t)));
+
                     // if buffers != buffers2 {
-                    //     println!("PANIC: Unequal outputs!!! (key: {:?}:", key);
-                    //     for index in 0 .. buffers.len() {
-                    //         if buffers[index] != buffers2[index] {
-                    //             for thing in &buffers[index].1 { println!("  buff1[{}]: {:?}", index, thing); }
-                    //             for thing in &buffers2[index].1 { println!("  buff2[{}]: {:?}", index, thing); }
-                    //         }
-                    //     }
+                    //     println!("PANIC: Output mis-match for key: {:?}", key);
+                    //     println!("expected: {:?}", buffers2);
+                    //     println!("actually: {:?}", buffers);
                     // }
-                    // assert_eq!(buffers, buffers2);
-
-                    // // if any of temp2 is not present in temporary, we may miss a time.
-                    // for time in &temp2 {
-                    //     if !temporary.iter().any(|t2| t2.le(&time)) {
-                    //         println!("PANIC: may miss time: {:?} for key: {:?}", time, key);
-                    //     }
-                    // }
-
-                    // assert_eq!(temporary, temp2);
+                    // assert!(buffers == buffers2);
 
                     // Record future warnings about interesting times (and assert they should be "future").
                     for time in temporary.drain(..) { 
@@ -458,11 +446,11 @@ where
                 }
                 capabilities = new_capabilities;
 
-                // let mut ul = upper_limit.clone();
-                // ul.sort();
+    // let mut ul = upper_limit.clone();
+    // ul.sort();
 
-                // let avg_ns = if compute_counter > 0 { (timer.elapsed() / compute_counter as u32).subsec_nanos() } else { 0 };
-                // println!("(key, times) pairs:\t{:?}\t{:?}\tavg {:?}ns\t{:?}", compute_counter, output_counter, avg_ns, ul);
+    // let avg_ns = if compute_counter > 0 { (timer.elapsed() / compute_counter as u32).subsec_nanos() } else { 0 };
+    // println!("(key, times) pairs:\t{:?}\t{:?}\t{:?}\tavg {:?}ns\t{:?}", compute_counter, output_counter, key_count, avg_ns, ul);
             }
 
             // We have processed all updates through `upper_limit` and will only use times in advance of 
@@ -471,34 +459,10 @@ where
             source_trace.advance_by(&upper_limit[..]);
             output_trace.advance_by(&upper_limit[..]);
 
-            // We no longer need to distinguish between the batches we have received and historical batches,
-            // so we should allow the trace to start merging them.
-            //
-            // Note: We know that there will be no further times through `upper_limit`, but we still use the
-            // earlier `upper_received` to avoid antagonizing the trace which may end up with `upper_limit`
-            // cutting through a single (largely empty, at least near `upper_limit`) batch. 
-            source_trace.distinguish_since(&upper_received[..]);
-            output_trace.distinguish_since(&upper_received[..]);
         });
 
         Arranged { stream: stream, trace: result_trace }
     }
-}
-
-// Several methods are broken out here to help understand performance profiling.
-
-#[inline(never)]
-fn sort_dedup_a<T: Ord>(list: &mut Vec<T>) {
-    list.dedup();
-    list.sort();
-    list.dedup();
-}
-
-#[inline(never)]
-fn sort_dedup_b<T: Ord>(list: &mut Vec<T>) {
-    list.dedup();
-    list.sort();
-    list.dedup();
 }
 
 #[inline(never)]
@@ -572,7 +536,7 @@ where
         key: &K, 
         input: &mut C1, 
         output: &mut C2, 
-        batches: &mut [C3],
+        batch: &mut C3,
         times: &mut Vec<T>, 
         logic: &L, 
         upper_limit: &[T],
@@ -581,8 +545,8 @@ where
     where 
         K: Eq+Clone+Debug,
         C1: Cursor<K, V1, T, R1>, 
-        C3: Cursor<K, V1, T, R1>, 
         C2: Cursor<K, V2, T, R2>, 
+        C3: Cursor<K, V1, T, R1>, 
         L: Fn(&K, &[(V1, R1)], &mut Vec<(V2, R2)>);
 }
 
@@ -593,403 +557,14 @@ mod history_replay {
     use std::fmt::Debug;
     use std::cmp::Ordering;
 
+    // use timely::progress::frontier::Antichain;
+
     use ::Ring;
     use lattice::Lattice;
     use trace::Cursor;
+    use operators::ValueHistory2;
 
-    use super::{PerKeyCompute, consolidate, sort_dedup_a, sort_dedup_b, consolidate_from};
-
-
-
-    /// The `HistoryReplayer` is a compute strategy based on moving through existing inputs, interesting times, etc in 
-    /// time order, maintaining consolidated representations of updates with respect to future interesting times.
-    pub struct HistoryReplayer2<V1, V2, T, R1, R2> 
-    where
-        V1: Ord+Clone,
-        V2: Ord+Clone,
-        T: Lattice+Ord+Clone,
-        R1: Ring,
-        R2: Ring,
-    {
-        input_history: CollectionHistory<V1, T, R1>,
-        output_history: CollectionHistory<V2, T, R2>,
-        input_buffer: Vec<(V1, R1)>,
-        output_buffer: Vec<(V2, R2)>,
-        output_produced: Vec<((V2, T), R2)>,
-        known_times: Vec<T>,
-        synth_times: Vec<T>,
-        meets: Vec<T>,
-        times_current: Vec<T>,
-        lower: Vec<T>,
-    }
-
-    impl<V1, V2, T, R1, R2> PerKeyCompute<V1, V2, T, R1, R2> for HistoryReplayer2<V1, V2, T, R1, R2> 
-    where
-        V1: Ord+Clone+Debug,
-        V2: Ord+Clone+Debug,
-        T: Lattice+Ord+Clone+Debug,
-        R1: Ring+Debug,
-        R2: Ring+Debug,
-    {
-        fn new() -> Self {
-            HistoryReplayer2 { 
-                input_history: CollectionHistory::new(),
-                output_history: CollectionHistory::new(),
-                input_buffer: Vec::new(),
-                output_buffer: Vec::new(),
-                output_produced: Vec::new(),
-                known_times: Vec::new(),
-                synth_times: Vec::new(),
-                meets: Vec::new(),
-                times_current: Vec::new(),
-                lower: Vec::new(),
-            }
-        }
-        #[inline(never)]
-        fn compute<K, C1, C2, C3, L>(
-            &mut self,
-            key: &K, 
-            source_cursor: &mut C1, 
-            output_cursor: &mut C2, 
-            batch_cursors: &mut [C3],
-            times: &mut Vec<T>, 
-            logic: &L, 
-            upper_limit: &[T],
-            outputs: &mut [(T, Vec<(V2, T, R2)>)],
-            new_interesting: &mut Vec<T>) -> (usize, usize)
-        where 
-            K: Eq+Clone+Debug,
-            C1: Cursor<K, V1, T, R1>, 
-            C3: Cursor<K, V1, T, R1>, 
-            C2: Cursor<K, V2, T, R2>, 
-            L: Fn(&K, &[(V1, R1)], &mut Vec<(V2, R2)>) 
-        {
-            // We determine the output changes for times not in advance of `upper_limit` by enumerating and 
-            // then exploring all times found in `
-
-
-
-            // we use meets[0], and this should be true anyhow (otherwise, don't call).
-            assert!(times.len() > 0);
-
-            // determine a lower frontier of interesting times.
-            self.lower.clear();
-            for time in times.drain(..) {
-                if !self.lower.iter().any(|t| t.le(&time)) { 
-                    self.lower.retain(|t| !time.lt(t));
-                    self.lower.push(time);
-                }
-            }
-
-            // All times we encounter will be at least `meet`, and so long as we just join with and compare 
-            // against interesting times, it is safe to advance all historical times by `meet`. 
-            //
-            // NOTE: This works fine for distributive lattices, but `advance_by` is more precise. This is a 
-            //       bit of an experiment to see what the difference might be. We may want to switch back to
-            //       `advance_by` in the future to make it more robust.
-            let mut meet = self.lower.iter().fold(T::max(), |meet, time| meet.meet(time));
-
-            // We build "histories" of the input and output, with respect to the times we may encounter in this
-            // invocation of `compute`. This means we advance times by joining them with `meet`, which can yield
-            // somewhat odd updates; we should not take the advanced times as anything other than a time that is
-            // safe to use for joining with and `le` testing against times in the interval.
-            //
-            // These histories act as caches in front of each cursor. They should provide the same functionality,
-            // but are capable of compacting their representation as we proceed through the computation.
-
-            self.input_history.reload(key, source_cursor, &meet);
-            self.output_history.reload(key, output_cursor, &meet);
-
-            // TODO: We should be able to thin out any updates at times that, advanced, are greater than some
-            //       element of `upper_limit`, as we will never incorporate that update. We should take care 
-            //       to notice these times, if we need to report them as interesting times, but once we have 
-            //       done that we can ditch the updates.
-            // NOTE: Doing this removes a certain amount of precision, in that we can no longer see to which
-            //       values the times correspond, and perhaps be less interested if the value is not observed.
-            //       Similarly, we lose the ability to see that updates cancel at some point; this may be less
-            //       common, if the "future" updates we would join with are largely historical, and so not 
-            //       changing in this invocation of `compute`.
-            // NOTE: Not done at the moment. The precision is reassuring for correctness.
-
-            // TODO: We should be able to restrict our attention down to just those times that are the joins
-            //       of times evident in the input and output. This could be useful in cases like `distinct`,
-            //       where the input updates collapse down to relatively fewer distinct moments.
-            // NOTE: One simple version of this is to just start with the times of the lower bound, and the 
-            //       times present in the input or output, ignoring `times` completely. I think this might be
-            //       a good "reference implementation", and it could/should check that each element of `times`
-            //       is actually considered. The non-emptiness of `times` would still drive whether we evaluate
-            //       a key for any given interval, and it is still important to correctly produce it as output.
-            // NOTE: We pay no attention to which times are "new" which are required for interesting times. We
-            //       could require that each time be interesting, in that it is the join that includes at least
-            //       one new update (from `batch_cursors`, which we do not have access to here) or `times`.
-
-            self.synth_times.clear();
-            self.times_current.clear();
-            self.output_produced.clear();
-
-            {   // Populate `self.known_times` with times from the input, output, and the `times` argument.
-                
-                self.known_times.clear();
-
-                // Merge the times in input actions and output actions.
-                let mut input_slice = &self.input_history.actions[..];
-                let mut output_slice = &self.output_history.actions[..];
-
-                while input_slice.len() > 0 || output_slice.len() > 0 {
-
-                    // Determine the next time.
-                    let mut next = T::max();
-                    if input_slice.len() > 0 && input_slice[0].0.cmp(&next) == Ordering::Less {
-                        next = input_slice[0].0.clone();
-                    }
-                    if output_slice.len() > 0 && output_slice[0].0.cmp(&next) == Ordering::Less {
-                        next = output_slice[0].0.clone();
-                    }
-
-                    // Advance each slice until we reach a new time.
-                    while input_slice.len() > 0 && input_slice[0].0 == next {
-                        input_slice = &input_slice[1..];
-                    }
-                    while output_slice.len() > 0 && output_slice[0].0 == next {
-                        output_slice = &output_slice[1..];
-                    }
-
-                    self.known_times.push(next);
-                }
-            }
-
-            {   // Populate `self.meets` with the meets of suffixes of `self.known_times`.
-
-                // As we move through `self.known_times`, we want to collapse down historical updates, even
-                // those that were distinct at the beginning of the interval. To do this, we track the `meet`
-                // of each suffix of `self.known_times`, and use this to advance times in update histories.
-
-                self.meets.clear();
-                self.meets.reserve(self.known_times.len());
-                self.meets.extend(self.known_times.iter().cloned());
-                for i in (1 .. self.meets.len()).rev() {
-                    self.meets[i-1] = self.meets[i-1].meet(&self.meets[i]);
-                }
-            }
-
-            // we track our position in each of our lists of actions using slices; 
-            // as we pull work from the front, we advance the slice. we could have
-            // used drain iterators, but we want to peek at the next element and 
-            // this seemed like the simplest way to do that.
-
-            let mut known_slice = &self.known_times[..];
-            let mut meets_slice = &self.meets[..];
-
-            let mut compute_counter = 0;
-            let mut output_counter = 0;
-
-            // Times to process can either by "known" a priori, or "synth"-etic times produced as 
-            // the joins of updates and interesting times. As long as we have either, we should continue
-            // to do work.
-            while known_slice.len() > 0 || self.synth_times.len() > 0 {
-
-                // Determine the next time to process.
-                let mut next_time = T::max();
-                if known_slice.len() > 0 && next_time.cmp(&known_slice[0]) == Ordering::Greater {
-                    next_time = known_slice[0].clone();
-                }
-                if self.synth_times.len() > 0 && next_time.cmp(&self.synth_times[0]) == Ordering::Greater {
-                    next_time = self.synth_times[0].clone();
-                }
-
-                // Advance `known_slice` and `synth_times` past `next_time`.
-                while known_slice.len() > 0 && known_slice[0] == next_time {
-                    known_slice = &known_slice[1..];
-                    meets_slice = &meets_slice[1..];
-                }
-                while self.synth_times.len() > 0 && self.synth_times[0] == next_time {
-                    self.synth_times.remove(0); // <-- TODO: this could be a min-heap.
-                }
-
-                // Advance each history that we track.
-                // TODO: Add batch history somewhere.
-                self.input_history.advance_through(&next_time);
-                self.output_history.advance_through(&next_time);
-
-                // We should only process times that are not in advance of `upper_limit`. 
-                //
-                // We have no particular guarantee that known times will not be in advance of `upper_limit`.
-                // We may have the guarantee that synthetic times will not be, as we test against the limit
-                // before we add the time to `synth_times`.
-                if !upper_limit.iter().any(|t| t.le(&next_time)) {
-
-                    compute_counter += 1;
-
-                    // Assemble the input collection at `next_time`. (`self.input_buffer` cleared just after use).
-                    debug_assert!(self.input_buffer.is_empty());
-                    self.input_history.insert(&next_time, &meet, &mut self.input_buffer);
-
-                    // Apply user logic if non-empty input and see what happens!
-                    self.output_buffer.clear();
-                    if self.input_buffer.len() > 0 {
-                        logic(key, &self.input_buffer[..], &mut self.output_buffer);
-                        self.input_buffer.clear();
-                    }
-            
-                    // Subtract relevant output differences to determine the difference between the intended 
-                    // output and the actual current output. Note: we have two places where output differences
-                    // live: `output_history` and `output_produced`; the former are those output updates from
-                    // the output trace, and the latter are output updates we have produced as this invocation
-                    // of `compute` has executed.
-                    //
-                    // TODO: This could perhaps be done better, as `output_history` is grouped by value and we
-                    //       also eventually want to group `output_produced` by value. Perhaps we can manage
-                    //       each organized by value and then sort only `self.output_buffer` and merge whatever
-                    //       results to see output updates. A log-structured merge list would work, but is more
-                    //       engineering than I can pinch off right now.
-
-                    self.output_history.remove(&next_time, &meet, &mut self.output_buffer);
-                    for &((ref value, ref time), diff) in self.output_produced.iter() {
-                        if time.le(&next_time) {
-                            self.output_buffer.push((value.clone(), -diff));
-                        }
-                    }
-
-                    // Having subtracted output updates from user output, consolidate the results to determine
-                    // if there is anything worth reporting. Note: this also orders the results by value, so 
-                    // that could make the above merging plan even easier. 
-                    consolidate(&mut self.output_buffer);
-
-                    // Stash produced updates into both capability-indexed buffers and `output_produced`. 
-                    // The two locations are important, in that we will compact `output_produced` as we move 
-                    // through times, but we cannot compact the output buffers because we need their actual
-                    // times.
-                    if self.output_buffer.len() > 0 {
-
-                        output_counter += 1;
-
-                        // any times not greater than `lower` must be empty (and should be skipped, but testing!)
-                        assert!(self.lower.iter().any(|t| t.le(&next_time)));
-
-                        // We *should* be able to find a capability for `next_time`. Any thing else would 
-                        // indicate a logical error somewhere along the way; either we release a capability 
-                        // we should have kept, or we have computed the output incorrectly (or both!)
-                        let idx = outputs.iter().rev().position(|&(ref time, _)| time.le(&next_time));
-                        let idx = outputs.len() - idx.unwrap() - 1;
-                        for (val, diff) in self.output_buffer.drain(..) {
-                            self.output_produced.push(((val.clone(), next_time.clone()), diff));
-                            outputs[idx].1.push((val, next_time.clone(), diff));
-                        }
-
-                        // Advance times in `self.output_produced` and consolidate the representation.
-                        // NOTE: We only do this when we add records; it could be that there are situations 
-                        //       where we want to consolidate even without changes (because an initially
-                        //       large collection can now be collapsed).
-                        for entry in &mut self.output_produced {
-                            (entry.0).1 = (entry.0).1.join(&meet);
-                        }
-                        consolidate(&mut self.output_produced);
-
-                    }
-
-                    // Determine synthetic interesting times.
-                    //
-                    // This implementation makes the pessimistic assumption that the time we consider could 
-                    // be joined with any other time we have seen in this invocation, and that the result 
-                    // could possibly be interesting. That isn't wrong, but it is very conservative.
-                    // 
-                    // Other options include:
-                    //     1. Accumulate updates from `batch` separately, and only join input and output times
-                    //        against times present in the current accumulation of `batch`. Times that cancel
-                    //        don't need to be interesting. 
-                    //     2. Notice which times are observed by the user logic, specifically those times that
-                    //        were considered but discarded by user logic, indicating that something different
-                    //        could happen when the update becomes active.
-                    //     3. Only emit the lower bound of joined times, ignoring any joined times greater than
-                    //        those warned about, on the premise that when the warned time is considered we can
-                    //        warn about further times, if they still seem interesting (e.g., their times have
-                    //        not yet cancelled). This may require some assumptions about how times warn about
-                    //        future times, to make sure we don't miss things (might fight with other opts).
-
-                    for time in &self.times_current {
-                        if !time.le(&next_time) {
-
-                            // The joined time may be available to process in this interval, in which case we 
-                            // should enqueue it (we may not be able to process it immediately, and there may
-                            // be input or output updates at the same time to integrate).
-                            // Otherwise, enqueue the joined time in the `new_interesting` list of future warnings.
-                            let join = next_time.join(time);
-                            if !upper_limit.iter().any(|t| t.le(&join)) {
-                                self.synth_times.push(join); 
-                            }
-                            else {
-                                // NOTE: This implementation only warns about the lower bound of observed warnings.
-                                //       I'm a bit worried about this, because I'm not really sure the advantages
-                                //       (compactness) outweight the downsides (imprecision).
-                                // NOTE: We may need to discard warnings that are not in advance of capabilities.
-                                //       I guess this could happen if we previously had evidence that no outputs
-                                //       would be produced for a time, and then lost track of that evidence. The
-                                //       outer `group` logic will panic if it cannot find a capability for elements
-                                //       of `new_interesting`, and we should probably suppress such but notice them
-                                //       and confirm that they are not logic bugs (e.g., for each suppressed time
-                                //       determine when we released its capability, and understand why that was ok).
-                                if outputs.iter().any(|&(ref t,_)| t.le(&join)) {
-                                    new_interesting.push(join);
-                                }
-                                else {
-                                    // TODO: Should we tell someone?
-                                }
-                            }
-                        }
-                    }
-                }
-                else {  
-
-                    // If the time is not in advance of `upper_limit`, we should not process it but instead enqueue
-                    // it for future re-consideration. As above, we may need to discard updates that are not in 
-                    // advance of some capability. For example, just because we saw an advanced time for an input
-                    // or output update does not mean that we hold the capability to produce outputs at that time.
-                    // If we have previously released the capability, we have committed to *not* producing output at
-                    // that time, and we should respect that (also, the outer `group` logic will panic).
-                    if outputs.iter().any(|&(ref t,_)| t.le(&next_time)) {
-                        new_interesting.push(next_time.clone());
-                    }
-                    else {
-                        // TODO: Should we tell someone?
-                        // NOTE: Not incorrect to be here, if it is due to advanced input or output update times.
-                    }
-                }
-
-                // Record `next_time` as a time we considered, for future times to join against.
-                self.times_current.push(next_time);
-
-                // Update `meet`, and advance and deduplicate times is `self.times_current`.
-                // NOTE: This does not advance input or output collections, which is done when the are accumulated.
-                if meets_slice.len() > 0 || self.synth_times.len() > 0 {
-
-                    // Start from `T::max()` and take the meet with each synthetic time. Also meet with the first 
-                    // element of `meets_slice` if it exists.
-                    meet = self.synth_times.iter().fold(T::max(), |meet, time| meet.meet(time));
-                    if meets_slice.len() > 0 { meet = meet.meet(&meets_slice[0]); }
-
-                    // Advance and deduplicate `self.times_current`.
-                    for time in &mut self.times_current {
-                        *time = time.join(&meet);
-                    }
-                    sort_dedup_a(&mut self.times_current);
-                }
-
-                // Sort and deduplicate `self.synth_times`. This is our poor replacement for a min-heap, but works.
-                sort_dedup_b(&mut self.synth_times);
-            }
-
-            // Normalize the representation of `new_interesting`, deduplicating and ordering. 
-            // NOTE: This only makes sense for as long as we track the lower frontier. Once we track more precise
-            //       times, we will have non-trivial deduplication to perform here. The logic will be similar, but
-            //       the current `debug_assert!` will not be correct (it asserts "already deduplicated").
-            new_interesting.sort();
-            new_interesting.dedup();
-
-            (compute_counter, output_counter)
-        }
-    }
-
-
+    use super::{PerKeyCompute, consolidate, sort_dedup};
 
     /// The `HistoryReplayer` is a compute strategy based on moving through existing inputs, interesting times, etc in 
     /// time order, maintaining consolidated representations of updates with respect to future interesting times.
@@ -1001,16 +576,18 @@ mod history_replay {
         R1: Ring,
         R2: Ring,
     {
-        input_history: CollectionHistory<V1, T, R1>,
-        output_history: CollectionHistory<V2, T, R2>,
+        batch_history: ValueHistory2<V1, T, R1>,
+        input_history: ValueHistory2<V1, T, R1>,
+        output_history: ValueHistory2<V2, T, R2>,
         input_buffer: Vec<(V1, R1)>,
         output_buffer: Vec<(V2, R2)>,
         output_produced: Vec<((V2, T), R2)>,
-        known_times: Vec<T>,
+        // known_times: Vec<T>,
         synth_times: Vec<T>,
         meets: Vec<T>,
         times_current: Vec<T>,
-        lower: Vec<T>,
+        // lower: Vec<T>,
+        temporary: Vec<T>,
     }
 
     impl<V1, V2, T, R1, R2> PerKeyCompute<V1, V2, T, R1, R2> for HistoryReplayer<V1, V2, T, R1, R2> 
@@ -1023,6 +600,346 @@ mod history_replay {
     {
         fn new() -> Self {
             HistoryReplayer { 
+                batch_history: ValueHistory2::new(),
+                input_history: ValueHistory2::new(),
+                output_history: ValueHistory2::new(),
+                input_buffer: Vec::new(),
+                output_buffer: Vec::new(),
+                output_produced: Vec::new(),
+                // known_times: Vec::new(),
+                synth_times: Vec::new(),
+                meets: Vec::new(),
+                times_current: Vec::new(),
+                // lower: Vec::new(),
+                temporary: Vec::new(),
+            }
+        }
+        #[inline(never)]
+        fn compute<K, C1, C2, C3, L>(
+            &mut self,
+            key: &K, 
+            source_cursor: &mut C1, 
+            output_cursor: &mut C2, 
+            batch_cursor: &mut C3,
+            times: &mut Vec<T>, 
+            logic: &L, 
+            upper_limit: &[T],
+            outputs: &mut [(T, Vec<(V2, T, R2)>)],
+            new_interesting: &mut Vec<T>) -> (usize, usize)
+        where 
+            K: Eq+Clone+Debug,
+            C1: Cursor<K, V1, T, R1>, 
+            C2: Cursor<K, V2, T, R2>, 
+            C3: Cursor<K, V1, T, R1>, 
+            L: Fn(&K, &[(V1, R1)], &mut Vec<(V2, R2)>) 
+        {
+            // The first thing we need to know is which times and values we are worried about.
+            // We use `T::min` as the lower bound with which we join everything to avoid changing the times,
+            // not knowing any better, but also because all updates should be ahead of the interval's lower
+            // bound.
+
+            self.batch_history.clear(); 
+            if batch_cursor.key_valid() && batch_cursor.key() == key {
+                self.batch_history.load(batch_cursor, |time| time.clone());
+            }
+
+            // Tracks the frontier of times we may still consider. Repeatedly re-derived from frontiers of 
+            // each of the (currently five) sources of times we consider. Could be simplified to just be the
+            // meet of these times, but would lose minimality (not correctness) for non-distributed lattices.
+
+            // Determine a lower frontier of interesting times.
+            // I'm not sure what we do with this other than a `debug_assert` and re-scan it to produce `meet`.
+            // Perhaps we should just grab the meet here? Or we could leave this here, because as grown-ups we
+            // will eventually want to use `advance_by` with a frontier anyhow.
+            let mut meet = T::max();
+            if let Some(time) = self.batch_history.meet() { meet = meet.meet(&time); }
+
+            self.meets.clear();
+            self.meets.extend(times.iter().cloned());
+            for index in (1 .. self.meets.len()).rev() {
+                self.meets[index-1] = self.meets[index-1].meet(&self.meets[index]);
+            }
+
+            if self.meets.len() > 0 { meet = meet.meet(&self.meets[0]); }
+
+            self.input_history.clear(); 
+            source_cursor.seek_key(key);
+            if source_cursor.key_valid() && source_cursor.key() == key {
+                self.input_history.load(source_cursor, |time| time.join(&meet));
+            }
+
+            self.output_history.clear();
+            output_cursor.seek_key(key);
+            if output_cursor.key_valid() && output_cursor.key() == key {
+               self.output_history.load(output_cursor, |time| time.join(&meet));
+            }
+
+            self.synth_times.clear();
+            self.times_current.clear();
+            self.output_produced.clear();
+
+            // The frontier of times we may still consider. 
+            // Derived from frontiers of our update histories, supplied times, and synthetic times.
+
+            let mut times_slice = &times[..];
+            let mut meets_slice = &self.meets[..];
+
+            let mut compute_counter = 0;
+            let mut output_counter = 0;
+
+            while !self.input_history.is_done() || !self.output_history.is_done() || 
+                  !self.batch_history.is_done() || self.synth_times.len() > 0 || times_slice.len() > 0 {
+
+                // Determine the next time we will process from the available source of times.
+                let mut next_time = T::max();
+                if let Some(time) = self.input_history.time() { if time.cmp(&next_time) == Ordering::Less { next_time = time.clone(); } }
+                if let Some(time) = self.output_history.time() { if time.cmp(&next_time) == Ordering::Less { next_time = time.clone(); } }
+                if let Some(time) = self.batch_history.time() { if time.cmp(&next_time) == Ordering::Less { next_time = time.clone(); } }
+                if let Some(time) = self.synth_times.first() { if time.cmp(&next_time) == Ordering::Less { next_time = time.clone(); } }
+                if let Some(time) = times_slice.first() { if time.cmp(&next_time) == Ordering::Less { next_time = time.clone(); } }
+                assert!(next_time != T::max());
+
+                // advance input and output histories.
+                self.input_history.step_while_time_is(&next_time);
+                self.output_history.step_while_time_is(&next_time);
+
+                // advance batch history, but capture whether an update exists at `next_time`.
+                let mut interesting = self.batch_history.step_while_time_is(&next_time);
+                if interesting { self.batch_history.advance_buffer_by(&meet); }
+
+                // advance both `synth_times` and `times_slice`, marking the time interesting if in either.
+                while self.synth_times.last() == Some(&next_time) {
+                    // We don't know enough about `next_time` to avoid putting it in to `times_current`.
+                    // TODO: If we knew that the time derived from a canceled batch update, we could remove the time. 
+                    self.times_current.push(self.synth_times.pop().unwrap()); // <-- TODO: this could be a min-heap.
+                    interesting = true;
+                }
+                while times_slice.len() > 0 && times_slice[0] == next_time {
+                    // We know nothing about why we were warned about `next_time`, and must include it to scare future times.
+                    self.times_current.push(times_slice[0].clone());
+                    times_slice = &times_slice[1..];
+                    meets_slice = &meets_slice[1..];
+                    interesting = true;
+                }
+
+                // Times could also be interesting if an interesting time is less than them, as they would join
+                // and become the time itself. They may not equal the current time because whatever frontier we
+                // are tracking may not have advanced far enough.
+                // TODO: `batch_history` may or may not be super compact at this point, and so this check might 
+                //       yield false positives if not sufficiently compact. Maybe we should into this and see.
+                interesting = interesting || self.batch_history.buffer.iter().any(|&((_, ref t),_)| t.le(&next_time));
+                interesting = interesting || self.times_current.iter().any(|t| t.le(&next_time));
+
+                // We should only process times that are not in advance of `upper_limit`. 
+                //
+                // We have no particular guarantee that known times will not be in advance of `upper_limit`.
+                // We may have the guarantee that synthetic times will not be, as we test against the limit
+                // before we add the time to `synth_times`.
+                if !upper_limit.iter().any(|t| t.le(&next_time)) {
+
+                    // We should re-evaluate the computation if this is an interesting time.
+                    // If the time is uninteresting (and our logic is sound) it is not possible for there to be 
+                    // output produced. This sounds like a good test to have for debug builds!
+                    if interesting { 
+
+                        compute_counter += 1;
+
+                        // Assemble the input collection at `next_time`. (`self.input_buffer` cleared just after use).
+                        debug_assert!(self.input_buffer.is_empty());
+                        self.input_history.advance_buffer_by(&meet);
+                        for &((ref value, ref time), diff) in self.input_history.buffer.iter() {
+                            if time.le(&next_time) {
+                                self.input_buffer.push((value.clone(), diff));
+                            }
+                            else {
+                                self.temporary.push(next_time.join(time));
+                            }
+                        }
+                        consolidate(&mut self.input_buffer);
+
+                        // Apply user logic if non-empty input and see what happens!
+                        if self.input_buffer.len() > 0 {
+                            logic(key, &self.input_buffer[..], &mut self.output_buffer);
+                            self.input_buffer.clear();
+                        }            
+
+                        self.output_history.advance_buffer_by(&meet);
+                        for &((ref value, ref time), diff) in self.output_history.buffer.iter() {
+                            if time.le(&next_time) {
+                                self.output_buffer.push((value.clone(), -diff));
+                            }
+                            else {
+                                self.temporary.push(next_time.join(time));
+                            }
+                        }
+                        for &((ref value, ref time), diff) in self.output_produced.iter() {
+                            if time.le(&next_time) {
+                                self.output_buffer.push((value.clone(), -diff));
+                            }
+                            else {
+                                self.temporary.push(next_time.join(time));
+                            }
+                        }
+
+                        // Having subtracted output updates from user output, consolidate the results to determine
+                        // if there is anything worth reporting. Note: this also orders the results by value, so 
+                        // that could make the above merging plan even easier. 
+                        consolidate(&mut self.output_buffer);
+
+                        // Stash produced updates into both capability-indexed buffers and `output_produced`. 
+                        // The two locations are important, in that we will compact `output_produced` as we move 
+                        // through times, but we cannot compact the output buffers because we need their actual
+                        // times.
+                        if self.output_buffer.len() > 0 {
+
+                            output_counter += 1;
+
+                            // We *should* be able to find a capability for `next_time`. Any thing else would 
+                            // indicate a logical error somewhere along the way; either we release a capability 
+                            // we should have kept, or we have computed the output incorrectly (or both!)
+                            let idx = outputs.iter().rev().position(|&(ref time, _)| time.le(&next_time));
+                            let idx = outputs.len() - idx.unwrap() - 1;
+                            for (val, diff) in self.output_buffer.drain(..) {
+                                self.output_produced.push(((val.clone(), next_time.clone()), diff));
+                                outputs[idx].1.push((val, next_time.clone(), diff));
+                            }
+
+                            // Advance times in `self.output_produced` and consolidate the representation.
+                            // NOTE: We only do this when we add records; it could be that there are situations 
+                            //       where we want to consolidate even without changes (because an initially
+                            //       large collection can now be collapsed).
+                            for entry in &mut self.output_produced {
+                                (entry.0).1 = (entry.0).1.join(&meet);
+                            }
+                            consolidate(&mut self.output_produced);
+                        }
+                    }
+
+                    // Determine synthetic interesting times.
+                    //
+                    // Synthetic interesting times are produced differently for interesting and uninteresting
+                    // times. An uninteresting time must join with an interesting time to become interesting,
+                    // which means joins with `self.batch_history` and  `self.times_current`. I think we can
+                    // skip `self.synth_times` as we haven't gotten to them yet, but we will and they will be
+                    // joined against everything.
+
+                    // Any time, even uninteresting times, must be joined with the current accumulation of 
+                    // batch times as well as the current accumulation of `times_current`.
+                    for &((_, ref time), _) in self.batch_history.buffer.iter() {
+                        if !time.le(&next_time) {
+                            self.temporary.push(time.join(&next_time));
+                        }
+                    }
+                    for time in self.times_current.iter() {
+                        if !time.le(&next_time) {
+                            self.temporary.push(time.join(&next_time));
+                        }
+                    }
+
+                    sort_dedup(&mut self.temporary);
+
+                    // Introduce synthetic times, and re-organize if we add any.
+                    let synth_len = self.synth_times.len();
+                    for time in self.temporary.drain(..) {
+                        // We can either service `join` now, or must delay for the future.
+                        if upper_limit.iter().any(|t| t.le(&time)) {
+                            debug_assert!(outputs.iter().any(|&(ref t,_)| t.le(&time)));
+                            new_interesting.push(time);
+                        }
+                        else {
+                            self.synth_times.push(time);
+                        }
+                    }
+                    if self.synth_times.len() > synth_len {
+                        self.synth_times.sort_by(|x,y| y.cmp(x));
+                        self.synth_times.dedup();
+                    }
+                }
+                else {  
+
+                    if interesting {
+                        // We cannot process `next_time` now, and must delay it. 
+                        //
+                        // I think we are probably only here because of an uninteresting time declared interesting,
+                        // as initial interesting times are filtered to be in interval, and synthetic times are also
+                        // filtered before introducing them to `self.synth_times`.
+                        new_interesting.push(next_time.clone());
+                        debug_assert!(outputs.iter().any(|&(ref t,_)| t.le(&next_time)))
+                    }
+                }
+
+                // Update `meet` to track the meet of each source of times.
+                meet = T::max();
+                if let Some(time) = self.batch_history.meet() { meet = meet.meet(time); }
+                if let Some(time) = self.input_history.meet() { meet = meet.meet(time); }
+                if let Some(time) = self.output_history.meet() { meet = meet.meet(time); }
+                for time in self.synth_times.iter() { meet = meet.meet(time); }
+                if let Some(time) = meets_slice.first() { meet = meet.meet(time); }
+
+                // Update `times_current` by the frontier.
+                for time in self.times_current.iter_mut() {
+                    *time = time.join(&meet);
+                }
+
+                sort_dedup(&mut self.times_current);
+            }
+
+            // Normalize the representation of `new_interesting`, deduplicating and ordering.
+            sort_dedup(new_interesting);
+
+            (compute_counter, output_counter)
+        }
+    }
+}
+
+
+/// Implementation based on replaying historical and new updates together.
+mod history_replay_prior {
+
+    use std::fmt::Debug;
+    use std::cmp::Ordering;
+
+    use ::Ring;
+    use lattice::Lattice;
+    use trace::Cursor;
+
+    use super::{PerKeyCompute, consolidate, sort_dedup, consolidate_from};
+
+    /// The `HistoryReplayer` is a compute strategy based on moving through existing inputs, interesting times, etc in 
+    /// time order, maintaining consolidated representations of updates with respect to future interesting times.
+    pub struct HistoryReplayer<V1, V2, T, R1, R2> 
+    where
+        V1: Ord+Clone,
+        V2: Ord+Clone,
+        T: Lattice+Ord+Clone,
+        R1: Ring,
+        R2: Ring,
+    {
+        batch_history: CollectionHistory<V1, T, R1>,
+        input_history: CollectionHistory<V1, T, R1>,
+        output_history: CollectionHistory<V2, T, R2>,
+        input_buffer: Vec<(V1, R1)>,
+        output_buffer: Vec<(V2, R2)>,
+        output_produced: Vec<((V2, T), R2)>,
+        known_times: Vec<T>,
+        synth_times: Vec<T>,
+        meets: Vec<T>,
+        times_current: Vec<T>,
+        lower: Vec<T>,
+        temporary: Vec<T>,
+    }
+
+    impl<V1, V2, T, R1, R2> PerKeyCompute<V1, V2, T, R1, R2> for HistoryReplayer<V1, V2, T, R1, R2> 
+    where
+        V1: Ord+Clone+Debug,
+        V2: Ord+Clone+Debug,
+        T: Lattice+Ord+Clone+Debug,
+        R1: Ring+Debug,
+        R2: Ring+Debug,
+    {
+        fn new() -> Self {
+            HistoryReplayer { 
+                batch_history: CollectionHistory::new(),
                 input_history: CollectionHistory::new(),
                 output_history: CollectionHistory::new(),
                 input_buffer: Vec::new(),
@@ -1033,6 +950,7 @@ mod history_replay {
                 meets: Vec::new(),
                 times_current: Vec::new(),
                 lower: Vec::new(),
+                temporary: Vec::new(),
             }
         }
         #[inline(never)]
@@ -1041,7 +959,7 @@ mod history_replay {
             key: &K, 
             source_cursor: &mut C1, 
             output_cursor: &mut C2, 
-            batch_cursors: &mut [C3], 
+            batch_cursor: &mut C3,
             times: &mut Vec<T>, 
             logic: &L, 
             upper_limit: &[T],
@@ -1050,29 +968,34 @@ mod history_replay {
         where 
             K: Eq+Clone+Debug,
             C1: Cursor<K, V1, T, R1>, 
-            C3: Cursor<K, V1, T, R1>, 
             C2: Cursor<K, V2, T, R2>, 
+            C3: Cursor<K, V1, T, R1>, 
             L: Fn(&K, &[(V1, R1)], &mut Vec<(V2, R2)>) 
         {
+            // The first thing we need to know is which times and values we are worried about.
+            // We use `T::min` as the lower bound with which we join everything to avoid changing the times.
+            self.batch_history.reload1(key, batch_cursor, &T::min());
 
-            // we use meets[0], and this should be true anyhow (otherwise, don't call).
-            assert!(times.len() > 0);
-
-            // determine a lower frontier of interesting times.
+            // Determine a lower frontier of interesting times.
+            // I'm not sure what we do with this other than a `debug_assert` and re-scan it to produce `meet`.
+            // Perhaps we should just grab the meet here? Or we could leave this here, because as grown-ups we
+            // will eventually want to use `advance_by` with a frontier anyhow.
             self.lower.clear();
-            for time in times.drain(..) {
-                if !self.lower.iter().any(|t| t.le(&time)) { 
+            for thing in self.batch_history.times.iter() {
+                if !self.lower.iter().any(|t| t.le(&thing.0)) { 
+                    self.lower.retain(|t| !thing.0.lt(t));
+                    self.lower.push(thing.0.clone());
+                }                
+            }
+            for time in times.iter() {
+                if !self.lower.iter().any(|t| t.le(time)) { 
                     self.lower.retain(|t| !time.lt(t));
-                    self.lower.push(time);
+                    self.lower.push(time.clone());
                 }
             }
 
             // All times we encounter will be at least `meet`, and so long as we just join with and compare 
             // against interesting times, it is safe to advance all historical times by `meet`. 
-            //
-            // NOTE: This works fine for distributive lattices, but `advance_by` is more precise. This is a 
-            //       bit of an experiment to see what the difference might be. We may want to switch back to
-            //       `advance_by` in the future to make it more robust.
             let mut meet = self.lower.iter().fold(T::max(), |meet, time| meet.meet(time));
 
             // We build "histories" of the input and output, with respect to the times we may encounter in this
@@ -1083,8 +1006,8 @@ mod history_replay {
             // These histories act as caches in front of each cursor. They should provide the same functionality,
             // but are capable of compacting their representation as we proceed through the computation.
 
-            self.input_history.reload(key, source_cursor, &meet);
-            self.output_history.reload(key, output_cursor, &meet);
+            self.input_history.reload2(key, source_cursor, &meet);
+            self.output_history.reload3(key, output_cursor, &meet);
 
             // TODO: We should be able to thin out any updates at times that, advanced, are greater than some
             //       element of `upper_limit`, as we will never incorporate that update. We should take care 
@@ -1114,48 +1037,43 @@ mod history_replay {
             self.output_produced.clear();
 
             {   // Populate `self.known_times` with times from the input, output, and the `times` argument.
-                
-                self.known_times.clear();
-
+                //
                 // Merge the times in input actions and output actions.
+                self.known_times.clear();
+                let mut times_slice = &times[..]; 
+                let mut batch_slice = &self.batch_history.actions[..];
                 let mut input_slice = &self.input_history.actions[..];
                 let mut output_slice = &self.output_history.actions[..];
-
-                while input_slice.len() > 0 || output_slice.len() > 0 {
+                while times_slice.len() > 0 || batch_slice.len() > 0 || input_slice.len() > 0 || output_slice.len() > 0 {
 
                     // Determine the next time.
                     let mut next = T::max();
-                    if input_slice.len() > 0 && input_slice[0].0.cmp(&next) == Ordering::Less {
-                        next = input_slice[0].0.clone();
-                    }
-                    if output_slice.len() > 0 && output_slice[0].0.cmp(&next) == Ordering::Less {
-                        next = output_slice[0].0.clone();
-                    }
+                    if times_slice.len() > 0 && times_slice[0].cmp(&next) == Ordering::Less { next = times_slice[0].clone(); }
+                    if batch_slice.len() > 0 && batch_slice[0].0.cmp(&next) == Ordering::Less { next = batch_slice[0].0.clone(); }
+                    if input_slice.len() > 0 && input_slice[0].0.cmp(&next) == Ordering::Less { next = input_slice[0].0.clone(); }
+                    if output_slice.len() > 0 && output_slice[0].0.cmp(&next) == Ordering::Less { next = output_slice[0].0.clone(); }
 
                     // Advance each slice until we reach a new time.
-                    while input_slice.len() > 0 && input_slice[0].0 == next {
-                        input_slice = &input_slice[1..];
-                    }
-                    while output_slice.len() > 0 && output_slice[0].0 == next {
-                        output_slice = &output_slice[1..];
-                    }
+                    while times_slice.len() > 0 && times_slice[0] == next { times_slice = &times_slice[1..]; }
+                    while batch_slice.len() > 0 && batch_slice[0].0 == next { batch_slice = &batch_slice[1..]; }
+                    while input_slice.len() > 0 && input_slice[0].0 == next { input_slice = &input_slice[1..]; }
+                    while output_slice.len() > 0 && output_slice[0].0 == next { output_slice = &output_slice[1..]; }
 
                     self.known_times.push(next);
                 }
             }
 
-            {   // Populate `self.meets` with the meets of suffixes of `self.known_times`.
+            // Populate `self.meets` with the meets of suffixes of `self.known_times`.
+            //
+            // As we move through `self.known_times`, we want to collapse down historical updates, even
+            // those that were distinct at the beginning of the interval. To do this, we track the `meet`
+            // of each suffix of `self.known_times`, and use this to advance times in update histories.
 
-                // As we move through `self.known_times`, we want to collapse down historical updates, even
-                // those that were distinct at the beginning of the interval. To do this, we track the `meet`
-                // of each suffix of `self.known_times`, and use this to advance times in update histories.
-
-                self.meets.clear();
-                self.meets.reserve(self.known_times.len());
-                self.meets.extend(self.known_times.iter().cloned());
-                for i in (1 .. self.meets.len()).rev() {
-                    self.meets[i-1] = self.meets[i-1].meet(&self.meets[i]);
-                }
+            self.meets.clear();
+            self.meets.reserve(self.known_times.len());
+            self.meets.extend(self.known_times.iter().cloned());
+            for i in (1 .. self.meets.len()).rev() {
+                self.meets[i-1] = self.meets[i-1].meet(&self.meets[i]);
             }
 
             // we track our position in each of our lists of actions using slices; 
@@ -1163,6 +1081,7 @@ mod history_replay {
             // used drain iterators, but we want to peek at the next element and 
             // this seemed like the simplest way to do that.
 
+            let mut times_slice = &times[..];
             let mut known_slice = &self.known_times[..];
             let mut meets_slice = &self.meets[..];
 
@@ -1183,19 +1102,55 @@ mod history_replay {
                     next_time = self.synth_times[0].clone();
                 }
 
+                // Advance each history that we track.
+                // TODO: Add batch history somewhere.
+                self.input_history.advance_through(&next_time);
+                self.output_history.advance_through(&next_time);
+
+                // A time is interesting if it is the join of times, at least one of is from `batch_history` 
+                // or `times`. Clearly, times that are present in `batch_history` or `times` are interesting,
+                // but so are times in `synth_times` (which result from joining with interesting times) as well
+                // as any times that would join with something in one of these sets and end up the same.
+
+                // As we are going to join with each of the active sets in all cases, except when we are beyond
+                // the frontier, which we really shouldn't be, perhaps we should do that first and populate 
+                // `synth_times`
+
+                // We judge a time interesting if it involves the time of at least one unresolved update.
+                // One way this can happen is if it is the time of an update received in this batch.
+                // 
+                // There are several other ways that a time might be interesting. For example, when we join
+                // an apparently uninteresting time with e.g. batch_history and find that the same time comes
+                // out, it should be promoted to interesting.
+                //
+                // Perhaps we should start out with determining the synthetic times for uninteresting times, 
+                // and then determine whether to proceed with interesting times. 
+
+                let mut interesting = self.batch_history.advance_through(&next_time);
+                if interesting { self.batch_history.collapse_all(&meet); }
+
                 // Advance `known_slice` and `synth_times` past `next_time`.
                 while known_slice.len() > 0 && known_slice[0] == next_time {
                     known_slice = &known_slice[1..];
                     meets_slice = &meets_slice[1..];
                 }
                 while self.synth_times.len() > 0 && self.synth_times[0] == next_time {
+                    self.times_current.push(self.synth_times[0].clone());
                     self.synth_times.remove(0); // <-- TODO: this could be a min-heap.
+                    interesting = true;
+                }
+                while times_slice.len() > 0 && times_slice[0] == next_time {
+                    self.times_current.push(times_slice[0].clone());
+                    times_slice = &times_slice[1..];
+                    interesting = true;
                 }
 
-                // Advance each history that we track.
-                // TODO: Add batch history somewhere.
-                self.input_history.advance_through(&next_time);
-                self.output_history.advance_through(&next_time);
+                // Times could also be interesting if an interesting time is less than them, as they would join
+                // and become the time itself.
+                interesting = interesting || self.batch_history.values.iter().any(|h| self.batch_history.times[h.lower .. h.valid]
+                                                                                                .iter().any(|t| t.0.le(&next_time)));
+                interesting = interesting || self.times_current.iter().any(|t| t.le(&next_time));
+
 
                 // We should only process times that are not in advance of `upper_limit`. 
                 //
@@ -1204,164 +1159,165 @@ mod history_replay {
                 // before we add the time to `synth_times`.
                 if !upper_limit.iter().any(|t| t.le(&next_time)) {
 
-                    compute_counter += 1;
-
-                    // Assemble the input collection at `next_time`. (`self.input_buffer` cleared just after use).
-                    debug_assert!(self.input_buffer.is_empty());
-                    self.input_history.insert(&next_time, &meet, &mut self.input_buffer);
-
-                    // Apply user logic if non-empty input and see what happens!
-                    self.output_buffer.clear();
-                    if self.input_buffer.len() > 0 {
-                        logic(key, &self.input_buffer[..], &mut self.output_buffer);
-                        self.input_buffer.clear();
-                    }
-            
-                    // Subtract relevant output differences to determine the difference between the intended 
-                    // output and the actual current output. Note: we have two places where output differences
-                    // live: `output_history` and `output_produced`; the former are those output updates from
-                    // the output trace, and the latter are output updates we have produced as this invocation
-                    // of `compute` has executed.
-                    //
-                    // TODO: This could perhaps be done better, as `output_history` is grouped by value and we
-                    //       also eventually want to group `output_produced` by value. Perhaps we can manage
-                    //       each organized by value and then sort only `self.output_buffer` and merge whatever
-                    //       results to see output updates. A log-structured merge list would work, but is more
-                    //       engineering than I can pinch off right now.
-
-                    self.output_history.remove(&next_time, &meet, &mut self.output_buffer);
-                    for &((ref value, ref time), diff) in self.output_produced.iter() {
-                        if time.le(&next_time) {
-                            self.output_buffer.push((value.clone(), -diff));
-                        }
-                    }
-
-                    // Having subtracted output updates from user output, consolidate the results to determine
-                    // if there is anything worth reporting. Note: this also orders the results by value, so 
-                    // that could make the above merging plan even easier. 
-                    consolidate(&mut self.output_buffer);
-
-                    // Stash produced updates into both capability-indexed buffers and `output_produced`. 
-                    // The two locations are important, in that we will compact `output_produced` as we move 
-                    // through times, but we cannot compact the output buffers because we need their actual
-                    // times.
-                    if self.output_buffer.len() > 0 {
-
-                        output_counter += 1;
+                    // We should re-evaluate the computation if this is an interesting time.
+                    // If the time is uninteresting (and our logic is sound) it is not possible for there to be 
+                    // output produced. This sounds like a good test to have for debug builds!
+                    if interesting { 
 
                         // any times not greater than `lower` must be empty (and should be skipped, but testing!)
-                        assert!(self.lower.iter().any(|t| t.le(&next_time)));
 
-                        // We *should* be able to find a capability for `next_time`. Any thing else would 
-                        // indicate a logical error somewhere along the way; either we release a capability 
-                        // we should have kept, or we have computed the output incorrectly (or both!)
-                        let idx = outputs.iter().rev().position(|&(ref time, _)| time.le(&next_time));
-                        let idx = outputs.len() - idx.unwrap() - 1;
-                        for (val, diff) in self.output_buffer.drain(..) {
-                            self.output_produced.push(((val.clone(), next_time.clone()), diff));
-                            outputs[idx].1.push((val, next_time.clone(), diff));
+                        if !self.lower.iter().any(|t| t.le(&next_time)) {
+                            println!("PANIC: interesting time inversion:");
+                            println!("    time:   {:?}", next_time);
+                            println!("    lower: {:?}", self.lower);
+                            panic!();
                         }
 
-                        // Advance times in `self.output_produced` and consolidate the representation.
-                        // NOTE: We only do this when we add records; it could be that there are situations 
-                        //       where we want to consolidate even without changes (because an initially
-                        //       large collection can now be collapsed).
-                        for entry in &mut self.output_produced {
-                            (entry.0).1 = (entry.0).1.join(&meet);
-                        }
-                        consolidate(&mut self.output_produced);
+                        compute_counter += 1;
 
+                        // Assemble the input collection at `next_time`. (`self.input_buffer` cleared just after use).
+                        debug_assert!(self.input_buffer.is_empty());
+                        self.input_history.insert(&next_time, &meet, &mut self.input_buffer);
+
+                        // Apply user logic if non-empty input and see what happens!
+                        self.output_buffer.clear();
+                        if self.input_buffer.len() > 0 {
+                            logic(key, &self.input_buffer[..], &mut self.output_buffer);
+                        }
+                
+                        self.input_buffer.clear();
+
+                        // Subtract relevant output differences to determine the difference between the intended 
+                        // output and the actual current output. Note: we have two places where output differences
+                        // live: `output_history` and `output_produced`; the former are those output updates from
+                        // the output trace, and the latter are output updates we have produced as this invocation
+                        // of `compute` has executed.
+                        //
+                        // TODO: This could perhaps be done better, as `output_history` is grouped by value and we
+                        //       also eventually want to group `output_produced` by value. Perhaps we can manage
+                        //       each organized by value and then sort only `self.output_buffer` and merge whatever
+                        //       results to see output updates. A log-structured merge list would work, but is more
+                        //       engineering than I can pinch off right now.
+
+                        self.output_history.remove(&next_time, &meet, &mut self.output_buffer);
+                        for &((ref value, ref time), diff) in self.output_produced.iter() {
+                            if time.le(&next_time) {
+                                self.output_buffer.push((value.clone(), -diff));
+                            }
+                        }
+
+                        // Having subtracted output updates from user output, consolidate the results to determine
+                        // if there is anything worth reporting. Note: this also orders the results by value, so 
+                        // that could make the above merging plan even easier. 
+                        consolidate(&mut self.output_buffer);
+
+                        // Stash produced updates into both capability-indexed buffers and `output_produced`. 
+                        // The two locations are important, in that we will compact `output_produced` as we move 
+                        // through times, but we cannot compact the output buffers because we need their actual
+                        // times.
+                        if self.output_buffer.len() > 0 {
+
+                            output_counter += 1;
+
+                            // We *should* be able to find a capability for `next_time`. Any thing else would 
+                            // indicate a logical error somewhere along the way; either we release a capability 
+                            // we should have kept, or we have computed the output incorrectly (or both!)
+                            let idx = outputs.iter().rev().position(|&(ref time, _)| time.le(&next_time));
+                            let idx = outputs.len() - idx.unwrap() - 1;
+                            for (val, diff) in self.output_buffer.drain(..) {
+                                self.output_produced.push(((val.clone(), next_time.clone()), diff));
+                                outputs[idx].1.push((val, next_time.clone(), diff));
+                            }
+
+                            // Advance times in `self.output_produced` and consolidate the representation.
+                            // NOTE: We only do this when we add records; it could be that there are situations 
+                            //       where we want to consolidate even without changes (because an initially
+                            //       large collection can now be collapsed).
+                            for entry in &mut self.output_produced {
+                                (entry.0).1 = (entry.0).1.join(&meet);
+                            }
+                            consolidate(&mut self.output_produced);
+                        }
                     }
 
                     // Determine synthetic interesting times.
                     //
-                    // This implementation makes the pessimistic assumption that the time we consider could 
-                    // be joined with any other time we have seen in this invocation, and that the result 
-                    // could possibly be interesting. That isn't wrong, but it is very conservative.
-                    // 
-                    // Other options include:
-                    //     1. Accumulate updates from `batch` separately, and only join input and output times
-                    //        against times present in the current accumulation of `batch`. Times that cancel
-                    //        don't need to be interesting. 
-                    //     2. Notice which times are observed by the user logic, specifically those times that
-                    //        were considered but discarded by user logic, indicating that something different
-                    //        could happen when the update becomes active.
-                    //     3. Only emit the lower bound of joined times, ignoring any joined times greater than
-                    //        those warned about, on the premise that when the warned time is considered we can
-                    //        warn about further times, if they still seem interesting (e.g., their times have
-                    //        not yet cancelled). This may require some assumptions about how times warn about
-                    //        future times, to make sure we don't miss things (might fight with other opts).
+                    // Synthetic interesting times are produced differently for interesting and uninteresting
+                    // times. An uninteresting time must join with an interesting time to become interesting,
+                    // which means joins with `self.batch_history` and  `self.times_current`. I think we can
+                    // skip `self.synth_times` as we haven't gotten to them yet, but we will and they will be
+                    // joined against everything.
 
-                    for time in &self.times_current {
+                    self.batch_history.join_with_into(&next_time, &mut self.temporary);
+                    for time in self.times_current.iter() {
                         if !time.le(&next_time) {
+                            self.temporary.push(time.join(&next_time));
+                        }
+                    }
 
-                            // The joined time may be available to process in this interval, in which case we 
-                            // should enqueue it (we may not be able to process it immediately, and there may
-                            // be input or output updates at the same time to integrate).
-                            // Otherwise, enqueue the joined time in the `new_interesting` list of future warnings.
-                            let join = next_time.join(time);
-                            if !upper_limit.iter().any(|t| t.le(&join)) {
-                                self.synth_times.push(join); 
+                    // Interesting times should also join with times of updates present in `self.input_history`
+                    // and `self.output_history`. 
+                    if interesting {
+                        self.input_history.join_with_into(&next_time, &mut self.temporary);
+                        self.output_history.join_with_into(&next_time, &mut self.temporary);
+                        for &((_, ref time), _) in self.output_produced.iter() {
+                            if !time.le(&next_time) {
+                                self.temporary.push(time.join(&next_time));
                             }
-                            else {
-                                // NOTE: This implementation only warns about the lower bound of observed warnings.
-                                //       I'm a bit worried about this, because I'm not really sure the advantages
-                                //       (compactness) outweight the downsides (imprecision).
-                                // NOTE: We may need to discard warnings that are not in advance of capabilities.
-                                //       I guess this could happen if we previously had evidence that no outputs
-                                //       would be produced for a time, and then lost track of that evidence. The
-                                //       outer `group` logic will panic if it cannot find a capability for elements
-                                //       of `new_interesting`, and we should probably suppress such but notice them
-                                //       and confirm that they are not logic bugs (e.g., for each suppressed time
-                                //       determine when we released its capability, and understand why that was ok).
-                                if outputs.iter().any(|&(ref t,_)| t.le(&join)) {
-                                    new_interesting.push(join);
-                                }
-                                else {
-                                    // TODO: Should we tell someone?
-                                }
-                            }
+                        }
+                    }
+
+                    self.temporary.sort();
+                    self.temporary.dedup();
+
+                    for time in self.temporary.drain(..) {
+                        // We can either service `join` now, or must delay for the future.
+                        if upper_limit.iter().any(|t| t.le(&time)) {
+                            debug_assert!(outputs.iter().any(|&(ref t,_)| t.le(&time)));
+                            new_interesting.push(time);
+                        }
+                        else {
+                            self.synth_times.push(time);
                         }
                     }
                 }
                 else {  
 
-                    // If the time is not in advance of `upper_limit`, we should not process it but instead enqueue
-                    // it for future re-consideration. As above, we may need to discard updates that are not in 
-                    // advance of some capability. For example, just because we saw an advanced time for an input
-                    // or output update does not mean that we hold the capability to produce outputs at that time.
-                    // If we have previously released the capability, we have committed to *not* producing output at
-                    // that time, and we should respect that (also, the outer `group` logic will panic).
-                    if outputs.iter().any(|&(ref t,_)| t.le(&next_time)) {
+                    if interesting {
+                        // We cannot process `next_time` now, and must delay it. I'm not sure why we would ever 
+                        // be here, actually. I think we have already filtered all new interesting times, and all
+                        // other interesting times should be within the interval.
                         new_interesting.push(next_time.clone());
-                    }
-                    else {
-                        // TODO: Should we tell someone?
-                        // NOTE: Not incorrect to be here, if it is due to advanced input or output update times.
+                        debug_assert!(outputs.iter().any(|&(ref t,_)| t.le(&next_time)))
                     }
                 }
 
-                // Record `next_time` as a time we considered, for future times to join against.
-                self.times_current.push(next_time);
+                // Whether a time is interesting or not (in both cases) we must consider joining it with the times
+                // currently present in `self.batch_history` and likely the times in `self.synth_times`. I am less
+                // clear on whether we need to track interesting times from `times` and join with those as well. =/
+                //
+                // It would seem that the join of a historical time with a historically interesting time should have
+                // already been warned about, if previous executions were correct. Or is this the point where we have
+                // to admit that we didn't produce the full closure under join before? >.<  Shit.
 
-                // Update `meet`, and advance and deduplicate times is `self.times_current`.
+                // Update `meet`, and advance and deduplicate times in `self.times_current`.
                 // NOTE: This does not advance input or output collections, which is done when the are accumulated.
                 if meets_slice.len() > 0 || self.synth_times.len() > 0 {
-
                     // Start from `T::max()` and take the meet with each synthetic time. Also meet with the first 
                     // element of `meets_slice` if it exists.
                     meet = self.synth_times.iter().fold(T::max(), |meet, time| meet.meet(time));
                     if meets_slice.len() > 0 { meet = meet.meet(&meets_slice[0]); }
 
-                    // Advance and deduplicate `self.times_current`.
-                    for time in &mut self.times_current {
+                    // Advance the contents of `self.times_current`.
+                    for time in self.times_current.iter_mut() {
                         *time = time.join(&meet);
                     }
-                    sort_dedup_a(&mut self.times_current);
+                    self.times_current.sort();
+                    self.times_current.dedup();
                 }
 
                 // Sort and deduplicate `self.synth_times`. This is our poor replacement for a min-heap, but works.
-                sort_dedup_b(&mut self.synth_times);
+                sort_dedup(&mut self.synth_times);
             }
 
             // Normalize the representation of `new_interesting`, deduplicating and ordering. 
@@ -1401,7 +1357,8 @@ mod history_replay {
             }
         }
 
-        fn reload<K, C>(&mut self, key: &K, cursor: &mut C, meet: &T) 
+        #[inline(never)]
+        fn reload1<K, C>(&mut self, key: &K, cursor: &mut C, meet: &T) 
         where K: Eq+Clone+Debug, C: Cursor<K, V, T, R> { 
 
             self.values.clear();
@@ -1421,16 +1378,89 @@ mod history_replay {
                     self.seal_from(cursor.val().clone(), start);
                     cursor.step_val();
                 }
+                cursor.step_key();
+            }
+
+            self.build_actions();
+        }
+
+        #[inline(never)]
+        fn reload2<K, C>(&mut self, key: &K, cursor: &mut C, meet: &T) 
+        where K: Eq+Clone+Debug, C: Cursor<K, V, T, R> { 
+
+            self.values.clear();
+            self.actions.clear();
+            self.action_cursor = 0;
+            self.times.clear();
+
+            cursor.seek_key(&key);
+            if cursor.key_valid() && cursor.key() == key {
+                while cursor.val_valid() {
+                    // let val: V1 = source_cursor.val().clone();
+                    let start = self.times.len();
+                    cursor.map_times(|t, d| {
+                        // println!("  INPUT: ({:?}, {:?}, {:?}, {:?})", key, val, t, d);
+                        self.times.push((t.join(&meet), d));
+                    });
+                    self.seal_from(cursor.val().clone(), start);
+                    cursor.step_val();
+                }
+                cursor.step_key();
+            }
+
+            self.build_actions();
+        }
+
+        #[inline(never)]
+        fn reload3<K, C>(&mut self, key: &K, cursor: &mut C, meet: &T) 
+        where K: Eq+Clone+Debug, C: Cursor<K, V, T, R> { 
+
+            self.values.clear();
+            self.actions.clear();
+            self.action_cursor = 0;
+            self.times.clear();
+
+            cursor.seek_key(&key);
+            if cursor.key_valid() && cursor.key() == key {
+                while cursor.val_valid() {
+                    // let val: V1 = source_cursor.val().clone();
+                    let start = self.times.len();
+                    cursor.map_times(|t, d| {
+                        // println!("  INPUT: ({:?}, {:?}, {:?}, {:?})", key, val, t, d);
+                        self.times.push((t.join(&meet), d));
+                    });
+                    self.seal_from(cursor.val().clone(), start);
+                    cursor.step_val();
+                }
+                cursor.step_key();
             }
 
             self.build_actions();
         }
 
         /// Advances the indexed value by one, with the ability to compact times by `meet`.
-        fn advance_through(&mut self, time: &T) {
+        fn advance_through(&mut self, time: &T) -> bool {
+            let mut advanced = false;
             while self.action_cursor < self.actions.len() && self.actions[self.action_cursor].0.cmp(time) != Ordering::Greater {
                 self.values[self.actions[self.action_cursor].1].valid += 1;
                 self.action_cursor += 1;
+                advanced = true;
+            }
+            advanced
+        }
+
+        fn collapse_all(&mut self, meet: &T) {
+
+            for value_index in 0 .. self.values.len() {
+
+                let clean = self.values[value_index].clean;
+                let valid = self.values[value_index].valid;
+
+                // take the time to collapse if there are changes. 
+                // this is not the only reason to collapse, and we may want to be more or less aggressive
+                if clean < valid {
+                    self.collapse(value_index, meet);
+                }
             }
         }
 
@@ -1570,529 +1600,17 @@ mod history_replay {
                 }
             }
         }
-    }
-}
 
-/// Implementation based on breaking times into chains and being clever.
-mod interest_accumulator {
-
-    use std::fmt::Debug;
-
-    use ::Ring;
-    use lattice::Lattice;
-    use trace::Cursor;
-
-    use super::PerKeyCompute;
-    use super::consolidate;
-
-    pub struct InterestAccumulator<V1, V2, T, R1, R2>
-    where 
-        V1: Ord+Clone,
-        V2: Ord+Clone,
-        T: Lattice+Ord+Clone,
-        R1: Ring,
-        R2: Ring,
-    {
-        interestinator: Interestinator<T>,
-        input_accumulator: Accumulator<V1, T, R1>,
-        output_accumulator: Accumulator<V2, T, R2>,
-        yielded_accumulator: Accumulator<V2, T, R2>,
-        time_buffer1: Vec<(T, R1)>,
-        time_buffer2: Vec<(T, R2)>,
-        output_logic: Vec<(V2, R2)>,
-    }
-
-    impl<V1, V2, T, R1, R2> PerKeyCompute<V1, V2, T, R1, R2> for InterestAccumulator<V1, V2, T, R1, R2> 
-    where 
-        V1: Ord+Clone+Debug,
-        V2: Ord+Clone+Debug,
-        T: Lattice+Ord+Clone+Debug,
-        R1: Ring,
-        R2: Ring,
-    {
-        fn new() -> Self {
-            InterestAccumulator {
-                interestinator: Interestinator::new(),
-                input_accumulator: Accumulator::new(),
-                output_accumulator: Accumulator::new(),
-                yielded_accumulator: Accumulator::new(),
-                time_buffer1: Vec::new(),
-                time_buffer2: Vec::new(),
-                output_logic: Vec::new(),
-            }
-        }
-        fn compute<K, C1, C2, C3, L>(
-            &mut self,
-            key: &K, 
-            source_cursor: &mut C1, 
-            output_cursor: &mut C2, 
-            batch_cursors: &mut [C3], 
-            interesting_times: &mut Vec<T>, 
-            logic: &L,
-            upper_limit: &[T],
-            outputs: &mut [(T, Vec<(V2, T, R2)>)],
-            new_interesting: &mut Vec<T>) -> (usize, usize)
-        where 
-            K: Eq+Clone+Debug,
-            C1: Cursor<K, V1, T, R1>, 
-            C3: Cursor<K, V1, T, R1>, 
-            C2: Cursor<K, V2, T, R2>, 
-            L: Fn(&K, &[(V1, R1)], &mut Vec<(V2, R2)>)
-    {
-            // Determine the `meet` of times, useful in restricting updates to capture.
-            let mut meet = interesting_times[0].clone(); 
-            for index in 1 .. interesting_times.len() {
-                meet = meet.meet(&interesting_times[index]);
-            }
-
-            // clear accumulators (will now repopulate)
-            self.yielded_accumulator.clear();
-            self.yielded_accumulator.time = interesting_times[0].clone();
-
-            // Accumulate into `input_stage` and populate `input_edits`.
-            self.input_accumulator.clear();
-            self.input_accumulator.time = interesting_times[0].clone();
-            source_cursor.seek_key(&key);
-            if source_cursor.key_valid() && source_cursor.key() == key {
-                while source_cursor.val_valid() {
-                    let val: V1 = source_cursor.val().clone();
-                    let mut sum = R1::zero();
-
-                    source_cursor.map_times(|t,d| {
-
-                        // println!("INPUT UPDATE: {:?}, {:?}, {:?}, {:?}", key, val, t, d);
-
-                        if t.le(&self.input_accumulator.time) { 
-                            sum = sum + d; 
-                        }
-                        if !t.le(&meet) {
-                            self.time_buffer1.push((t.join(&meet), d));
-                        }
-                    });
-                    consolidate(&mut self.time_buffer1);
-                    self.input_accumulator.edits.extend(self.time_buffer1.drain(..).map(|(t,d)| (val.clone(), t, d)));
-                    if !sum.is_zero() {
-                        self.input_accumulator.accum.push((val, sum));
-                    }
-                    source_cursor.step_val();
-                }
-            }
-            self.input_accumulator.shackle();
-
-            // Accumulate into `output_stage` and populate `output_edits`. 
-            self.output_accumulator.clear();
-            self.output_accumulator.time = interesting_times[0].clone();
-            output_cursor.seek_key(&key);
-            if output_cursor.key_valid() && output_cursor.key() == key {
-                while output_cursor.val_valid() {
-                    let val: V2 = output_cursor.val().clone();
-                    let mut sum = R2::zero();
-                    output_cursor.map_times(|t,d| {
-                        if t.le(&self.output_accumulator.time) {
-                            sum = sum + d;
-                        }
-                        if !t.le(&meet) {
-                            self.time_buffer2.push((t.join(&meet), d));
-                        }
-                    });
-                    consolidate(&mut self.time_buffer2);
-                    self.output_accumulator.edits.extend(self.time_buffer2.drain(..).map(|(t,d)| (val.clone(), t, d)));
-                    if !sum.is_zero() {
-                        self.output_accumulator.accum.push((val, sum));
-                    }
-                    output_cursor.step_val();
-                }
-            }
-            self.output_accumulator.shackle();
-
-            self.interestinator.close_interesting_times(&self.input_accumulator.edits[..], interesting_times);
-
-            // each interesting time must be considered!
-            for this_time in interesting_times.drain(..) {
-
-                // not all times are ready to be finalized. stash them with the key.
-                if upper_limit.iter().any(|t| t.le(&this_time)) {
-                    new_interesting.push(this_time);
-                }
-                else {
-
-                    // 1. update `input_stage` and `output_stage` to `this_time`.
-                    self.input_accumulator.update_to(this_time.clone());
-                    self.output_accumulator.update_to(this_time.clone());
-                    self.yielded_accumulator.update_to(this_time.clone());
-
-                    // 2. apply user logic (only if non-empty input).
-                    self.output_logic.clear();
-                    if self.input_accumulator.accum.len() > 0 {
-                        logic(&key, &self.input_accumulator.accum[..], &mut self.output_logic);
-                    }
-
-                    // println!("key: {:?}, input: {:?}, ouput: {:?} @ {:?}", 
-                    //          key, &self.input_accumulator.accum[..], self.output_logic, this_time);
-
-                    // 3. subtract existing output differences.
-                    for &(ref val, diff) in &self.output_accumulator.accum[..] {
-                        self.output_logic.push((val.clone(), -diff));
-                    }
-                    // incorporate uncommitted output updates.
-                    for &(ref val, diff) in &self.yielded_accumulator.accum {
-                        self.output_logic.push((val.clone(), -diff));
-                    }
-                    consolidate(&mut self.output_logic);
-
-                    // 4. stashed produced updates in capability-indexed buffers, and `yielded_accumulator`.
-                    let idx = outputs.iter().rev().position(|&(ref time, _)| time.le(&this_time));
-                    let idx = idx.unwrap();
-                    let idx = outputs.len() - idx - 1;
-                    for (val, diff) in self.output_logic.drain(..) {
-                        self.yielded_accumulator.push_edit((val.clone(), this_time.clone(), diff));
-                        outputs[idx].1.push((val, this_time.clone(), diff));
+        // Joins `time` with the time of each active update and adds the result to `destination` if the 
+        // result is strictly greater than `time`.
+        fn join_with_into(&self, time: &T, destination: &mut Vec<T>) {
+            for history in self.values.iter() {
+                for &(ref t, _) in &self.times[history.lower .. history.valid] {
+                    if !t.le(time) {
+                        destination.push(t.join(time));
                     }
                 }
             }
-
-            (0, 0)
-        }
-    }
-
-    /// Allocated state and temporary buffers for closing interesting time under join.
-    #[derive(Default)]
-    struct Interestinator<T: Ord+Lattice+Clone> {
-
-        total: Vec<(T, isize)>,     // holds all times; a non-zero value indicates a new time.
-
-        old_accum: Vec<T>,          // accumulated old times, compacted via self.frontier.
-        new_accum: Vec<T>,          // accumulated new times, compacted via self.frontier.
-
-        entrance: Vec<(T, usize)>,  // times and self.total indices at which they enter self.frontier.
-        frontier: Vec<T>,           // allocation to hold the evolving frontier.
-
-        old_temp: Vec<T>,           // temporary storage to avoid 
-        new_temp: Vec<T>,
-    }
-
-    impl<T: Ord+Lattice+Clone+::std::fmt::Debug> Interestinator<T> {
-        fn new() -> Self {
-            Interestinator {
-                total: Vec::new(),
-                old_accum: Vec::new(),
-                new_accum: Vec::new(),
-                entrance: Vec::new(),
-                frontier: Vec::new(),
-                old_temp: Vec::new(),
-                new_temp: Vec::new(),
-            }
-        }
-
-        /// Extends `times` with the join of subsets of `edits` and `times` with at least one element from `times`.
-        ///
-        /// This method has a somewhat non-standard implementation in the aim of being "more linear", which makes it
-        /// a bit more complicated that you might think, and with possibly surprising performance. If this method shows
-        /// up on performance profiling, it may be worth asking for more information, as it is a work in progress.
-        #[inline(never)]
-        fn close_interesting_times<D, R>(&mut self, edits: &[(D, T, R)], times: &mut Vec<T>) {
-
-            // Candidate algorithm: sort list of (time, is_new) pairs describing old and new times. 
-            // We aim to do not much worse than processing times in this order. 
-            // 
-            // We will maintain a few accumulations to help us correctly maintain the set of new times.
-            //
-            //   Frontier: We track the elements in the frontier, identified in an initial reverse scan.
-            //   old_accum: We accumulate old times using the frontier, which I hope is correct.
-            //   new_accum: We accumulate new times using the frontier, which I hope is correct.
-            //
-            // For each time, we check whether the frontier changes, and if so perhaps update our accums.
-            // We then do something based on whether it is a new or old time:
-            // 
-            //   new time: join with each element of old_accum, add results + self to new_accum, re-close, emit.
-            //   old time: join with each element of new_accum, re-close, emit.
-            //
-            // We can either re-close the new_accum set with each element, or repeat the process with new
-            // synthetic times. In either case, we need to be careful to not leave a massive amount of work
-            // behind (e.g. if a closed new_accum becomes enormous and un-accumulable, bad news for us). It is 
-            // probably safe to close in place, as the in-order execution would do this anyhow.
-
-            if edits.len() + times.len() < 10 { 
-                self._close_interesting_times_reference(edits, times);
-            }
-            else {
-
-                // CLEVER IMPLEMENTATION
-                // 1. populate uniform list of times, and indicate whether they are for new or old times.
-                assert!(self.total.len() == 0);
-                self.total.reserve(edits.len() + times.len());
-                for &(_, ref time, _) in edits { self.total.push((time.clone(), 1)); }
-                for time in times.iter() { self.total.push((time.clone(), edits.len() as isize + 1)); }
-
-                consolidate(&mut self.total);
-
-                // 2. determine the frontiers by scanning list in reverse order (for each: when it exits frontier).
-                self.frontier.clear();
-                self.entrance.clear();
-                self.entrance.reserve(self.total.len());
-                let mut position = self.total.len();
-                while position > 0 {
-                    position -= 1;
-                    // "add" total[position] and seeing who drops == who is exposed when total[position] removed.
-                    let mut index = 0;
-                    while index < self.frontier.len() {
-                        if self.total[position].0.le(&self.frontier[index]) {
-                            self.entrance.push((self.frontier.swap_remove(index), position));
-                        }
-                        else {
-                            index += 1;
-                        }
-                    }
-                    self.frontier.push(self.total[position].0.clone());
-                }
-
-                // 3. swing through `total` and apply per-time thinkings.
-                self.old_temp.clear();
-                self.new_temp.clear();
-                self.old_accum.clear();
-                self.new_accum.clear();
-
-                for (index, (time, is_new)) in self.total.drain(..).enumerate() {
-                    
-                    if is_new > edits.len() as isize {
-                        for new_time in &self.new_accum {
-                            let join = time.join(new_time);
-                            if join != time { 
-                                self.new_temp.push(join.clone()); 
-                                times.push(join); 
-                            }
-                        }
-                        for t in self.new_temp.drain(..) { self.new_accum.push(t); }
-
-                        for old_time in &self.old_accum {
-                            let join = time.join(old_time);
-                            if join != time { 
-                                self.new_accum.push(join.clone()); 
-                                times.push(join); 
-                            }
-                        }
-                        self.new_accum.push(time.clone());
-                    }
-                    else {
-
-                        for new_time in &self.new_accum {
-                            let join = time.join(new_time);
-                            self.new_temp.push(join.clone()); 
-                            times.push(join); 
-                        }
-                        for t in self.new_temp.drain(..) { self.new_accum.push(t); }
-
-                        for old_time in &self.old_accum {
-                            let join = time.join(old_time);
-                            if join != time { self.old_temp.push(join); }
-                        }
-                        for t in self.old_temp.drain(..) { self.old_accum.push(t); }
-                        self.old_accum.push(time.clone());
-                    }
-
-            
-                    // update old_accum and new_accum with frontier changes, deduplicating.
-
-                    // TODO: Can we mantain frontiers corresponding to new times and the current `new_accum`, as all 
-                    //       future additions must be joined with such elements. This could reduce the complexity of 
-                    //       `old_accum` substantially, removing distinctions between irrelevant prior times.
-
-                    // a. remove time from frontier; it's not there any more.
-                    self.frontier.retain(|x| !x.eq(&time));
-                    // b. add any indicated elements
-                    while self.entrance.last().map(|x| x.1) == Some(index) {
-                        self.frontier.push(self.entrance.pop().unwrap().0);
-                    }
-
-                    if self.frontier.len() > 0 {
-                        // advance times in the old accumulation, sort and deduplicate.
-                        for time in &mut self.old_accum { *time = time.advance_by(&self.frontier[..]); }
-                        self.old_accum.sort();
-                        self.old_accum.dedup();
-                        // advance times in the new accumulation, sort and deduplicate.
-                        for time in &mut self.new_accum { *time = time.advance_by(&self.frontier[..]); }
-                        self.new_accum.sort();
-                        self.new_accum.dedup();
-                    }
-                }
-
-                times.sort();
-                times.dedup();
-
-                // assert_eq!(*times, reference);
-            }
-        }
-
-        /// Reference implementation for `close_interesting_times`, using lots more effort than should be needed.
-        fn _close_interesting_times_reference<D, R>(&mut self, edits: &[(D, T, R)], times: &mut Vec<T>) {
-
-            // REFERENCE IMPLEMENTATION (LESS CLEVER)
-            let times_len = times.len();
-            for position in 0 .. times_len {
-                for &(_, ref time, _) in edits {
-                    if !time.le(&times[position]) {
-                        let join = time.join(&times[position]);
-                        times.push(join);
-                    }
-                }
-            }
-            
-            let mut position = 0;
-            while position < times.len() {
-                for index in 0 .. position {
-                    if !times[index].le(&times[position]) {
-                        let join = times[index].join(&times[position]);
-                        times.push(join);
-                    }
-                }
-                position += 1;
-                times[position..].sort();
-                times.dedup();
-            }
-        }
-    }
-
-    /// Maintains an accumulation of updates over partially ordered times.
-    ///
-    /// The `Accumulator` tries to cleverly partition its input edits into "chains": totally ordered contiguous 
-    /// subsequences. These chains simplify updating of accumulations, as in each chain it is relatively easy to 
-    /// understand how mnay updates must be re-considered.
-    ///
-    /// Many of the methods on `Accumulator` require understanding of how they should be used. Perhaps this can
-    /// be fixed with an `AccumulatorBuilder` helper type, but the intended life-cycle is: the `Accumulator` is 
-    /// initially valid, and `push_edit` and `update_to` may be called at will. Direct manipulation of the public
-    /// fields (which we do) requires a call to `shackle` before using the `Accumulator` again (to rebuild the 
-    /// chains and correct the accumulation).
-    struct Accumulator<D: Ord+Clone, T: Lattice+Ord, R: Ring> {
-        pub time: T,
-        pub edits: Vec<(D, T, R)>,
-        pub chains: Vec<(usize, usize, usize)>,
-        pub accum: Vec<(D, R)>,
-    }
-
-    impl<D: Ord+Clone, T: Lattice+Ord+Debug, R: Ring> Accumulator<D, T, R> {
-
-        /// Allocates a new empty accumulator.
-        fn new() -> Self {
-            Accumulator {
-                time: T::min(),
-                edits: Vec::new(),
-                chains: Vec::new(),
-                accum: Vec::new(),
-            }
-        }
-
-        /// Clears the allocator and sets the time to `T::min()`.
-        fn clear(&mut self) {
-            self.time = T::min();
-            self.edits.clear();
-            self.chains.clear();
-            self.accum.clear();
-        }
-
-        /// Introduces edits into a live accumulation.
-        fn push_edit(&mut self, edit: (D, T, R)) {
-
-            // do we need a new chain?
-            if self.edits.len() == 0 || !self.edits[self.edits.len()-1].1.le(&edit.1) {
-                let edits = self.edits.len();
-                self.chains.push((edits, edits, edits + 1));
-                self.edits.push(edit);
-            }
-            else {
-                let chains = self.chains.len();
-                self.edits.push(edit);
-                self.chains[chains-1].2 = self.edits.len();
-            }
-
-            // we may need to advance the finger of the last chain by one.
-            let finger = self.chains[self.chains.len()-1].1;
-            if self.edits[finger].1.le(&self.time) {
-                self.accum.push((self.edits[finger].0.clone(), self.edits[finger].2));
-                let chains_len = self.chains.len();
-                self.chains[chains_len-1].1 += 1;
-            }
-        }
-
-        /// Sorts `edits` and forms chains.
-        fn shackle(&mut self) {
-
-            // consolidate2(&mut self.edits);
-            consolidate(&mut self.accum);
-
-            self.edits.sort_by(|x,y| x.1.cmp(&y.1));
-
-            let mut lower = 0;
-            for upper in 1 .. self.edits.len() {
-                if !self.edits[upper-1].1.le(&self.edits[upper].1) {
-                    self.chains.push((lower, lower, upper));
-                    lower = upper;
-                }
-            }
-
-            if self.edits.len() > 0 {
-                self.chains.push((lower, lower, self.edits.len()));
-            }
-
-            for chain in 0 .. self.chains.len() {
-                let mut finger = self.chains[chain].1;
-                while finger < self.chains[chain].2 && self.edits[finger].1.le(&self.time) {
-                    finger += 1;
-                }
-                self.chains[chain].1 = finger;
-            }
-
-            // if self.chains.len() > 5 { println!("chains: {:?}", self.chains.len()); }
-        }
-        
-        /// Updates the internal accumulation to correspond to `new_time`.
-        ///
-        /// This method traverses edits by chains, or totally ordered subsequences. It traverses
-        /// each chain at most once over the course of totally ordered updates, as it only moves
-        /// forward through each of its own internal chains. Although the method should be correct
-        /// for arbitrary sequences of times, the performance could be arbitrarily poor.
-
-        #[inline(never)]
-        fn update_to(&mut self, new_time: T) -> &[(D, R)] {
-
-            // println!("updating from {:?} to {:?}", self.time, new_time);
-
-            let meet = self.time.meet(&new_time);
-            for chain in 0 .. self.chains.len() {
-
-                // finger is the first element *not* `le` this.time.
-                let mut finger = self.chains[chain].1;
-
-                // possibly move forward, adding edits while times less than `new_time`.
-                while finger < self.chains[chain].2 && self.edits[finger].1.le(&new_time) {
-                    self.accum.push((self.edits[finger].0.clone(), self.edits[finger].2));
-                    finger += 1;
-                }
-                // possibly move backward, subtracting edits with times not less than `new_time`.
-                while finger > self.chains[chain].0 && !self.edits[finger-1].1.le(&new_time) {
-                    self.accum.push((self.edits[finger-1].0.clone(), -self.edits[finger-1].2));
-                    finger -= 1;                    
-                }
-
-                let position = ::std::cmp::min(self.chains[chain].1, finger);
-                self.chains[chain].1 = finger;
-
-                // from the lower end of updates things are less certain; 
-                while position > self.chains[chain].0 && !self.edits[position-1].1.le(&meet) {
-
-                    let le_prev = self.edits[position-1].1.le(&self.time);
-                    let le_this = self.edits[position-1].1.le(&new_time);
-                    if le_prev != le_this {
-                        if le_prev { self.accum.push((self.edits[position-1].0.clone(),-self.edits[position-1].2)); }
-                        else       { self.accum.push((self.edits[position-1].0.clone(), self.edits[position-1].2)); }
-                    }
-
-                }
-            }
-
-            self.time = new_time;
-            consolidate(&mut self.accum);
-            &self.accum[..]
         }
     }
 }

--- a/src/operators/group.rs
+++ b/src/operators/group.rs
@@ -33,12 +33,10 @@
 
 use std::fmt::Debug;
 use std::default::Default;
-use std::cmp::Ordering;
 
 use hashable::{Hashable, UnsignedWrapper};
 use ::{Data, Collection, Ring};
 
-// use timely::progress::Antichain;
 use timely::dataflow::*;
 use timely::dataflow::operators::Unary;
 use timely::dataflow::channels::pact::Pipeline;
@@ -155,11 +153,11 @@ where
             L: Fn(&K, &[(V, R)], &mut Vec<(V2, R2)>)+'static {
 
         let mut source_trace = self.new_handle();
-        let mut output_trace = TraceHandle::new(empty, &[<G::Timestamp as Lattice>::min()], &[<G::Timestamp as Lattice>::min()]);
+        let mut output_trace = TraceHandle::new(empty, &[G::Timestamp::min()], &[G::Timestamp::min()]);
         let result_trace = output_trace.clone();
 
-        // let mut thinker2 = InterestAccumulator::<V, V2, G::Timestamp, R, R2>::new();
-        let mut thinker2 = HistoryReplayer::<V, V2, G::Timestamp, R, R2>::new();
+        let mut thinker1 = interest_accumulator::InterestAccumulator::<V, V2, G::Timestamp, R, R2>::new();
+        let mut thinker2 = history_replay::HistoryReplayer::<V, V2, G::Timestamp, R, R2>::new();
         let mut temporary = Vec::<G::Timestamp>::new();
 
         // Our implementation maintains a list of outstanding `(key, time)` synthetic interesting times, 
@@ -170,8 +168,13 @@ where
         // buffers and logic for computing per-key interesting times "efficiently".
         let mut interesting_times = Vec::<G::Timestamp>::new();
 
+        // space for assembling the upper bound of times to process.
+        let mut upper_limit = Vec::<G::Timestamp>::new();
+
         // tracks frontiers received from batches, for sanity.
-        let mut lower_sanity = vec![<G::Timestamp as Lattice>::min()];
+        let mut upper_received = vec![<G::Timestamp as Lattice>::min()];
+
+        // We separately track the frontiers for what we have sent, and what we have sealed. 
         let mut lower_issued = vec![<G::Timestamp as Lattice>::min()];
 
         let id = self.stream.scope().index();
@@ -199,33 +202,64 @@ where
 
             let mut batch_cursors = Vec::new();
 
-            // capture each batch into our stash; update our view of the frontier.
+            // Drain the input stream of batches, validating the contiguity of the batch descriptions and
+            // capturing a cursor for each of the batches as well as ensuring we hold a capability for the
+            // times in the batch.
             input.for_each(|capability, batches| {
+
+                // In principle we could have multiple batches per message (in practice, it would be weird).
                 for batch in batches.drain(..).map(|x| x.item) {
-                    assert!(&lower_sanity[..] == batch.description().lower());
-                    lower_sanity = batch.description().upper().to_vec();
+                    assert!(&upper_received[..] == batch.description().lower());
+                    upper_received = batch.description().upper().to_vec();
                     batch_cursors.push(batch.cursor());                    
                 }
 
-                // update capabilities to also cover the capabilities of these batches.
+                // Ensure that `capabilities` covers the capability of the batch.
                 capabilities.retain(|cap| !capability.time().lt(&cap.time()));
                 if !capabilities.iter().any(|cap| cap.time().le(&capability.time())) {
                     capabilities.push(capability);
                 }
             });
 
-            // assemble frontier we will use from `upper` and our notificator frontier.
-            let mut upper_limit = notificator.frontier(0).to_vec();
-            upper_limit.retain(|t1| !lower_sanity.iter().any(|t2| t1.lt(t2)));
-            for time in &lower_sanity {
-                if !upper_limit.iter().any(|t1| time.le(t1)) {
-                    upper_limit.push(time.clone());
+            // The interval of times we can retire is upper bounded by both the most recently received batch
+            // upper bound (`upper_received`) and by the input progress frontier (`notificator.frontier(0)`).
+            // Any new changes must be at times in advance of *both* of these antichains, as both the batch 
+            // and the frontier guarantee no more updates at times not in advance of them.
+            //
+            // I think the right thing to do is define a new frontier from the joins of elements in the two
+            // antichains. Elements we will see in the future must be greater or equal to elements in both
+            // antichains, and so much be greater or equal to some pairwise join of the antichain elements.
+            // At the same time, any element greater than some pairwise join is greater than either antichain,
+            // and so could plausibly be seen in the future (and so is not safe to retire).
+            upper_limit.clear();
+            for time1 in notificator.frontier(0) {
+                for time2 in &upper_received {
+                    let join = time1.join(time2);
+                    if !upper_limit.iter().any(|t| t.le(&join)) {
+                        upper_limit.retain(|t| !join.le(t));
+                        upper_limit.push(join);
+                    }
                 }
             }
 
-            if batch_cursors.len() > 0 || interesting.len() > 0 {
+            // If we have no capabilities, then we (i) should not produce any outputs and (ii) could not send
+            // any produced outputs even if they were (incorrectly) produced. We cannot even send empty batches
+            // to indicate forward progress, and must hope that downstream operators look at progress frontiers
+            // as well as batch descriptions.
+            //
+            // We can (and should) advance source and output traces if `upper_limit` indicates this is possible.
+            if capabilities.iter().any(|c| !upper_limit.iter().any(|t| t.le(&c.time()))) {
 
-                // Our plan is to retire all updates not at times greater or equal to an element of `frontier`.
+                // println!("upper: {:?}", upper_limit);
+
+                // println!("working in group; advancing from, to:");
+                // println!("  capabilities: {:?}", capabilities);
+                // println!("  upper_limit:  {:?}", upper_limit);
+                // println!("  frontier:     {:?}", notificator.frontier(0));
+                // println!("  received:     {:?}", upper_received);
+
+                // `interesting` contains "warnings" about keys and times that may need to be re-considered.
+                // We first extract those times from this list that lie in the interval we will process.
                 sort_dedup(&mut interesting);
                 let mut new_interesting = Vec::new();
                 let mut exposed = Vec::new();
@@ -235,8 +269,14 @@ where
                 interesting = new_interesting;
 
                 // Prepare an output buffer and builder for each capability. 
-                // It would be better if all updates went into one batch, but timely dataflow prevents this as 
-                // long as there is only one capability for each message.
+                //
+                // We buffer and build separately, as outputs are produced grouped by time, whereas the 
+                // builder wants to see outputs grouped by value. While the per-key computation could 
+                // do the re-sorting itself, buffering per-key outputs lets us double check the results
+                // against other implementations for accuracy.
+                //
+                // TODO: It would be better if all updates went into one batch, but timely dataflow prevents 
+                //       this as long as it requires that there is only one capability for each message.
                 let mut buffers = Vec::<(G::Timestamp, Vec<(V2, G::Timestamp, R2)>)>::new();
                 let mut builders = Vec::new();
                 for i in 0 .. capabilities.len() {
@@ -248,34 +288,45 @@ where
                 let mut source_cursor: T1::Cursor = source_trace.cursor();
                 let mut output_cursor: T2::Cursor = output_trace.cursor();
 
-                let mut synth_position = 0;
-                batch_cursors.retain(|cursor| cursor.key_valid());
-                while batch_cursors.len() > 0 || synth_position < exposed.len() {
+                let mut compute_counter = 0;
+                let mut output_counter = 0;
+                let timer = ::std::time::Instant::now();
 
-                    // determine the next key we will work on; could be synthetic, could be from a batch.
+                // We now march through the keys we must work on, drawing from `batch_cursors` and `exposed`.
+                //
+                // We only keep valid cursors (those with more data) in `batch_cursors`, and so its length
+                // indicates whether more data remain. We move throuh `exposed` using `exposed_position`.
+                // There could perhaps be a less provocative variable name.
+                let mut exposed_position = 0;
+                batch_cursors.retain(|cursor| cursor.key_valid());
+                while batch_cursors.len() > 0 || exposed_position < exposed.len() {
+
+                    // Determine the next key we will work on; could be synthetic, could be from a batch.
                     let mut key = None;
-                    if synth_position < exposed.len() { key = Some(exposed[synth_position].0.clone()); }
+                    if exposed_position < exposed.len() { key = Some(exposed[exposed_position].0.clone()); }
                     for batch_cursor in &batch_cursors {
-                        if key == None { 
-                            key = Some(batch_cursor.key().clone()); 
-                        }
-                        else {
-                            key = key.map(|k| ::std::cmp::min(k, batch_cursor.key().clone()));
-                        }
+                        if key == None { key = Some(batch_cursor.key().clone()); }
+                        else           { key = key.map(|k| ::std::cmp::min(k, batch_cursor.key().clone())); }
                     }
                     debug_assert!(key.is_some());
                     let key = key.unwrap();
 
-                    // Prepare `interesting_times` for this key.
+                    // `interesting_times` contains those times between `lower_issued` and `upper_limit` 
+                    // that we need to re-consider. We now populate it, but perhaps this should be left
+                    // to the per-key computation, which may be able to avoid examining the times of some
+                    // values (for example, in the case of min/max/topk).
                     interesting_times.clear();
 
-                    // populate `interesting_times` with synthetic interesting times for this key.
-                    while synth_position < exposed.len() && exposed[synth_position].0 == key {
-                        interesting_times.push(exposed[synth_position].1.clone());
-                        synth_position += 1;
+                    // Populate `interesting_times` with synthetic interesting times for this key.
+                    while exposed_position < exposed.len() && exposed[exposed_position].0 == key {
+                        interesting_times.push(exposed[exposed_position].1.clone());
+                        exposed_position += 1;
                     }
 
-                    // populate `interesting_times` with times from newly accepted updates.
+                    // Populate `interesting_times` with times from newly accepted updates.
+                    // TODO: This work is partially redundant with the traversal of input updates, and 
+                    //       in clever implementations (e.g. min/max/topk) we may want to extract these 
+                    //       updates lazily.
                     for batch_cursor in &mut batch_cursors {
                         if batch_cursor.key_valid() && batch_cursor.key() == &key {
                             while batch_cursor.val_valid() {
@@ -293,13 +344,15 @@ where
 
                     // let mut interesting_times2 = interesting_times.clone();
                     // let mut buffers2 = buffers.clone();
+                    // let mut temp2 = Vec::new();
 
                     // do the per-key computation.
                     temporary.clear();
-                    thinker2.compute(
+                    let counters = thinker2.compute(
                         &key, 
                         &mut source_cursor, 
                         &mut output_cursor, 
+                        &mut batch_cursors[..],
                         &mut interesting_times, 
                         &logic, 
                         &upper_limit[..], 
@@ -307,11 +360,12 @@ where
                         &mut temporary,
                     );
 
+                    compute_counter += counters.0;
+                    output_counter += counters.1;
 
                     // source_cursor.rewind_vals();
                     // output_cursor.rewind_vals();
                     // // do the per-key computation.
-                    // let mut temp2 = Vec::new();
                     // thinker1.compute(
                     //     &key, 
                     //     &mut source_cursor, 
@@ -323,15 +377,36 @@ where
                     //     &mut temp2,
                     // );
 
+                    // if buffers != buffers2 {
+                    //     println!("PANIC: Unequal outputs!!! (key: {:?}:", key);
+                    //     for index in 0 .. buffers.len() {
+                    //         if buffers[index] != buffers2[index] {
+                    //             for thing in &buffers[index].1 { println!("  buff1[{}]: {:?}", index, thing); }
+                    //             for thing in &buffers2[index].1 { println!("  buff2[{}]: {:?}", index, thing); }
+                    //         }
+                    //     }
+                    // }
                     // assert_eq!(buffers, buffers2);
+
+                    // // if any of temp2 is not present in temporary, we may miss a time.
+                    // for time in &temp2 {
+                    //     if !temporary.iter().any(|t2| t2.le(&time)) {
+                    //         println!("PANIC: may miss time: {:?} for key: {:?}", time, key);
+                    //     }
+                    // }
+
                     // assert_eq!(temporary, temp2);
 
+                    // Record future warnings about interesting times (and assert they should be "future").
                     for time in temporary.drain(..) { 
                         assert!(upper_limit.iter().any(|t| t.le(&time)));
                         interesting.push((key.clone(), time)); 
                     }
 
-                    // move all updates for this key into corresponding builders.
+                    // Sort each buffer by value and move into the corresponding builder.
+                    // TODO: This makes assumptions about at least one of (i) the stability of `sort_by`, 
+                    //       (ii) that the buffers are time-ordered, and (iii) that the builders accept 
+                    //       arbitrarily ordered times.
                     for index in 0 .. buffers.len() {
                         buffers[index].1.sort_by(|x,y| x.0.cmp(&y.0));
                         for (val, time, diff) in buffers[index].1.drain(..) {
@@ -351,16 +426,15 @@ where
                         }
                     }
 
-                    let batch = builder.done(&lower_issued[..], &local_upper[..], &lower_issued[..]);
-                    lower_issued = local_upper;
-
-                    output.session(&capabilities[index]).give(BatchWrapper { item: batch.clone() });
-                    output_trace.wrapper.borrow_mut().trace.insert(batch);
+                    if lower_issued != local_upper {
+                        let batch = builder.done(&lower_issued[..], &local_upper[..], &lower_issued[..]);
+                        lower_issued = local_upper;
+                        output.session(&capabilities[index]).give(BatchWrapper { item: batch.clone() });
+                        output_trace.wrapper.borrow_mut().trace.insert(batch);
+                    }
                 }
 
-                assert!(lower_issued == upper_limit);
-
-                // update capabilities to reflect `interesting` pairs.
+                // Determine the frontier of our interesting times.
                 let mut frontier = Vec::<G::Timestamp>::new();
                 for &(_, ref time) in &interesting {                    
                     if !frontier.iter().any(|t| t.le(time)) {
@@ -369,7 +443,7 @@ where
                     }
                 }
 
-                // update capabilities (readable?)
+                // Update `capabilities` to reflect interesting pairs described by `frontier`.
                 let mut new_capabilities = Vec::new();
                 for time in frontier.drain(..) {
                     if let Some(cap) = capabilities.iter().find(|c| c.time().le(&time)) {
@@ -383,14 +457,28 @@ where
                     }
                 }
                 capabilities = new_capabilities;
+
+                // let mut ul = upper_limit.clone();
+                // ul.sort();
+
+                // let avg_ns = if compute_counter > 0 { (timer.elapsed() / compute_counter as u32).subsec_nanos() } else { 0 };
+                // println!("(key, times) pairs:\t{:?}\t{:?}\tavg {:?}ns\t{:?}", compute_counter, output_counter, avg_ns, ul);
             }
 
-            // We have processed all updates through `frontier`, and can advance input and output traces.
+            // We have processed all updates through `upper_limit` and will only use times in advance of 
+            // this frontier to compare against historical times, so we should allow the trace to start
+            // compacting batches by advancing times.
             source_trace.advance_by(&upper_limit[..]);
             output_trace.advance_by(&upper_limit[..]);
 
-            source_trace.distinguish_since(&upper_limit[..]);
-            output_trace.distinguish_since(&upper_limit[..]);
+            // We no longer need to distinguish between the batches we have received and historical batches,
+            // so we should allow the trace to start merging them.
+            //
+            // Note: We know that there will be no further times through `upper_limit`, but we still use the
+            // earlier `upper_received` to avoid antagonizing the trace which may end up with `upper_limit`
+            // cutting through a single (largely empty, at least near `upper_limit`) batch. 
+            source_trace.distinguish_since(&upper_received[..]);
+            output_trace.distinguish_since(&upper_received[..]);
         });
 
         Arranged { stream: stream, trace: result_trace }
@@ -408,13 +496,6 @@ fn sort_dedup_a<T: Ord>(list: &mut Vec<T>) {
 
 #[inline(never)]
 fn sort_dedup_b<T: Ord>(list: &mut Vec<T>) {
-    list.dedup();
-    list.sort();
-    list.dedup();
-}
-
-#[inline(never)]
-fn sort_dedup_c<T: Ord>(list: &mut Vec<T>) {
     list.dedup();
     list.sort();
     list.dedup();
@@ -486,1122 +567,1532 @@ where
     R2: Ring,
 {
     fn new() -> Self;
-    fn compute<K, C1, C2, L>(
+    fn compute<K, C1, C2, C3, L>(
         &mut self,
         key: &K, 
         input: &mut C1, 
         output: &mut C2, 
+        batches: &mut [C3],
         times: &mut Vec<T>, 
         logic: &L, 
         upper_limit: &[T],
         outputs: &mut [(T, Vec<(V2, T, R2)>)],
-        new_interesting: &mut Vec<T>) 
+        new_interesting: &mut Vec<T>) -> (usize, usize)
     where 
         K: Eq+Clone+Debug,
         C1: Cursor<K, V1, T, R1>, 
+        C3: Cursor<K, V1, T, R1>, 
         C2: Cursor<K, V2, T, R2>, 
         L: Fn(&K, &[(V1, R1)], &mut Vec<(V2, R2)>);
 }
 
 
-/// The `HistoryReplayer` is a compute strategy based on moving through existing inputs, interesting times, etc in 
-/// time order, maintaining consolidated representations of updates with respect to future interesting times.
-struct HistoryReplayer<V1, V2, T, R1, R2> 
-where
-    V1: Ord+Clone,
-    V2: Ord+Clone,
-    T: Lattice+Ord+Clone,
-    R1: Ring,
-    R2: Ring,
-{
-    input_history: CollectionHistory<V1, T, R1>,
-    input_actions: Vec<(T, usize)>,
-    output_history: CollectionHistory<V2, T, R2>,
-    output_actions: Vec<(T, usize)>,
-    input_buffer: Vec<(V1, R1)>,
-    output_buffer: Vec<(V2, R2)>,
-    output_produced: Vec<((V2, T), R2)>,
-    known_times: Vec<T>,
-    synth_times: Vec<T>,
-    meets: Vec<T>,
-    times_current: Vec<T>,
-    lower: Vec<T>,
-}
+/// Implementation based on replaying historical and new updates together.
+mod history_replay {
 
-impl<V1, V2, T, R1, R2> HistoryReplayer<V1, V2, T, R1, R2> 
-where
-    V1: Ord+Clone+Debug,
-    V2: Ord+Clone+Debug,
-    T: Lattice+Ord+Clone+Debug,
-    R1: Ring+Debug,
-    R2: Ring+Debug,
-{
-    #[inline(never)]
-    fn build_input_history<K, C1>(&mut self, key: &K, source_cursor: &mut C1, meet: &T, _upper_limit: &[T]) 
-    where K: Eq+Clone+Debug, C1: Cursor<K, V1, T, R1>, {
+    use std::fmt::Debug;
+    use std::cmp::Ordering;
 
-        self.input_history.clear();
-        self.input_actions.clear();
+    use ::Ring;
+    use lattice::Lattice;
+    use trace::Cursor;
 
-        source_cursor.seek_key(&key);
-        if source_cursor.key_valid() && source_cursor.key() == key {
-            while source_cursor.val_valid() {
-                let start = self.input_history.times.len();
-                source_cursor.map_times(|t, d| {
-                    // if format!("{:?}", key) == "OrdWrapper { item: 0 }".to_owned() {
-                    //     println!("key 0 input:\t{:?}, {:?}", t, d);
-                    // }
+    use super::{PerKeyCompute, consolidate, sort_dedup_a, sort_dedup_b, consolidate_from};
 
-                    let join = t.join(&meet);
-                    if _upper_limit.iter().any(|t| t.le(&join)) {
-                        if !self.known_times.iter().any(|t| t.le(&join)) {
-                            self.known_times.retain(|t| !join.le(t));
-                            self.known_times.push(join);
-                        }
-                    }
-                    else {
-                        self.input_history.times.push((join, d));
-                    }
-                });
-                self.input_history.seal_from(source_cursor.val().clone(), start);
-                source_cursor.step_val();
-            }
-        }
 
-        self.input_actions.reserve(self.input_history.times.len());
-        for (index, history) in self.input_history.values.iter().enumerate() {
-            for offset in history.lower .. history.upper {
-                // if format!("{:?}", key) == "OrdWrapper { item: 0 }".to_owned() {
-                //     println!("key 0 input:\t{:?}, {:?}, {:?}", self.input_history.times[offset].0, self.input_history.values[index].value, self.input_history.times[offset].1);
-                // }
-                self.input_actions.push((self.input_history.times[offset].0.clone(), index));
-            }
-        }
 
-        // TODO: this could have been a merge; helpful if few values. (perhaps it is with mergesort!)
-        self.sort_input_actions();
-    }
-
-    #[inline(never)]
-    fn sort_input_actions(&mut self) {
-        self.input_actions.sort_by(|x,y| x.0.cmp(&y.0));
-    }
-
-    #[inline(never)]
-    fn build_output_history<K, C2>(&mut self, key: &K, output_cursor: &mut C2, meet: &T, _upper_limit: &[T]) 
-    where K: Eq+Clone+Debug, C2: Cursor<K, V2, T, R2>, {
-
-        self.output_history.clear();
-        self.output_actions.clear();
-
-        output_cursor.seek_key(&key);
-        if output_cursor.key_valid() && output_cursor.key() == key {
-            while output_cursor.val_valid() {
-                let start = self.output_history.times.len();
-                output_cursor.map_times(|t, d| {
-
-                    // if format!("{:?}", key) == "OrdWrapper { item: 0 }".to_owned() {
-                    //     println!("key 0 output:\t{:?}, {:?}", t, d);
-                    // }
-
-                    let join = t.join(&meet);
-                    if _upper_limit.iter().any(|t| t.le(&join)) {
-                        if !self.known_times.iter().any(|t| t.le(&join)) {
-                            self.known_times.retain(|t| !join.le(t));
-                            self.known_times.push(join);
-                        }
-                    }
-                    else {
-                        self.output_history.times.push((join, d));
-                    }
-                });
-                self.output_history.seal_from(output_cursor.val().clone(), start);
-                output_cursor.step_val();
-            }
-        }
-
-        self.output_actions.reserve(self.output_history.times.len());
-        for (index, history) in self.output_history.values.iter().enumerate() {
-            for offset in history.lower .. history.upper {
-                // if format!("{:?}", key) == "OrdWrapper { item: 0 }".to_owned() {
-                //     println!("key 0 output:\t{:?}, {:?}, {:?}", self.output_history.times[offset].0, self.output_history.values[index].value, self.output_history.times[offset].1);
-                // }
-                self.output_actions.push((self.output_history.times[offset].0.clone(), index));
-            }
-        }
-
-        // TODO: this could have been a merge; helpful if few values. (perhaps it is with mergesort!)
-        self.output_actions.sort_by(|x,y| x.0.cmp(&y.0)); 
-
-        // println!("{:?}", key);
-        // if format!("{:?}", key) == "OrdWrapper { item: 0 }".to_owned() {
-        //     println!("hey: {:?}", meet);
-        // }
-    }
-}
-
-impl<V1, V2, T, R1, R2> PerKeyCompute<V1, V2, T, R1, R2> for HistoryReplayer<V1, V2, T, R1, R2> 
-where
-    V1: Ord+Clone+Debug,
-    V2: Ord+Clone+Debug,
-    T: Lattice+Ord+Clone+Debug,
-    R1: Ring+Debug,
-    R2: Ring+Debug,
-{
-    fn new() -> Self {
-        HistoryReplayer { 
-            input_history: CollectionHistory::new(),
-            input_actions: Vec::new(),
-            output_history: CollectionHistory::new(),
-            output_actions: Vec::new(),
-            input_buffer: Vec::new(),
-            output_buffer: Vec::new(),
-            output_produced: Vec::new(),
-            known_times: Vec::new(),
-            synth_times: Vec::new(),
-            meets: Vec::new(),
-            times_current: Vec::new(),
-            lower: Vec::new(),
-        }
-    }
-    #[inline(never)]
-    fn compute<K, C1, C2, L>(
-        &mut self,
-        key: &K, 
-        source_cursor: &mut C1, 
-        output_cursor: &mut C2, 
-        times: &mut Vec<T>, 
-        logic: &L, 
-        upper_limit: &[T],
-        outputs: &mut [(T, Vec<(V2, T, R2)>)],
-        new_interesting: &mut Vec<T>) 
-    where 
-        K: Eq+Clone+Debug,
-        C1: Cursor<K, V1, T, R1>, 
-        C2: Cursor<K, V2, T, R2>, 
-        L: Fn(&K, &[(V1, R1)], &mut Vec<(V2, R2)>) 
+    /// The `HistoryReplayer` is a compute strategy based on moving through existing inputs, interesting times, etc in 
+    /// time order, maintaining consolidated representations of updates with respect to future interesting times.
+    pub struct HistoryReplayer2<V1, V2, T, R1, R2> 
+    where
+        V1: Ord+Clone,
+        V2: Ord+Clone,
+        T: Lattice+Ord+Clone,
+        R1: Ring,
+        R2: Ring,
     {
+        input_history: CollectionHistory<V1, T, R1>,
+        output_history: CollectionHistory<V2, T, R2>,
+        input_buffer: Vec<(V1, R1)>,
+        output_buffer: Vec<(V2, R2)>,
+        output_produced: Vec<((V2, T), R2)>,
+        known_times: Vec<T>,
+        synth_times: Vec<T>,
+        meets: Vec<T>,
+        times_current: Vec<T>,
+        lower: Vec<T>,
+    }
 
-        // we use meets[0], and this should be true anyhow (otherwise, don't call).
-        assert!(times.len() > 0);
-
-        // determine a lower frontier of interesting times.
-        self.lower.clear();
-        for time in times.drain(..) {
-            if !self.lower.iter().any(|t| t.le(&time)) { 
-                self.lower.retain(|t| !time.lt(t));
-                self.lower.push(time);
+    impl<V1, V2, T, R1, R2> PerKeyCompute<V1, V2, T, R1, R2> for HistoryReplayer2<V1, V2, T, R1, R2> 
+    where
+        V1: Ord+Clone+Debug,
+        V2: Ord+Clone+Debug,
+        T: Lattice+Ord+Clone+Debug,
+        R1: Ring+Debug,
+        R2: Ring+Debug,
+    {
+        fn new() -> Self {
+            HistoryReplayer2 { 
+                input_history: CollectionHistory::new(),
+                output_history: CollectionHistory::new(),
+                input_buffer: Vec::new(),
+                output_buffer: Vec::new(),
+                output_produced: Vec::new(),
+                known_times: Vec::new(),
+                synth_times: Vec::new(),
+                meets: Vec::new(),
+                times_current: Vec::new(),
+                lower: Vec::new(),
             }
         }
+        #[inline(never)]
+        fn compute<K, C1, C2, C3, L>(
+            &mut self,
+            key: &K, 
+            source_cursor: &mut C1, 
+            output_cursor: &mut C2, 
+            batch_cursors: &mut [C3],
+            times: &mut Vec<T>, 
+            logic: &L, 
+            upper_limit: &[T],
+            outputs: &mut [(T, Vec<(V2, T, R2)>)],
+            new_interesting: &mut Vec<T>) -> (usize, usize)
+        where 
+            K: Eq+Clone+Debug,
+            C1: Cursor<K, V1, T, R1>, 
+            C3: Cursor<K, V1, T, R1>, 
+            C2: Cursor<K, V2, T, R2>, 
+            L: Fn(&K, &[(V1, R1)], &mut Vec<(V2, R2)>) 
+        {
+            // We determine the output changes for times not in advance of `upper_limit` by enumerating and 
+            // then exploring all times found in `
 
-        // experimenting with meet vs frontiers for advancing (good for distributive lattices).
-        // could also just use `lower` for advancing if we find it isn't too painful.
-        let mut meet = self.lower.iter().fold(T::max(), |meet, time| meet.meet(time));
 
-        self.known_times.clear();
 
-        // The fast-forwarding we are about to do with input and output can result in very weird looking
-        // data. In particular, we can have "old" updates in the future of "new" updates, and even beyond
-        // the frontier of work we can do. We should not take their times as indications of anything other
-        // than whether they should be included in accumulations.
-        //
-        // We extract input and output updates into flat value-indexed arrays, each range of which we sort
-        // by time so that the history for a value is always a prefix of its range. As we proceed through 
-        // time we extend the valid ranges.
+            // we use meets[0], and this should be true anyhow (otherwise, don't call).
+            assert!(times.len() > 0);
 
-        self.build_input_history(key, source_cursor, &meet, upper_limit);
-        self.build_output_history(key, output_cursor, &meet, upper_limit);
+            // determine a lower frontier of interesting times.
+            self.lower.clear();
+            for time in times.drain(..) {
+                if !self.lower.iter().any(|t| t.le(&time)) { 
+                    self.lower.retain(|t| !time.lt(t));
+                    self.lower.push(time);
+                }
+            }
 
-        // TODO: We should be able to thin out any updates at times that, advanced, are greater than some
-        //       element of `upper_limit`, as we will never incorporate that update. We should take care 
-        //       to notice these times, if we need to report them as interesting times, but once we have 
-        //       done that we can ditch the updates.
+            // All times we encounter will be at least `meet`, and so long as we just join with and compare 
+            // against interesting times, it is safe to advance all historical times by `meet`. 
+            //
+            // NOTE: This works fine for distributive lattices, but `advance_by` is more precise. This is a 
+            //       bit of an experiment to see what the difference might be. We may want to switch back to
+            //       `advance_by` in the future to make it more robust.
+            let mut meet = self.lower.iter().fold(T::max(), |meet, time| meet.meet(time));
 
-        // TODO: We should be able to restrict our attention down to just those times that are the joins
-        //       of times evident in the input and output. This could be useful in cases like `distinct`,
-        //       where the input updates collapse down to relatively fewer distinct moments.
+            // We build "histories" of the input and output, with respect to the times we may encounter in this
+            // invocation of `compute`. This means we advance times by joining them with `meet`, which can yield
+            // somewhat odd updates; we should not take the advanced times as anything other than a time that is
+            // safe to use for joining with and `le` testing against times in the interval.
+            //
+            // These histories act as caches in front of each cursor. They should provide the same functionality,
+            // but are capable of compacting their representation as we proceed through the computation.
 
-        self.synth_times.clear();
-        self.times_current.clear();
-        self.output_produced.clear();
+            self.input_history.reload(key, source_cursor, &meet);
+            self.output_history.reload(key, output_cursor, &meet);
 
-        {   // populate `self.known_times` with times from the input, output, and the `times` argument.
+            // TODO: We should be able to thin out any updates at times that, advanced, are greater than some
+            //       element of `upper_limit`, as we will never incorporate that update. We should take care 
+            //       to notice these times, if we need to report them as interesting times, but once we have 
+            //       done that we can ditch the updates.
+            // NOTE: Doing this removes a certain amount of precision, in that we can no longer see to which
+            //       values the times correspond, and perhaps be less interested if the value is not observed.
+            //       Similarly, we lose the ability to see that updates cancel at some point; this may be less
+            //       common, if the "future" updates we would join with are largely historical, and so not 
+            //       changing in this invocation of `compute`.
+            // NOTE: Not done at the moment. The precision is reassuring for correctness.
+
+            // TODO: We should be able to restrict our attention down to just those times that are the joins
+            //       of times evident in the input and output. This could be useful in cases like `distinct`,
+            //       where the input updates collapse down to relatively fewer distinct moments.
+            // NOTE: One simple version of this is to just start with the times of the lower bound, and the 
+            //       times present in the input or output, ignoring `times` completely. I think this might be
+            //       a good "reference implementation", and it could/should check that each element of `times`
+            //       is actually considered. The non-emptiness of `times` would still drive whether we evaluate
+            //       a key for any given interval, and it is still important to correctly produce it as output.
+            // NOTE: We pay no attention to which times are "new" which are required for interesting times. We
+            //       could require that each time be interesting, in that it is the join that includes at least
+            //       one new update (from `batch_cursors`, which we do not have access to here) or `times`.
+
+            self.synth_times.clear();
+            self.times_current.clear();
+            self.output_produced.clear();
+
+            {   // Populate `self.known_times` with times from the input, output, and the `times` argument.
+                
+                self.known_times.clear();
+
+                // Merge the times in input actions and output actions.
+                let mut input_slice = &self.input_history.actions[..];
+                let mut output_slice = &self.output_history.actions[..];
+
+                while input_slice.len() > 0 || output_slice.len() > 0 {
+
+                    // Determine the next time.
+                    let mut next = T::max();
+                    if input_slice.len() > 0 && input_slice[0].0.cmp(&next) == Ordering::Less {
+                        next = input_slice[0].0.clone();
+                    }
+                    if output_slice.len() > 0 && output_slice[0].0.cmp(&next) == Ordering::Less {
+                        next = output_slice[0].0.clone();
+                    }
+
+                    // Advance each slice until we reach a new time.
+                    while input_slice.len() > 0 && input_slice[0].0 == next {
+                        input_slice = &input_slice[1..];
+                    }
+                    while output_slice.len() > 0 && output_slice[0].0 == next {
+                        output_slice = &output_slice[1..];
+                    }
+
+                    self.known_times.push(next);
+                }
+            }
+
+            {   // Populate `self.meets` with the meets of suffixes of `self.known_times`.
+
+                // As we move through `self.known_times`, we want to collapse down historical updates, even
+                // those that were distinct at the beginning of the interval. To do this, we track the `meet`
+                // of each suffix of `self.known_times`, and use this to advance times in update histories.
+
+                self.meets.clear();
+                self.meets.reserve(self.known_times.len());
+                self.meets.extend(self.known_times.iter().cloned());
+                for i in (1 .. self.meets.len()).rev() {
+                    self.meets[i-1] = self.meets[i-1].meet(&self.meets[i]);
+                }
+            }
+
+            // we track our position in each of our lists of actions using slices; 
+            // as we pull work from the front, we advance the slice. we could have
+            // used drain iterators, but we want to peek at the next element and 
+            // this seemed like the simplest way to do that.
+
+            let mut known_slice = &self.known_times[..];
+            let mut meets_slice = &self.meets[..];
+
+            let mut compute_counter = 0;
+            let mut output_counter = 0;
+
+            // Times to process can either by "known" a priori, or "synth"-etic times produced as 
+            // the joins of updates and interesting times. As long as we have either, we should continue
+            // to do work.
+            while known_slice.len() > 0 || self.synth_times.len() > 0 {
+
+                // Determine the next time to process.
+                let mut next_time = T::max();
+                if known_slice.len() > 0 && next_time.cmp(&known_slice[0]) == Ordering::Greater {
+                    next_time = known_slice[0].clone();
+                }
+                if self.synth_times.len() > 0 && next_time.cmp(&self.synth_times[0]) == Ordering::Greater {
+                    next_time = self.synth_times[0].clone();
+                }
+
+                // Advance `known_slice` and `synth_times` past `next_time`.
+                while known_slice.len() > 0 && known_slice[0] == next_time {
+                    known_slice = &known_slice[1..];
+                    meets_slice = &meets_slice[1..];
+                }
+                while self.synth_times.len() > 0 && self.synth_times[0] == next_time {
+                    self.synth_times.remove(0); // <-- TODO: this could be a min-heap.
+                }
+
+                // Advance each history that we track.
+                // TODO: Add batch history somewhere.
+                self.input_history.advance_through(&next_time);
+                self.output_history.advance_through(&next_time);
+
+                // We should only process times that are not in advance of `upper_limit`. 
+                //
+                // We have no particular guarantee that known times will not be in advance of `upper_limit`.
+                // We may have the guarantee that synthetic times will not be, as we test against the limit
+                // before we add the time to `synth_times`.
+                if !upper_limit.iter().any(|t| t.le(&next_time)) {
+
+                    compute_counter += 1;
+
+                    // Assemble the input collection at `next_time`. (`self.input_buffer` cleared just after use).
+                    debug_assert!(self.input_buffer.is_empty());
+                    self.input_history.insert(&next_time, &meet, &mut self.input_buffer);
+
+                    // Apply user logic if non-empty input and see what happens!
+                    self.output_buffer.clear();
+                    if self.input_buffer.len() > 0 {
+                        logic(key, &self.input_buffer[..], &mut self.output_buffer);
+                        self.input_buffer.clear();
+                    }
             
-            // TODO: This could be a merge (perhaps it is, if we use mergesort).
-            let mut input_slice = &self.input_actions[..];
-            let mut output_slice = &self.output_actions[..];
+                    // Subtract relevant output differences to determine the difference between the intended 
+                    // output and the actual current output. Note: we have two places where output differences
+                    // live: `output_history` and `output_produced`; the former are those output updates from
+                    // the output trace, and the latter are output updates we have produced as this invocation
+                    // of `compute` has executed.
+                    //
+                    // TODO: This could perhaps be done better, as `output_history` is grouped by value and we
+                    //       also eventually want to group `output_produced` by value. Perhaps we can manage
+                    //       each organized by value and then sort only `self.output_buffer` and merge whatever
+                    //       results to see output updates. A log-structured merge list would work, but is more
+                    //       engineering than I can pinch off right now.
 
-            while input_slice.len() > 0 || output_slice.len() > 0 {
-                let mut next = T::max();
-                if input_slice.len() > 0 && input_slice[0].0.cmp(&next) == Ordering::Less {
-                    next = input_slice[0].0.clone();
-                }
-                if output_slice.len() > 0 && output_slice[0].0.cmp(&next) == Ordering::Less {
-                    next = output_slice[0].0.clone();
-                }
-
-
-                while input_slice.len() > 0 && input_slice[0].0 == next {
-                    input_slice = &input_slice[1..];
-                }
-                while output_slice.len() > 0 && output_slice[0].0 == next {
-                    output_slice = &output_slice[1..];
-                }
-
-                self.known_times.push(next);
-            }
-
-            // for &(ref time, _) in &self.input_actions { self.known_times.push(time.clone()); }
-            // for &(ref time, _) in &self.output_actions { self.known_times.push(time.clone()); }
-
-            sort_dedup_c(&mut self.known_times);
-        }
-
-        {   // populate `self.meets` with the meets of suffixes of `self.known_times`.
-
-            self.meets.clear();
-            self.meets.reserve(self.known_times.len());
-            self.meets.extend(self.known_times.iter().cloned());
-            for i in (1 .. self.meets.len()).rev() {
-                self.meets[i-1] = self.meets[i-1].meet(&self.meets[i]);
-            }
-        }
-
-        // we track our position in each of our lists of actions using slices; 
-        // as we pull work from the front, we advance the slice. we could have
-        // used drain iterators, but we want to peek at the next element and 
-        // this seemed like the simplest way to do that.
-        let mut input_slice = &self.input_actions[..];
-        let mut output_slice = &self.output_actions[..];
-
-        let mut known_slice = &self.known_times[..];
-        let mut meets_slice = &self.meets[..];
-
-        while known_slice.len() > 0 || self.synth_times.len() > 0 {
-
-            // determine the next time to process.
-            let mut next_time = T::max();
-            if known_slice.len() > 0 && next_time.cmp(&known_slice[0]) == Ordering::Greater {
-                next_time = known_slice[0].clone();
-            }
-            if self.synth_times.len() > 0 && next_time.cmp(&self.synth_times[0]) == Ordering::Greater {
-                next_time = self.synth_times[0].clone();
-            }
-
-            // advance `known_slice` and `synth_times` as appropriate.
-            while known_slice.len() > 0 && known_slice[0] == next_time {
-                known_slice = &known_slice[1..];
-                meets_slice = &meets_slice[1..];
-            }
-            while self.synth_times.len() > 0 && self.synth_times[0] == next_time {
-                self.synth_times.remove(0); // <-- this should really be a min-heap.
-            }
-
-            // advance valid ranges of inputs and outputs for this time.
-            while input_slice.len() > 0 && input_slice[0].0 == next_time {
-                let value_index = input_slice[0].1;
-                self.input_history.step(value_index);
-                input_slice = &input_slice[1..];
-            }
-            while output_slice.len() > 0 && output_slice[0].0 == next_time {
-                let value_index = output_slice[0].1;
-                self.output_history.step(value_index);
-                output_slice = &output_slice[1..];
-            }
-
-            // we should only process times that are not in the future.
-            if !upper_limit.iter().any(|t| t.le(&next_time)) {
-
-                // assemble input collection (`self.input_buffer` cleared just after use).
-                debug_assert!(self.input_buffer.is_empty());
-                self.input_history.insert(&next_time, &meet, &mut self.input_buffer);
-
-                // apply user logic and see what happens!
-                self.output_buffer.clear();
-                if self.input_buffer.len() > 0 {
-                    logic(key, &self.input_buffer[..], &mut self.output_buffer);
-                    self.input_buffer.clear();
-                }
-        
-                // spill output differences into `self.output_buffer`. 
-                // this could probably be done much better, but we currently produce new output
-                // updates that we cannot (easily) pack into `self.output_history`. so for now we
-                // just have a big pile of output updates and hope that it is painful enough to fix.
-
-                // subtracts pre-existing output updates maintained in `self.output_history`.
-                self.output_history.remove(&next_time, &meet, &mut self.output_buffer);
-                // subtracts newly formed output updates maintained in `self.output_produced`.
-                for &((ref value, ref time), diff) in self.output_produced.iter() {
-                    if time.le(&next_time) {
-                        self.output_buffer.push((value.clone(), -diff));
-                    }
-                }
-
-                // we can't rely on user code to do this (plus it's presently all a mess anyhow).
-                consolidate(&mut self.output_buffer);
-
-                // stash produced updates in capability-indexed buffers, and `output_updates`.
-                if self.output_buffer.len() > 0 {
-
-                    // any times not greater than `lower` must be empty (and should be skipped, but testing!)
-                    assert!(self.lower.iter().any(|t| t.le(&next_time)));
-
-                    let idx = outputs.iter().rev().position(|&(ref time, _)| time.le(&next_time));
-                    let idx = outputs.len() - idx.unwrap() - 1;
-                    for (val, diff) in self.output_buffer.drain(..) {
-                        self.output_produced.push(((val.clone(), next_time.clone()), diff));
-                        outputs[idx].1.push((val, next_time.clone(), diff));
-                    }
-
-                    // consolidate `self.output_produced`.
-                    for entry in &mut self.output_produced {
-                        (entry.0).1 = (entry.0).1.join(&meet);
-                    }
-                    consolidate(&mut self.output_produced);
-
-                }
-
-                // determine synthetic interesting times!
-                // could just join `next_time` with all times in `input_updates` and `output_updates`.
-                // could also just retire to some beach and drink a lot. that is not why we are here!
-
-                for time in &self.times_current {
-                    let join = next_time.join(time);
-                    if join != next_time {
-                        // enqueue `join` if not beyond `upper_limit`; else add to `new_interesting` frontier.
-                        if !upper_limit.iter().any(|t| t.le(&join)) {
-                            self.synth_times.push(join); 
+                    self.output_history.remove(&next_time, &meet, &mut self.output_buffer);
+                    for &((ref value, ref time), diff) in self.output_produced.iter() {
+                        if time.le(&next_time) {
+                            self.output_buffer.push((value.clone(), -diff));
                         }
-                        else {
-                            if outputs.iter().any(|&(ref t,_)| t.le(&join)) {
-                                if !new_interesting.iter().any(|t| t.le(&join)) { 
-                                    new_interesting.retain(|t| !join.lt(t));
-                                    // if !outputs.iter().any(|&(ref t,_)| t.le(&join)) {
-                                    //     panic!("warning about time w/o capability");
-                                    // }
+                    }
+
+                    // Having subtracted output updates from user output, consolidate the results to determine
+                    // if there is anything worth reporting. Note: this also orders the results by value, so 
+                    // that could make the above merging plan even easier. 
+                    consolidate(&mut self.output_buffer);
+
+                    // Stash produced updates into both capability-indexed buffers and `output_produced`. 
+                    // The two locations are important, in that we will compact `output_produced` as we move 
+                    // through times, but we cannot compact the output buffers because we need their actual
+                    // times.
+                    if self.output_buffer.len() > 0 {
+
+                        output_counter += 1;
+
+                        // any times not greater than `lower` must be empty (and should be skipped, but testing!)
+                        assert!(self.lower.iter().any(|t| t.le(&next_time)));
+
+                        // We *should* be able to find a capability for `next_time`. Any thing else would 
+                        // indicate a logical error somewhere along the way; either we release a capability 
+                        // we should have kept, or we have computed the output incorrectly (or both!)
+                        let idx = outputs.iter().rev().position(|&(ref time, _)| time.le(&next_time));
+                        let idx = outputs.len() - idx.unwrap() - 1;
+                        for (val, diff) in self.output_buffer.drain(..) {
+                            self.output_produced.push(((val.clone(), next_time.clone()), diff));
+                            outputs[idx].1.push((val, next_time.clone(), diff));
+                        }
+
+                        // Advance times in `self.output_produced` and consolidate the representation.
+                        // NOTE: We only do this when we add records; it could be that there are situations 
+                        //       where we want to consolidate even without changes (because an initially
+                        //       large collection can now be collapsed).
+                        for entry in &mut self.output_produced {
+                            (entry.0).1 = (entry.0).1.join(&meet);
+                        }
+                        consolidate(&mut self.output_produced);
+
+                    }
+
+                    // Determine synthetic interesting times.
+                    //
+                    // This implementation makes the pessimistic assumption that the time we consider could 
+                    // be joined with any other time we have seen in this invocation, and that the result 
+                    // could possibly be interesting. That isn't wrong, but it is very conservative.
+                    // 
+                    // Other options include:
+                    //     1. Accumulate updates from `batch` separately, and only join input and output times
+                    //        against times present in the current accumulation of `batch`. Times that cancel
+                    //        don't need to be interesting. 
+                    //     2. Notice which times are observed by the user logic, specifically those times that
+                    //        were considered but discarded by user logic, indicating that something different
+                    //        could happen when the update becomes active.
+                    //     3. Only emit the lower bound of joined times, ignoring any joined times greater than
+                    //        those warned about, on the premise that when the warned time is considered we can
+                    //        warn about further times, if they still seem interesting (e.g., their times have
+                    //        not yet cancelled). This may require some assumptions about how times warn about
+                    //        future times, to make sure we don't miss things (might fight with other opts).
+
+                    for time in &self.times_current {
+                        if !time.le(&next_time) {
+
+                            // The joined time may be available to process in this interval, in which case we 
+                            // should enqueue it (we may not be able to process it immediately, and there may
+                            // be input or output updates at the same time to integrate).
+                            // Otherwise, enqueue the joined time in the `new_interesting` list of future warnings.
+                            let join = next_time.join(time);
+                            if !upper_limit.iter().any(|t| t.le(&join)) {
+                                self.synth_times.push(join); 
+                            }
+                            else {
+                                // NOTE: This implementation only warns about the lower bound of observed warnings.
+                                //       I'm a bit worried about this, because I'm not really sure the advantages
+                                //       (compactness) outweight the downsides (imprecision).
+                                // NOTE: We may need to discard warnings that are not in advance of capabilities.
+                                //       I guess this could happen if we previously had evidence that no outputs
+                                //       would be produced for a time, and then lost track of that evidence. The
+                                //       outer `group` logic will panic if it cannot find a capability for elements
+                                //       of `new_interesting`, and we should probably suppress such but notice them
+                                //       and confirm that they are not logic bugs (e.g., for each suppressed time
+                                //       determine when we released its capability, and understand why that was ok).
+                                if outputs.iter().any(|&(ref t,_)| t.le(&join)) {
                                     new_interesting.push(join);
-                                }                        
+                                }
+                                else {
+                                    // TODO: Should we tell someone?
+                                }
                             }
                         }
                     }
                 }
-            }
-            else {  
-                // otherwise we delay the time for the future (and warn about it)
-                if outputs.iter().any(|&(ref t,_)| t.le(&next_time)) {
-                    if !new_interesting.iter().any(|t| t.le(&next_time)) { 
-                        new_interesting.retain(|t| !next_time.lt(t));
+                else {  
+
+                    // If the time is not in advance of `upper_limit`, we should not process it but instead enqueue
+                    // it for future re-consideration. As above, we may need to discard updates that are not in 
+                    // advance of some capability. For example, just because we saw an advanced time for an input
+                    // or output update does not mean that we hold the capability to produce outputs at that time.
+                    // If we have previously released the capability, we have committed to *not* producing output at
+                    // that time, and we should respect that (also, the outer `group` logic will panic).
+                    if outputs.iter().any(|&(ref t,_)| t.le(&next_time)) {
                         new_interesting.push(next_time.clone());
-                        // if !outputs.iter().any(|&(ref t,_)| t.le(&next_time)) {
-                        //     panic!("warning about time w/o capability");
-                        // }
+                    }
+                    else {
+                        // TODO: Should we tell someone?
+                        // NOTE: Not incorrect to be here, if it is due to advanced input or output update times.
                     }
                 }
-            }
 
-            self.times_current.push(next_time);
+                // Record `next_time` as a time we considered, for future times to join against.
+                self.times_current.push(next_time);
 
-            // update our view of the meet of remaining times. 
-            // NOTE: this does not advance collections, which can be done value-by-value as appropriate.
-            if meets_slice.len() > 0 || self.synth_times.len() > 0 {
-                meet = self.synth_times.iter().fold(T::max(), |meet, time| meet.meet(time));
-                if meets_slice.len() > 0 { meet = meet.meet(&meets_slice[0]); }
-                // for time in &self.synth_times { meet = meet.meet(time); }
+                // Update `meet`, and advance and deduplicate times is `self.times_current`.
+                // NOTE: This does not advance input or output collections, which is done when the are accumulated.
+                if meets_slice.len() > 0 || self.synth_times.len() > 0 {
 
-                for time in &mut self.times_current {
-                    *time = time.join(&meet);
+                    // Start from `T::max()` and take the meet with each synthetic time. Also meet with the first 
+                    // element of `meets_slice` if it exists.
+                    meet = self.synth_times.iter().fold(T::max(), |meet, time| meet.meet(time));
+                    if meets_slice.len() > 0 { meet = meet.meet(&meets_slice[0]); }
+
+                    // Advance and deduplicate `self.times_current`.
+                    for time in &mut self.times_current {
+                        *time = time.join(&meet);
+                    }
+                    sort_dedup_a(&mut self.times_current);
                 }
-                sort_dedup_a(&mut self.times_current);
+
+                // Sort and deduplicate `self.synth_times`. This is our poor replacement for a min-heap, but works.
+                sort_dedup_b(&mut self.synth_times);
             }
 
-            // again, this should be a min-heap.
-            sort_dedup_b(&mut self.synth_times);
+            // Normalize the representation of `new_interesting`, deduplicating and ordering. 
+            // NOTE: This only makes sense for as long as we track the lower frontier. Once we track more precise
+            //       times, we will have non-trivial deduplication to perform here. The logic will be similar, but
+            //       the current `debug_assert!` will not be correct (it asserts "already deduplicated").
+            new_interesting.sort();
+            new_interesting.dedup();
+
+            (compute_counter, output_counter)
+        }
+    }
+
+
+
+    /// The `HistoryReplayer` is a compute strategy based on moving through existing inputs, interesting times, etc in 
+    /// time order, maintaining consolidated representations of updates with respect to future interesting times.
+    pub struct HistoryReplayer<V1, V2, T, R1, R2> 
+    where
+        V1: Ord+Clone,
+        V2: Ord+Clone,
+        T: Lattice+Ord+Clone,
+        R1: Ring,
+        R2: Ring,
+    {
+        input_history: CollectionHistory<V1, T, R1>,
+        output_history: CollectionHistory<V2, T, R2>,
+        input_buffer: Vec<(V1, R1)>,
+        output_buffer: Vec<(V2, R2)>,
+        output_produced: Vec<((V2, T), R2)>,
+        known_times: Vec<T>,
+        synth_times: Vec<T>,
+        meets: Vec<T>,
+        times_current: Vec<T>,
+        lower: Vec<T>,
+    }
+
+    impl<V1, V2, T, R1, R2> PerKeyCompute<V1, V2, T, R1, R2> for HistoryReplayer<V1, V2, T, R1, R2> 
+    where
+        V1: Ord+Clone+Debug,
+        V2: Ord+Clone+Debug,
+        T: Lattice+Ord+Clone+Debug,
+        R1: Ring+Debug,
+        R2: Ring+Debug,
+    {
+        fn new() -> Self {
+            HistoryReplayer { 
+                input_history: CollectionHistory::new(),
+                output_history: CollectionHistory::new(),
+                input_buffer: Vec::new(),
+                output_buffer: Vec::new(),
+                output_produced: Vec::new(),
+                known_times: Vec::new(),
+                synth_times: Vec::new(),
+                meets: Vec::new(),
+                times_current: Vec::new(),
+                lower: Vec::new(),
+            }
+        }
+        #[inline(never)]
+        fn compute<K, C1, C2, C3, L>(
+            &mut self,
+            key: &K, 
+            source_cursor: &mut C1, 
+            output_cursor: &mut C2, 
+            batch_cursors: &mut [C3], 
+            times: &mut Vec<T>, 
+            logic: &L, 
+            upper_limit: &[T],
+            outputs: &mut [(T, Vec<(V2, T, R2)>)],
+            new_interesting: &mut Vec<T>) -> (usize, usize)
+        where 
+            K: Eq+Clone+Debug,
+            C1: Cursor<K, V1, T, R1>, 
+            C3: Cursor<K, V1, T, R1>, 
+            C2: Cursor<K, V2, T, R2>, 
+            L: Fn(&K, &[(V1, R1)], &mut Vec<(V2, R2)>) 
+        {
+
+            // we use meets[0], and this should be true anyhow (otherwise, don't call).
+            assert!(times.len() > 0);
+
+            // determine a lower frontier of interesting times.
+            self.lower.clear();
+            for time in times.drain(..) {
+                if !self.lower.iter().any(|t| t.le(&time)) { 
+                    self.lower.retain(|t| !time.lt(t));
+                    self.lower.push(time);
+                }
+            }
+
+            // All times we encounter will be at least `meet`, and so long as we just join with and compare 
+            // against interesting times, it is safe to advance all historical times by `meet`. 
+            //
+            // NOTE: This works fine for distributive lattices, but `advance_by` is more precise. This is a 
+            //       bit of an experiment to see what the difference might be. We may want to switch back to
+            //       `advance_by` in the future to make it more robust.
+            let mut meet = self.lower.iter().fold(T::max(), |meet, time| meet.meet(time));
+
+            // We build "histories" of the input and output, with respect to the times we may encounter in this
+            // invocation of `compute`. This means we advance times by joining them with `meet`, which can yield
+            // somewhat odd updates; we should not take the advanced times as anything other than a time that is
+            // safe to use for joining with and `le` testing against times in the interval.
+            //
+            // These histories act as caches in front of each cursor. They should provide the same functionality,
+            // but are capable of compacting their representation as we proceed through the computation.
+
+            self.input_history.reload(key, source_cursor, &meet);
+            self.output_history.reload(key, output_cursor, &meet);
+
+            // TODO: We should be able to thin out any updates at times that, advanced, are greater than some
+            //       element of `upper_limit`, as we will never incorporate that update. We should take care 
+            //       to notice these times, if we need to report them as interesting times, but once we have 
+            //       done that we can ditch the updates.
+            // NOTE: Doing this removes a certain amount of precision, in that we can no longer see to which
+            //       values the times correspond, and perhaps be less interested if the value is not observed.
+            //       Similarly, we lose the ability to see that updates cancel at some point; this may be less
+            //       common, if the "future" updates we would join with are largely historical, and so not 
+            //       changing in this invocation of `compute`.
+            // NOTE: Not done at the moment. The precision is reassuring for correctness.
+
+            // TODO: We should be able to restrict our attention down to just those times that are the joins
+            //       of times evident in the input and output. This could be useful in cases like `distinct`,
+            //       where the input updates collapse down to relatively fewer distinct moments.
+            // NOTE: One simple version of this is to just start with the times of the lower bound, and the 
+            //       times present in the input or output, ignoring `times` completely. I think this might be
+            //       a good "reference implementation", and it could/should check that each element of `times`
+            //       is actually considered. The non-emptiness of `times` would still drive whether we evaluate
+            //       a key for any given interval, and it is still important to correctly produce it as output.
+            // NOTE: We pay no attention to which times are "new" which are required for interesting times. We
+            //       could require that each time be interesting, in that it is the join that includes at least
+            //       one new update (from `batch_cursors`, which we do not have access to here) or `times`.
+
+            self.synth_times.clear();
+            self.times_current.clear();
+            self.output_produced.clear();
+
+            {   // Populate `self.known_times` with times from the input, output, and the `times` argument.
+                
+                self.known_times.clear();
+
+                // Merge the times in input actions and output actions.
+                let mut input_slice = &self.input_history.actions[..];
+                let mut output_slice = &self.output_history.actions[..];
+
+                while input_slice.len() > 0 || output_slice.len() > 0 {
+
+                    // Determine the next time.
+                    let mut next = T::max();
+                    if input_slice.len() > 0 && input_slice[0].0.cmp(&next) == Ordering::Less {
+                        next = input_slice[0].0.clone();
+                    }
+                    if output_slice.len() > 0 && output_slice[0].0.cmp(&next) == Ordering::Less {
+                        next = output_slice[0].0.clone();
+                    }
+
+                    // Advance each slice until we reach a new time.
+                    while input_slice.len() > 0 && input_slice[0].0 == next {
+                        input_slice = &input_slice[1..];
+                    }
+                    while output_slice.len() > 0 && output_slice[0].0 == next {
+                        output_slice = &output_slice[1..];
+                    }
+
+                    self.known_times.push(next);
+                }
+            }
+
+            {   // Populate `self.meets` with the meets of suffixes of `self.known_times`.
+
+                // As we move through `self.known_times`, we want to collapse down historical updates, even
+                // those that were distinct at the beginning of the interval. To do this, we track the `meet`
+                // of each suffix of `self.known_times`, and use this to advance times in update histories.
+
+                self.meets.clear();
+                self.meets.reserve(self.known_times.len());
+                self.meets.extend(self.known_times.iter().cloned());
+                for i in (1 .. self.meets.len()).rev() {
+                    self.meets[i-1] = self.meets[i-1].meet(&self.meets[i]);
+                }
+            }
+
+            // we track our position in each of our lists of actions using slices; 
+            // as we pull work from the front, we advance the slice. we could have
+            // used drain iterators, but we want to peek at the next element and 
+            // this seemed like the simplest way to do that.
+
+            let mut known_slice = &self.known_times[..];
+            let mut meets_slice = &self.meets[..];
+
+            let mut compute_counter = 0;
+            let mut output_counter = 0;
+
+            // Times to process can either by "known" a priori, or "synth"-etic times produced as 
+            // the joins of updates and interesting times. As long as we have either, we should continue
+            // to do work.
+            while known_slice.len() > 0 || self.synth_times.len() > 0 {
+
+                // Determine the next time to process.
+                let mut next_time = T::max();
+                if known_slice.len() > 0 && next_time.cmp(&known_slice[0]) == Ordering::Greater {
+                    next_time = known_slice[0].clone();
+                }
+                if self.synth_times.len() > 0 && next_time.cmp(&self.synth_times[0]) == Ordering::Greater {
+                    next_time = self.synth_times[0].clone();
+                }
+
+                // Advance `known_slice` and `synth_times` past `next_time`.
+                while known_slice.len() > 0 && known_slice[0] == next_time {
+                    known_slice = &known_slice[1..];
+                    meets_slice = &meets_slice[1..];
+                }
+                while self.synth_times.len() > 0 && self.synth_times[0] == next_time {
+                    self.synth_times.remove(0); // <-- TODO: this could be a min-heap.
+                }
+
+                // Advance each history that we track.
+                // TODO: Add batch history somewhere.
+                self.input_history.advance_through(&next_time);
+                self.output_history.advance_through(&next_time);
+
+                // We should only process times that are not in advance of `upper_limit`. 
+                //
+                // We have no particular guarantee that known times will not be in advance of `upper_limit`.
+                // We may have the guarantee that synthetic times will not be, as we test against the limit
+                // before we add the time to `synth_times`.
+                if !upper_limit.iter().any(|t| t.le(&next_time)) {
+
+                    compute_counter += 1;
+
+                    // Assemble the input collection at `next_time`. (`self.input_buffer` cleared just after use).
+                    debug_assert!(self.input_buffer.is_empty());
+                    self.input_history.insert(&next_time, &meet, &mut self.input_buffer);
+
+                    // Apply user logic if non-empty input and see what happens!
+                    self.output_buffer.clear();
+                    if self.input_buffer.len() > 0 {
+                        logic(key, &self.input_buffer[..], &mut self.output_buffer);
+                        self.input_buffer.clear();
+                    }
+            
+                    // Subtract relevant output differences to determine the difference between the intended 
+                    // output and the actual current output. Note: we have two places where output differences
+                    // live: `output_history` and `output_produced`; the former are those output updates from
+                    // the output trace, and the latter are output updates we have produced as this invocation
+                    // of `compute` has executed.
+                    //
+                    // TODO: This could perhaps be done better, as `output_history` is grouped by value and we
+                    //       also eventually want to group `output_produced` by value. Perhaps we can manage
+                    //       each organized by value and then sort only `self.output_buffer` and merge whatever
+                    //       results to see output updates. A log-structured merge list would work, but is more
+                    //       engineering than I can pinch off right now.
+
+                    self.output_history.remove(&next_time, &meet, &mut self.output_buffer);
+                    for &((ref value, ref time), diff) in self.output_produced.iter() {
+                        if time.le(&next_time) {
+                            self.output_buffer.push((value.clone(), -diff));
+                        }
+                    }
+
+                    // Having subtracted output updates from user output, consolidate the results to determine
+                    // if there is anything worth reporting. Note: this also orders the results by value, so 
+                    // that could make the above merging plan even easier. 
+                    consolidate(&mut self.output_buffer);
+
+                    // Stash produced updates into both capability-indexed buffers and `output_produced`. 
+                    // The two locations are important, in that we will compact `output_produced` as we move 
+                    // through times, but we cannot compact the output buffers because we need their actual
+                    // times.
+                    if self.output_buffer.len() > 0 {
+
+                        output_counter += 1;
+
+                        // any times not greater than `lower` must be empty (and should be skipped, but testing!)
+                        assert!(self.lower.iter().any(|t| t.le(&next_time)));
+
+                        // We *should* be able to find a capability for `next_time`. Any thing else would 
+                        // indicate a logical error somewhere along the way; either we release a capability 
+                        // we should have kept, or we have computed the output incorrectly (or both!)
+                        let idx = outputs.iter().rev().position(|&(ref time, _)| time.le(&next_time));
+                        let idx = outputs.len() - idx.unwrap() - 1;
+                        for (val, diff) in self.output_buffer.drain(..) {
+                            self.output_produced.push(((val.clone(), next_time.clone()), diff));
+                            outputs[idx].1.push((val, next_time.clone(), diff));
+                        }
+
+                        // Advance times in `self.output_produced` and consolidate the representation.
+                        // NOTE: We only do this when we add records; it could be that there are situations 
+                        //       where we want to consolidate even without changes (because an initially
+                        //       large collection can now be collapsed).
+                        for entry in &mut self.output_produced {
+                            (entry.0).1 = (entry.0).1.join(&meet);
+                        }
+                        consolidate(&mut self.output_produced);
+
+                    }
+
+                    // Determine synthetic interesting times.
+                    //
+                    // This implementation makes the pessimistic assumption that the time we consider could 
+                    // be joined with any other time we have seen in this invocation, and that the result 
+                    // could possibly be interesting. That isn't wrong, but it is very conservative.
+                    // 
+                    // Other options include:
+                    //     1. Accumulate updates from `batch` separately, and only join input and output times
+                    //        against times present in the current accumulation of `batch`. Times that cancel
+                    //        don't need to be interesting. 
+                    //     2. Notice which times are observed by the user logic, specifically those times that
+                    //        were considered but discarded by user logic, indicating that something different
+                    //        could happen when the update becomes active.
+                    //     3. Only emit the lower bound of joined times, ignoring any joined times greater than
+                    //        those warned about, on the premise that when the warned time is considered we can
+                    //        warn about further times, if they still seem interesting (e.g., their times have
+                    //        not yet cancelled). This may require some assumptions about how times warn about
+                    //        future times, to make sure we don't miss things (might fight with other opts).
+
+                    for time in &self.times_current {
+                        if !time.le(&next_time) {
+
+                            // The joined time may be available to process in this interval, in which case we 
+                            // should enqueue it (we may not be able to process it immediately, and there may
+                            // be input or output updates at the same time to integrate).
+                            // Otherwise, enqueue the joined time in the `new_interesting` list of future warnings.
+                            let join = next_time.join(time);
+                            if !upper_limit.iter().any(|t| t.le(&join)) {
+                                self.synth_times.push(join); 
+                            }
+                            else {
+                                // NOTE: This implementation only warns about the lower bound of observed warnings.
+                                //       I'm a bit worried about this, because I'm not really sure the advantages
+                                //       (compactness) outweight the downsides (imprecision).
+                                // NOTE: We may need to discard warnings that are not in advance of capabilities.
+                                //       I guess this could happen if we previously had evidence that no outputs
+                                //       would be produced for a time, and then lost track of that evidence. The
+                                //       outer `group` logic will panic if it cannot find a capability for elements
+                                //       of `new_interesting`, and we should probably suppress such but notice them
+                                //       and confirm that they are not logic bugs (e.g., for each suppressed time
+                                //       determine when we released its capability, and understand why that was ok).
+                                if outputs.iter().any(|&(ref t,_)| t.le(&join)) {
+                                    new_interesting.push(join);
+                                }
+                                else {
+                                    // TODO: Should we tell someone?
+                                }
+                            }
+                        }
+                    }
+                }
+                else {  
+
+                    // If the time is not in advance of `upper_limit`, we should not process it but instead enqueue
+                    // it for future re-consideration. As above, we may need to discard updates that are not in 
+                    // advance of some capability. For example, just because we saw an advanced time for an input
+                    // or output update does not mean that we hold the capability to produce outputs at that time.
+                    // If we have previously released the capability, we have committed to *not* producing output at
+                    // that time, and we should respect that (also, the outer `group` logic will panic).
+                    if outputs.iter().any(|&(ref t,_)| t.le(&next_time)) {
+                        new_interesting.push(next_time.clone());
+                    }
+                    else {
+                        // TODO: Should we tell someone?
+                        // NOTE: Not incorrect to be here, if it is due to advanced input or output update times.
+                    }
+                }
+
+                // Record `next_time` as a time we considered, for future times to join against.
+                self.times_current.push(next_time);
+
+                // Update `meet`, and advance and deduplicate times is `self.times_current`.
+                // NOTE: This does not advance input or output collections, which is done when the are accumulated.
+                if meets_slice.len() > 0 || self.synth_times.len() > 0 {
+
+                    // Start from `T::max()` and take the meet with each synthetic time. Also meet with the first 
+                    // element of `meets_slice` if it exists.
+                    meet = self.synth_times.iter().fold(T::max(), |meet, time| meet.meet(time));
+                    if meets_slice.len() > 0 { meet = meet.meet(&meets_slice[0]); }
+
+                    // Advance and deduplicate `self.times_current`.
+                    for time in &mut self.times_current {
+                        *time = time.join(&meet);
+                    }
+                    sort_dedup_a(&mut self.times_current);
+                }
+
+                // Sort and deduplicate `self.synth_times`. This is our poor replacement for a min-heap, but works.
+                sort_dedup_b(&mut self.synth_times);
+            }
+
+            // Normalize the representation of `new_interesting`, deduplicating and ordering. 
+            // NOTE: This only makes sense for as long as we track the lower frontier. Once we track more precise
+            //       times, we will have non-trivial deduplication to perform here. The logic will be similar, but
+            //       the current `debug_assert!` will not be correct (it asserts "already deduplicated").
+            new_interesting.sort();
+            new_interesting.dedup();
+
+            (compute_counter, output_counter)
+        }
+    }
+
+    // tracks 
+    struct ValueHistory<V> {
+        value: V,
+        lower: usize,
+        clean: usize,
+        valid: usize,
+        upper: usize,
+    }
+
+    struct CollectionHistory<V: Clone, T: Lattice+Ord+Clone, R: Ring> {
+        pub values: Vec<ValueHistory<V>>,
+        pub actions: Vec<(T, usize)>,
+        action_cursor: usize,
+        pub times: Vec<(T, R)>,
+    }
+
+    impl<V: Clone, T: Lattice+Ord+Clone+Debug, R: Ring> CollectionHistory<V, T, R> {
+        fn new() -> Self {
+            CollectionHistory {
+                values: Vec::new(),
+                actions: Vec::new(),
+                action_cursor: 0,
+                times: Vec::new(),
+            }
         }
 
-        new_interesting.sort();
-        for index in 1 .. new_interesting.len() {
-            debug_assert!(new_interesting[index-1].cmp(&new_interesting[index]) == Ordering::Less);
+        fn reload<K, C>(&mut self, key: &K, cursor: &mut C, meet: &T) 
+        where K: Eq+Clone+Debug, C: Cursor<K, V, T, R> { 
+
+            self.values.clear();
+            self.actions.clear();
+            self.action_cursor = 0;
+            self.times.clear();
+
+            cursor.seek_key(&key);
+            if cursor.key_valid() && cursor.key() == key {
+                while cursor.val_valid() {
+                    // let val: V1 = source_cursor.val().clone();
+                    let start = self.times.len();
+                    cursor.map_times(|t, d| {
+                        // println!("  INPUT: ({:?}, {:?}, {:?}, {:?})", key, val, t, d);
+                        self.times.push((t.join(&meet), d));
+                    });
+                    self.seal_from(cursor.val().clone(), start);
+                    cursor.step_val();
+                }
+            }
+
+            self.build_actions();
         }
 
-        // println!("input_diffs: {:?}, output_diffs: {:?}", self.input_actions.len(), self.output_actions.len());
+        /// Advances the indexed value by one, with the ability to compact times by `meet`.
+        fn advance_through(&mut self, time: &T) {
+            while self.action_cursor < self.actions.len() && self.actions[self.action_cursor].0.cmp(time) != Ordering::Greater {
+                self.values[self.actions[self.action_cursor].1].valid += 1;
+                self.action_cursor += 1;
+            }
+        }
+
+        #[inline(never)]
+        fn collapse(&mut self, value_index: usize, meet: &T) {
+
+            let lower = self.values[value_index].lower;
+            let valid = self.values[value_index].valid;
+
+            for index in lower .. valid {
+                self.times[index].0 = self.times[index].0.join(meet);
+            }
+
+            // consolidating updates with equal times (post-join).
+            self.times[lower .. valid].sort_by(|x,y| x.0.cmp(&y.0));
+
+            // only need to collapse if there are at least two updates.
+            if lower < valid - 1 {
+
+                // now to collapse updates *forward*, to end at `valid`.
+                let mut cursor = valid - 1;
+                for index in (lower .. valid - 1).rev() {
+                    if self.times[index].0 == self.times[cursor].0 {
+                        self.times[cursor].1 = self.times[cursor].1 + self.times[index].1;
+                        self.times[index].1 = R::zero();
+                    }
+                    else {
+                        if !self.times[cursor].1.is_zero() {
+                            cursor -= 1;
+                        }
+                        self.times.swap(cursor, index);
+                    }
+                }
+                // if the final element accumulated to zero, advance `cursor`.
+                if self.times[cursor].1.is_zero() {
+                    cursor += 1;
+                }
+                
+                // // should be a range of zeros, .. 
+                // debug_assert!(lower <= cursor);
+                // for index in lower .. cursor {
+                //     debug_assert!(self.times[index].1.is_zero());
+                // }
+                // // .. followed by a range of non-zeros.
+                // debug_assert!(cursor <= valid);
+                // for index in cursor .. valid {
+                //     debug_assert!(!self.times[index].1.is_zero());
+                // }
+
+                self.values[value_index].lower = cursor;
+                self.values[value_index].clean = valid;
+            }
+        }
+
+        fn seal_from(&mut self, value: V, start: usize) {
+
+            // collapse down the updates
+            consolidate_from(&mut self.times, start);
+
+            // if non-empty, push range info for value.
+            if self.times.len() > start {
+                self.values.push(ValueHistory {
+                    value: value,
+                    lower: start,
+                    clean: start,
+                    valid: start,
+                    upper: self.times.len(),
+                });
+            }
+        }
+
+        // Builds time-sorted list `self.actions` of what happens for each time.
+        fn build_actions(&mut self) {
+
+            self.actions.clear();
+            self.actions.reserve(self.times.len());
+            for (index, history) in self.values.iter().enumerate() {
+                for offset in history.lower .. history.upper {
+                    self.actions.push((self.times[offset].0.clone(), index));
+                }
+            }
+
+            self.actions.sort_by(|x,y| x.0.cmp(&y.0));
+        }
+
+        #[inline(never)]
+        fn insert(&mut self, time: &T, meet: &T, destination: &mut Vec<(V, R)>) {
+
+            for value_index in 0 .. self.values.len() {
+
+                let lower = self.values[value_index].lower;
+                let clean = self.values[value_index].clean;
+                let valid = self.values[value_index].valid;
+
+                // take the time to collapse if there are changes. 
+                // this is not the only reason to collapse, and we may want to be more or less aggressive
+                if clean < valid {
+                    self.collapse(value_index, meet);
+                }
+
+                let mut sum = R::zero();
+                for index in lower .. valid {
+                    if self.times[index].0.le(time) {
+                        sum = sum + self.times[index].1;
+                    }
+                }
+                if !sum.is_zero() {
+                    destination.push((self.values[value_index].value.clone(), sum));
+                    // return;  // <-- cool optimization for top_k
+                }
+            }
+        }
+
+        #[inline(never)]
+        fn remove(&mut self, time: &T, meet: &T, destination: &mut Vec<(V, R)>) {
+
+            for value_index in 0 .. self.values.len() {
+
+                let lower = self.values[value_index].lower;
+                let clean = self.values[value_index].clean;
+                let valid = self.values[value_index].valid;
+
+                // take the time to collapse if there are changes. 
+                // this is not the only reason to collapse, and we may want to be more or less aggressive
+                if clean < valid {
+                    self.collapse(value_index, meet);
+                }
+
+                let mut sum = R::zero();
+                for index in lower .. valid {
+                    if self.times[index].0.le(time) {
+                        sum = sum - self.times[index].1;
+                    }
+                }
+                if !sum.is_zero() {
+                    destination.push((self.values[value_index].value.clone(), sum));
+                }
+            }
+        }
     }
 }
 
-// tracks 
-struct ValueHistory<V> {
-    value: V,
-    lower: usize,
-    clean: usize,
-    valid: usize,
-    upper: usize,
-}
+/// Implementation based on breaking times into chains and being clever.
+mod interest_accumulator {
 
-struct CollectionHistory<V: Clone, T: Lattice+Ord+Clone, R: Ring> {
-    pub values: Vec<ValueHistory<V>>,
-    pub times: Vec<(T, R)>,
-}
+    use std::fmt::Debug;
 
-impl<V: Clone, T: Lattice+Ord+Clone+Debug, R: Ring> CollectionHistory<V, T, R> {
-    fn new() -> Self { 
-        CollectionHistory {
-            values: Vec::new(),
-            times: Vec::new(),
+    use ::Ring;
+    use lattice::Lattice;
+    use trace::Cursor;
+
+    use super::PerKeyCompute;
+    use super::consolidate;
+
+    pub struct InterestAccumulator<V1, V2, T, R1, R2>
+    where 
+        V1: Ord+Clone,
+        V2: Ord+Clone,
+        T: Lattice+Ord+Clone,
+        R1: Ring,
+        R2: Ring,
+    {
+        interestinator: Interestinator<T>,
+        input_accumulator: Accumulator<V1, T, R1>,
+        output_accumulator: Accumulator<V2, T, R2>,
+        yielded_accumulator: Accumulator<V2, T, R2>,
+        time_buffer1: Vec<(T, R1)>,
+        time_buffer2: Vec<(T, R2)>,
+        output_logic: Vec<(V2, R2)>,
+    }
+
+    impl<V1, V2, T, R1, R2> PerKeyCompute<V1, V2, T, R1, R2> for InterestAccumulator<V1, V2, T, R1, R2> 
+    where 
+        V1: Ord+Clone+Debug,
+        V2: Ord+Clone+Debug,
+        T: Lattice+Ord+Clone+Debug,
+        R1: Ring,
+        R2: Ring,
+    {
+        fn new() -> Self {
+            InterestAccumulator {
+                interestinator: Interestinator::new(),
+                input_accumulator: Accumulator::new(),
+                output_accumulator: Accumulator::new(),
+                yielded_accumulator: Accumulator::new(),
+                time_buffer1: Vec::new(),
+                time_buffer2: Vec::new(),
+                output_logic: Vec::new(),
+            }
         }
-    }
-    fn clear(&mut self) {
-        self.values.clear();
-        self.times.clear();
-    }
-    /// Advances the indexed value by one, with the ability to compact times by `meet`.
-    fn step(&mut self, value_index: usize) {
-        // we should not have run out of updates to incorporate.
-        debug_assert!(self.values[value_index].valid < self.values[value_index].upper);        
-        self.values[value_index].valid += 1;
-    }
+        fn compute<K, C1, C2, C3, L>(
+            &mut self,
+            key: &K, 
+            source_cursor: &mut C1, 
+            output_cursor: &mut C2, 
+            batch_cursors: &mut [C3], 
+            interesting_times: &mut Vec<T>, 
+            logic: &L,
+            upper_limit: &[T],
+            outputs: &mut [(T, Vec<(V2, T, R2)>)],
+            new_interesting: &mut Vec<T>) -> (usize, usize)
+        where 
+            K: Eq+Clone+Debug,
+            C1: Cursor<K, V1, T, R1>, 
+            C3: Cursor<K, V1, T, R1>, 
+            C2: Cursor<K, V2, T, R2>, 
+            L: Fn(&K, &[(V1, R1)], &mut Vec<(V2, R2)>)
+    {
+            // Determine the `meet` of times, useful in restricting updates to capture.
+            let mut meet = interesting_times[0].clone(); 
+            for index in 1 .. interesting_times.len() {
+                meet = meet.meet(&interesting_times[index]);
+            }
 
-    #[inline(never)]
-    fn collapse(&mut self, value_index: usize, meet: &T) {
+            // clear accumulators (will now repopulate)
+            self.yielded_accumulator.clear();
+            self.yielded_accumulator.time = interesting_times[0].clone();
 
-        let lower = self.values[value_index].lower;
-        let valid = self.values[value_index].valid;
+            // Accumulate into `input_stage` and populate `input_edits`.
+            self.input_accumulator.clear();
+            self.input_accumulator.time = interesting_times[0].clone();
+            source_cursor.seek_key(&key);
+            if source_cursor.key_valid() && source_cursor.key() == key {
+                while source_cursor.val_valid() {
+                    let val: V1 = source_cursor.val().clone();
+                    let mut sum = R1::zero();
 
-        for index in lower .. valid {
-            self.times[index].0 = self.times[index].0.join(meet);
-        }
+                    source_cursor.map_times(|t,d| {
 
-        // consolidating updates with equal times (post-join).
-        self.times[lower .. valid].sort_by(|x,y| x.0.cmp(&y.0));
+                        // println!("INPUT UPDATE: {:?}, {:?}, {:?}, {:?}", key, val, t, d);
 
-        // only need to collapse if there are at least two updates.
-        if lower < valid - 1 {
+                        if t.le(&self.input_accumulator.time) { 
+                            sum = sum + d; 
+                        }
+                        if !t.le(&meet) {
+                            self.time_buffer1.push((t.join(&meet), d));
+                        }
+                    });
+                    consolidate(&mut self.time_buffer1);
+                    self.input_accumulator.edits.extend(self.time_buffer1.drain(..).map(|(t,d)| (val.clone(), t, d)));
+                    if !sum.is_zero() {
+                        self.input_accumulator.accum.push((val, sum));
+                    }
+                    source_cursor.step_val();
+                }
+            }
+            self.input_accumulator.shackle();
 
-            // now to collapse updates *forward*, to end at `valid`.
-            let mut cursor = valid - 1;
-            for index in (lower .. valid - 1).rev() {
-                if self.times[index].0 == self.times[cursor].0 {
-                    self.times[cursor].1 = self.times[cursor].1 + self.times[index].1;
-                    self.times[index].1 = R::zero();
+            // Accumulate into `output_stage` and populate `output_edits`. 
+            self.output_accumulator.clear();
+            self.output_accumulator.time = interesting_times[0].clone();
+            output_cursor.seek_key(&key);
+            if output_cursor.key_valid() && output_cursor.key() == key {
+                while output_cursor.val_valid() {
+                    let val: V2 = output_cursor.val().clone();
+                    let mut sum = R2::zero();
+                    output_cursor.map_times(|t,d| {
+                        if t.le(&self.output_accumulator.time) {
+                            sum = sum + d;
+                        }
+                        if !t.le(&meet) {
+                            self.time_buffer2.push((t.join(&meet), d));
+                        }
+                    });
+                    consolidate(&mut self.time_buffer2);
+                    self.output_accumulator.edits.extend(self.time_buffer2.drain(..).map(|(t,d)| (val.clone(), t, d)));
+                    if !sum.is_zero() {
+                        self.output_accumulator.accum.push((val, sum));
+                    }
+                    output_cursor.step_val();
+                }
+            }
+            self.output_accumulator.shackle();
+
+            self.interestinator.close_interesting_times(&self.input_accumulator.edits[..], interesting_times);
+
+            // each interesting time must be considered!
+            for this_time in interesting_times.drain(..) {
+
+                // not all times are ready to be finalized. stash them with the key.
+                if upper_limit.iter().any(|t| t.le(&this_time)) {
+                    new_interesting.push(this_time);
                 }
                 else {
-                    if !self.times[cursor].1.is_zero() {
-                        cursor -= 1;
+
+                    // 1. update `input_stage` and `output_stage` to `this_time`.
+                    self.input_accumulator.update_to(this_time.clone());
+                    self.output_accumulator.update_to(this_time.clone());
+                    self.yielded_accumulator.update_to(this_time.clone());
+
+                    // 2. apply user logic (only if non-empty input).
+                    self.output_logic.clear();
+                    if self.input_accumulator.accum.len() > 0 {
+                        logic(&key, &self.input_accumulator.accum[..], &mut self.output_logic);
                     }
-                    self.times.swap(cursor, index);
+
+                    // println!("key: {:?}, input: {:?}, ouput: {:?} @ {:?}", 
+                    //          key, &self.input_accumulator.accum[..], self.output_logic, this_time);
+
+                    // 3. subtract existing output differences.
+                    for &(ref val, diff) in &self.output_accumulator.accum[..] {
+                        self.output_logic.push((val.clone(), -diff));
+                    }
+                    // incorporate uncommitted output updates.
+                    for &(ref val, diff) in &self.yielded_accumulator.accum {
+                        self.output_logic.push((val.clone(), -diff));
+                    }
+                    consolidate(&mut self.output_logic);
+
+                    // 4. stashed produced updates in capability-indexed buffers, and `yielded_accumulator`.
+                    let idx = outputs.iter().rev().position(|&(ref time, _)| time.le(&this_time));
+                    let idx = idx.unwrap();
+                    let idx = outputs.len() - idx - 1;
+                    for (val, diff) in self.output_logic.drain(..) {
+                        self.yielded_accumulator.push_edit((val.clone(), this_time.clone(), diff));
+                        outputs[idx].1.push((val, this_time.clone(), diff));
+                    }
                 }
             }
-            // if the final element accumulated to zero, advance `cursor`.
-            if self.times[cursor].1.is_zero() {
-                cursor += 1;
-            }
-            
-            // // should be a range of zeros, .. 
-            // debug_assert!(lower <= cursor);
-            // for index in lower .. cursor {
-            //     debug_assert!(self.times[index].1.is_zero());
-            // }
-            // // .. followed by a range of non-zeros.
-            // debug_assert!(cursor <= valid);
-            // for index in cursor .. valid {
-            //     debug_assert!(!self.times[index].1.is_zero());
-            // }
 
-            self.values[value_index].lower = cursor;
-            self.values[value_index].clean = valid;
+            (0, 0)
         }
     }
 
-    fn seal_from(&mut self, value: V, start: usize) {
+    /// Allocated state and temporary buffers for closing interesting time under join.
+    #[derive(Default)]
+    struct Interestinator<T: Ord+Lattice+Clone> {
 
-        // collapse down the updates
-        consolidate_from(&mut self.times, start);
+        total: Vec<(T, isize)>,     // holds all times; a non-zero value indicates a new time.
 
-        // if non-empty, push range info for value.
-        if self.times.len() > start {
-            self.values.push(ValueHistory {
-                value: value,
-                lower: start,
-                clean: start,
-                valid: start,
-                upper: self.times.len(),
-            });
-        }
+        old_accum: Vec<T>,          // accumulated old times, compacted via self.frontier.
+        new_accum: Vec<T>,          // accumulated new times, compacted via self.frontier.
+
+        entrance: Vec<(T, usize)>,  // times and self.total indices at which they enter self.frontier.
+        frontier: Vec<T>,           // allocation to hold the evolving frontier.
+
+        old_temp: Vec<T>,           // temporary storage to avoid 
+        new_temp: Vec<T>,
     }
 
-    #[inline(never)]
-    fn insert(&mut self, time: &T, meet: &T, destination: &mut Vec<(V, R)>) {
-
-        for value_index in 0 .. self.values.len() {
-
-            let lower = self.values[value_index].lower;
-            let clean = self.values[value_index].clean;
-            let valid = self.values[value_index].valid;
-
-            // take the time to collapse if there are changes. 
-            // this is not the only reason to collapse, and we may want to be more or less aggressive
-            if clean < valid {
-                self.collapse(value_index, meet);
-            }
-
-            let mut sum = R::zero();
-            for index in lower .. valid {
-                if self.times[index].0.le(time) {
-                    sum = sum + self.times[index].1;
-                }
-            }
-            if !sum.is_zero() {
-                destination.push((self.values[value_index].value.clone(), sum));
-                // return;  // <-- cool optimization for top_k
+    impl<T: Ord+Lattice+Clone+::std::fmt::Debug> Interestinator<T> {
+        fn new() -> Self {
+            Interestinator {
+                total: Vec::new(),
+                old_accum: Vec::new(),
+                new_accum: Vec::new(),
+                entrance: Vec::new(),
+                frontier: Vec::new(),
+                old_temp: Vec::new(),
+                new_temp: Vec::new(),
             }
         }
-    }
 
-    #[inline(never)]
-    fn remove(&mut self, time: &T, meet: &T, destination: &mut Vec<(V, R)>) {
+        /// Extends `times` with the join of subsets of `edits` and `times` with at least one element from `times`.
+        ///
+        /// This method has a somewhat non-standard implementation in the aim of being "more linear", which makes it
+        /// a bit more complicated that you might think, and with possibly surprising performance. If this method shows
+        /// up on performance profiling, it may be worth asking for more information, as it is a work in progress.
+        #[inline(never)]
+        fn close_interesting_times<D, R>(&mut self, edits: &[(D, T, R)], times: &mut Vec<T>) {
 
-        for value_index in 0 .. self.values.len() {
+            // Candidate algorithm: sort list of (time, is_new) pairs describing old and new times. 
+            // We aim to do not much worse than processing times in this order. 
+            // 
+            // We will maintain a few accumulations to help us correctly maintain the set of new times.
+            //
+            //   Frontier: We track the elements in the frontier, identified in an initial reverse scan.
+            //   old_accum: We accumulate old times using the frontier, which I hope is correct.
+            //   new_accum: We accumulate new times using the frontier, which I hope is correct.
+            //
+            // For each time, we check whether the frontier changes, and if so perhaps update our accums.
+            // We then do something based on whether it is a new or old time:
+            // 
+            //   new time: join with each element of old_accum, add results + self to new_accum, re-close, emit.
+            //   old time: join with each element of new_accum, re-close, emit.
+            //
+            // We can either re-close the new_accum set with each element, or repeat the process with new
+            // synthetic times. In either case, we need to be careful to not leave a massive amount of work
+            // behind (e.g. if a closed new_accum becomes enormous and un-accumulable, bad news for us). It is 
+            // probably safe to close in place, as the in-order execution would do this anyhow.
 
-            let lower = self.values[value_index].lower;
-            let clean = self.values[value_index].clean;
-            let valid = self.values[value_index].valid;
-
-            // take the time to collapse if there are changes. 
-            // this is not the only reason to collapse, and we may want to be more or less aggressive
-            if clean < valid {
-                self.collapse(value_index, meet);
-            }
-
-            let mut sum = R::zero();
-            for index in lower .. valid {
-                if self.times[index].0.le(time) {
-                    sum = sum - self.times[index].1;
-                }
-            }
-            if !sum.is_zero() {
-                destination.push((self.values[value_index].value.clone(), sum));
-            }
-        }
-    }
-}
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-struct InterestAccumulator<V1, V2, T, R1, R2>
-where 
-    V1: Ord+Clone,
-    V2: Ord+Clone,
-    T: Lattice+Ord+Clone,
-    R1: Ring,
-    R2: Ring,
-{
-    interestinator: Interestinator<T>,
-    input_accumulator: Accumulator<V1, T, R1>,
-    output_accumulator: Accumulator<V2, T, R2>,
-    yielded_accumulator: Accumulator<V2, T, R2>,
-    time_buffer1: Vec<(T, R1)>,
-    time_buffer2: Vec<(T, R2)>,
-    output_logic: Vec<(V2, R2)>,
-}
-
-impl<V1, V2, T, R1, R2> PerKeyCompute<V1, V2, T, R1, R2> for InterestAccumulator<V1, V2, T, R1, R2> 
-where 
-    V1: Ord+Clone+Debug,
-    V2: Ord+Clone+Debug,
-    T: Lattice+Ord+Clone+Debug,
-    R1: Ring,
-    R2: Ring,
-{
-    fn new() -> Self {
-        InterestAccumulator {
-            interestinator: Interestinator::new(),
-            input_accumulator: Accumulator::new(),
-            output_accumulator: Accumulator::new(),
-            yielded_accumulator: Accumulator::new(),
-            time_buffer1: Vec::new(),
-            time_buffer2: Vec::new(),
-            output_logic: Vec::new(),
-        }
-    }
-    fn compute<K, C1, C2, L>(
-        &mut self,
-        key: &K, 
-        source_cursor: &mut C1, 
-        output_cursor: &mut C2, 
-        interesting_times: &mut Vec<T>, 
-        logic: &L,
-        upper_limit: &[T],
-        outputs: &mut [(T, Vec<(V2, T, R2)>)],
-        new_interesting: &mut Vec<T>)
-    where 
-        K: Eq+Clone+Debug,
-        C1: Cursor<K, V1, T, R1>, 
-        C2: Cursor<K, V2, T, R2>, 
-        L: Fn(&K, &[(V1, R1)], &mut Vec<(V2, R2)>)
-{
-        // Determine the `meet` of times, useful in restricting updates to capture.
-        let mut meet = interesting_times[0].clone(); 
-        for index in 1 .. interesting_times.len() {
-            meet = meet.meet(&interesting_times[index]);
-        }
-
-        // clear accumulators (will now repopulate)
-        self.yielded_accumulator.clear();
-        self.yielded_accumulator.time = interesting_times[0].clone();
-
-        // Accumulate into `input_stage` and populate `input_edits`.
-        self.input_accumulator.clear();
-        self.input_accumulator.time = interesting_times[0].clone();
-        source_cursor.seek_key(&key);
-        if source_cursor.key_valid() && source_cursor.key() == key {
-            while source_cursor.val_valid() {
-                let val: V1 = source_cursor.val().clone();
-                let mut sum = R1::zero();
-
-                source_cursor.map_times(|t,d| {
-
-                    // println!("INPUT UPDATE: {:?}, {:?}, {:?}, {:?}", key, val, t, d);
-
-                    if t.le(&self.input_accumulator.time) { 
-                        sum = sum + d; 
-                    }
-                    if !t.le(&meet) {
-                        self.time_buffer1.push((t.join(&meet), d));
-                    }
-                });
-                consolidate(&mut self.time_buffer1);
-                self.input_accumulator.edits.extend(self.time_buffer1.drain(..).map(|(t,d)| (val.clone(), t, d)));
-                if !sum.is_zero() {
-                    self.input_accumulator.accum.push((val, sum));
-                }
-                source_cursor.step_val();
-            }
-        }
-        self.input_accumulator.shackle();
-
-        // Accumulate into `output_stage` and populate `output_edits`. 
-        self.output_accumulator.clear();
-        self.output_accumulator.time = interesting_times[0].clone();
-        output_cursor.seek_key(&key);
-        if output_cursor.key_valid() && output_cursor.key() == key {
-            while output_cursor.val_valid() {
-                let val: V2 = output_cursor.val().clone();
-                let mut sum = R2::zero();
-                output_cursor.map_times(|t,d| {
-                    if t.le(&self.output_accumulator.time) {
-                        sum = sum + d;
-                    }
-                    if !t.le(&meet) {
-                        self.time_buffer2.push((t.join(&meet), d));
-                    }
-                });
-                consolidate(&mut self.time_buffer2);
-                self.output_accumulator.edits.extend(self.time_buffer2.drain(..).map(|(t,d)| (val.clone(), t, d)));
-                if !sum.is_zero() {
-                    self.output_accumulator.accum.push((val, sum));
-                }
-                output_cursor.step_val();
-            }
-        }
-        self.output_accumulator.shackle();
-
-        self.interestinator.close_interesting_times(&self.input_accumulator.edits[..], interesting_times);
-
-        // each interesting time must be considered!
-        for this_time in interesting_times.drain(..) {
-
-            // not all times are ready to be finalized. stash them with the key.
-            if upper_limit.iter().any(|t| t.le(&this_time)) {
-                new_interesting.push(this_time);
+            if edits.len() + times.len() < 10 { 
+                self._close_interesting_times_reference(edits, times);
             }
             else {
 
-                // 1. update `input_stage` and `output_stage` to `this_time`.
-                self.input_accumulator.update_to(this_time.clone());
-                self.output_accumulator.update_to(this_time.clone());
-                self.yielded_accumulator.update_to(this_time.clone());
+                // CLEVER IMPLEMENTATION
+                // 1. populate uniform list of times, and indicate whether they are for new or old times.
+                assert!(self.total.len() == 0);
+                self.total.reserve(edits.len() + times.len());
+                for &(_, ref time, _) in edits { self.total.push((time.clone(), 1)); }
+                for time in times.iter() { self.total.push((time.clone(), edits.len() as isize + 1)); }
 
-                // 2. apply user logic (only if non-empty input).
-                self.output_logic.clear();
-                if self.input_accumulator.accum.len() > 0 {
-                    logic(&key, &self.input_accumulator.accum[..], &mut self.output_logic);
+                consolidate(&mut self.total);
+
+                // 2. determine the frontiers by scanning list in reverse order (for each: when it exits frontier).
+                self.frontier.clear();
+                self.entrance.clear();
+                self.entrance.reserve(self.total.len());
+                let mut position = self.total.len();
+                while position > 0 {
+                    position -= 1;
+                    // "add" total[position] and seeing who drops == who is exposed when total[position] removed.
+                    let mut index = 0;
+                    while index < self.frontier.len() {
+                        if self.total[position].0.le(&self.frontier[index]) {
+                            self.entrance.push((self.frontier.swap_remove(index), position));
+                        }
+                        else {
+                            index += 1;
+                        }
+                    }
+                    self.frontier.push(self.total[position].0.clone());
                 }
 
-                // println!("key: {:?}, input: {:?}, ouput: {:?} @ {:?}", 
-                //          key, &self.input_accumulator.accum[..], self.output_logic, this_time);
+                // 3. swing through `total` and apply per-time thinkings.
+                self.old_temp.clear();
+                self.new_temp.clear();
+                self.old_accum.clear();
+                self.new_accum.clear();
 
-                // 3. subtract existing output differences.
-                for &(ref val, diff) in &self.output_accumulator.accum[..] {
-                    self.output_logic.push((val.clone(), -diff));
-                }
-                // incorporate uncommitted output updates.
-                for &(ref val, diff) in &self.yielded_accumulator.accum {
-                    self.output_logic.push((val.clone(), -diff));
-                }
-                consolidate(&mut self.output_logic);
+                for (index, (time, is_new)) in self.total.drain(..).enumerate() {
+                    
+                    if is_new > edits.len() as isize {
+                        for new_time in &self.new_accum {
+                            let join = time.join(new_time);
+                            if join != time { 
+                                self.new_temp.push(join.clone()); 
+                                times.push(join); 
+                            }
+                        }
+                        for t in self.new_temp.drain(..) { self.new_accum.push(t); }
 
-                // 4. stashed produced updates in capability-indexed buffers, and `yielded_accumulator`.
-                let idx = outputs.iter().rev().position(|&(ref time, _)| time.le(&this_time));
-                let idx = idx.unwrap();
-                let idx = outputs.len() - idx - 1;
-                for (val, diff) in self.output_logic.drain(..) {
-                    self.yielded_accumulator.push_edit((val.clone(), this_time.clone(), diff));
-                    outputs[idx].1.push((val, this_time.clone(), diff));
-                }
-            }
-        }
-    }
-}
-
-/// Allocated state and temporary buffers for closing interesting time under join.
-#[derive(Default)]
-struct Interestinator<T: Ord+Lattice+Clone> {
-
-    total: Vec<(T, isize)>,     // holds all times; a non-zero value indicates a new time.
-
-    old_accum: Vec<T>,          // accumulated old times, compacted via self.frontier.
-    new_accum: Vec<T>,          // accumulated new times, compacted via self.frontier.
-
-    entrance: Vec<(T, usize)>,  // times and self.total indices at which they enter self.frontier.
-    frontier: Vec<T>,           // allocation to hold the evolving frontier.
-
-    old_temp: Vec<T>,           // temporary storage to avoid 
-    new_temp: Vec<T>,
-}
-
-impl<T: Ord+Lattice+Clone+::std::fmt::Debug> Interestinator<T> {
-    fn new() -> Self {
-        Interestinator {
-            total: Vec::new(),
-            old_accum: Vec::new(),
-            new_accum: Vec::new(),
-            entrance: Vec::new(),
-            frontier: Vec::new(),
-            old_temp: Vec::new(),
-            new_temp: Vec::new(),
-        }
-    }
-
-    /// Extends `times` with the join of subsets of `edits` and `times` with at least one element from `times`.
-    ///
-    /// This method has a somewhat non-standard implementation in the aim of being "more linear", which makes it
-    /// a bit more complicated that you might think, and with possibly surprising performance. If this method shows
-    /// up on performance profiling, it may be worth asking for more information, as it is a work in progress.
-    #[inline(never)]
-    fn close_interesting_times<D, R>(&mut self, edits: &[(D, T, R)], times: &mut Vec<T>) {
-
-        // Candidate algorithm: sort list of (time, is_new) pairs describing old and new times. 
-        // We aim to do not much worse than processing times in this order. 
-        // 
-        // We will maintain a few accumulations to help us correctly maintain the set of new times.
-        //
-        //   Frontier: We track the elements in the frontier, identified in an initial reverse scan.
-        //   old_accum: We accumulate old times using the frontier, which I hope is correct.
-        //   new_accum: We accumulate new times using the frontier, which I hope is correct.
-        //
-        // For each time, we check whether the frontier changes, and if so perhaps update our accums.
-        // We then do something based on whether it is a new or old time:
-        // 
-        //   new time: join with each element of old_accum, add results + self to new_accum, re-close, emit.
-        //   old time: join with each element of new_accum, re-close, emit.
-        //
-        // We can either re-close the new_accum set with each element, or repeat the process with new
-        // synthetic times. In either case, we need to be careful to not leave a massive amount of work
-        // behind (e.g. if a closed new_accum becomes enormous and un-accumulable, bad news for us). It is 
-        // probably safe to close in place, as the in-order execution would do this anyhow.
-
-        if edits.len() + times.len() < 10 { 
-            self._close_interesting_times_reference(edits, times);
-        }
-        else {
-
-            // CLEVER IMPLEMENTATION
-            // 1. populate uniform list of times, and indicate whether they are for new or old times.
-            assert!(self.total.len() == 0);
-            self.total.reserve(edits.len() + times.len());
-            for &(_, ref time, _) in edits { self.total.push((time.clone(), 1)); }
-            for time in times.iter() { self.total.push((time.clone(), edits.len() as isize + 1)); }
-
-            consolidate(&mut self.total);
-
-            // 2. determine the frontiers by scanning list in reverse order (for each: when it exits frontier).
-            self.frontier.clear();
-            self.entrance.clear();
-            self.entrance.reserve(self.total.len());
-            let mut position = self.total.len();
-            while position > 0 {
-                position -= 1;
-                // "add" total[position] and seeing who drops == who is exposed when total[position] removed.
-                let mut index = 0;
-                while index < self.frontier.len() {
-                    if self.total[position].0.le(&self.frontier[index]) {
-                        self.entrance.push((self.frontier.swap_remove(index), position));
+                        for old_time in &self.old_accum {
+                            let join = time.join(old_time);
+                            if join != time { 
+                                self.new_accum.push(join.clone()); 
+                                times.push(join); 
+                            }
+                        }
+                        self.new_accum.push(time.clone());
                     }
                     else {
-                        index += 1;
-                    }
-                }
-                self.frontier.push(self.total[position].0.clone());
-            }
 
-            // 3. swing through `total` and apply per-time thinkings.
-            self.old_temp.clear();
-            self.new_temp.clear();
-            self.old_accum.clear();
-            self.new_accum.clear();
-
-            for (index, (time, is_new)) in self.total.drain(..).enumerate() {
-                
-                if is_new > edits.len() as isize {
-                    for new_time in &self.new_accum {
-                        let join = time.join(new_time);
-                        if join != time { 
+                        for new_time in &self.new_accum {
+                            let join = time.join(new_time);
                             self.new_temp.push(join.clone()); 
                             times.push(join); 
                         }
-                    }
-                    for t in self.new_temp.drain(..) { self.new_accum.push(t); }
+                        for t in self.new_temp.drain(..) { self.new_accum.push(t); }
 
-                    for old_time in &self.old_accum {
-                        let join = time.join(old_time);
-                        if join != time { 
-                            self.new_accum.push(join.clone()); 
-                            times.push(join); 
+                        for old_time in &self.old_accum {
+                            let join = time.join(old_time);
+                            if join != time { self.old_temp.push(join); }
                         }
+                        for t in self.old_temp.drain(..) { self.old_accum.push(t); }
+                        self.old_accum.push(time.clone());
                     }
-                    self.new_accum.push(time.clone());
-                }
-                else {
 
-                    for new_time in &self.new_accum {
-                        let join = time.join(new_time);
-                        self.new_temp.push(join.clone()); 
-                        times.push(join); 
+            
+                    // update old_accum and new_accum with frontier changes, deduplicating.
+
+                    // TODO: Can we mantain frontiers corresponding to new times and the current `new_accum`, as all 
+                    //       future additions must be joined with such elements. This could reduce the complexity of 
+                    //       `old_accum` substantially, removing distinctions between irrelevant prior times.
+
+                    // a. remove time from frontier; it's not there any more.
+                    self.frontier.retain(|x| !x.eq(&time));
+                    // b. add any indicated elements
+                    while self.entrance.last().map(|x| x.1) == Some(index) {
+                        self.frontier.push(self.entrance.pop().unwrap().0);
                     }
-                    for t in self.new_temp.drain(..) { self.new_accum.push(t); }
 
-                    for old_time in &self.old_accum {
-                        let join = time.join(old_time);
-                        if join != time { self.old_temp.push(join); }
+                    if self.frontier.len() > 0 {
+                        // advance times in the old accumulation, sort and deduplicate.
+                        for time in &mut self.old_accum { *time = time.advance_by(&self.frontier[..]); }
+                        self.old_accum.sort();
+                        self.old_accum.dedup();
+                        // advance times in the new accumulation, sort and deduplicate.
+                        for time in &mut self.new_accum { *time = time.advance_by(&self.frontier[..]); }
+                        self.new_accum.sort();
+                        self.new_accum.dedup();
                     }
-                    for t in self.old_temp.drain(..) { self.old_accum.push(t); }
-                    self.old_accum.push(time.clone());
                 }
 
-        
-                // update old_accum and new_accum with frontier changes, deduplicating.
+                times.sort();
+                times.dedup();
 
-                // TODO: Can we mantain frontiers corresponding to new times and the current `new_accum`, as all 
-                //       future additions must be joined with such elements. This could reduce the complexity of 
-                //       `old_accum` substantially, removing distinctions between irrelevant prior times.
-
-                // a. remove time from frontier; it's not there any more.
-                self.frontier.retain(|x| !x.eq(&time));
-                // b. add any indicated elements
-                while self.entrance.last().map(|x| x.1) == Some(index) {
-                    self.frontier.push(self.entrance.pop().unwrap().0);
-                }
-
-                if self.frontier.len() > 0 {
-                    // advance times in the old accumulation, sort and deduplicate.
-                    for time in &mut self.old_accum { *time = time.advance_by(&self.frontier[..]); }
-                    self.old_accum.sort();
-                    self.old_accum.dedup();
-                    // advance times in the new accumulation, sort and deduplicate.
-                    for time in &mut self.new_accum { *time = time.advance_by(&self.frontier[..]); }
-                    self.new_accum.sort();
-                    self.new_accum.dedup();
-                }
-            }
-
-            times.sort();
-            times.dedup();
-
-            // assert_eq!(*times, reference);
-        }
-    }
-
-    /// Reference implementation for `close_interesting_times`, using lots more effort than should be needed.
-    fn _close_interesting_times_reference<D, R>(&mut self, edits: &[(D, T, R)], times: &mut Vec<T>) {
-
-        // REFERENCE IMPLEMENTATION (LESS CLEVER)
-        let times_len = times.len();
-        for position in 0 .. times_len {
-            for &(_, ref time, _) in edits {
-                if !time.le(&times[position]) {
-                    let join = time.join(&times[position]);
-                    times.push(join);
-                }
-            }
-        }
-        
-        let mut position = 0;
-        while position < times.len() {
-            for index in 0 .. position {
-                if !times[index].le(&times[position]) {
-                    let join = times[index].join(&times[position]);
-                    times.push(join);
-                }
-            }
-            position += 1;
-            times[position..].sort();
-            times.dedup();
-        }
-    }
-}
-
-/// Maintains an accumulation of updates over partially ordered times.
-///
-/// The `Accumulator` tries to cleverly partition its input edits into "chains": totally ordered contiguous 
-/// subsequences. These chains simplify updating of accumulations, as in each chain it is relatively easy to 
-/// understand how mnay updates must be re-considered.
-///
-/// Many of the methods on `Accumulator` require understanding of how they should be used. Perhaps this can
-/// be fixed with an `AccumulatorBuilder` helper type, but the intended life-cycle is: the `Accumulator` is 
-/// initially valid, and `push_edit` and `update_to` may be called at will. Direct manipulation of the public
-/// fields (which we do) requires a call to `shackle` before using the `Accumulator` again (to rebuild the 
-/// chains and correct the accumulation).
-struct Accumulator<D: Ord+Clone, T: Lattice+Ord, R: Ring> {
-    pub time: T,
-    pub edits: Vec<(D, T, R)>,
-    pub chains: Vec<(usize, usize, usize)>,
-    pub accum: Vec<(D, R)>,
-}
-
-impl<D: Ord+Clone, T: Lattice+Ord+Debug, R: Ring> Accumulator<D, T, R> {
-
-    /// Allocates a new empty accumulator.
-    fn new() -> Self {
-        Accumulator {
-            time: T::min(),
-            edits: Vec::new(),
-            chains: Vec::new(),
-            accum: Vec::new(),
-        }
-    }
-
-    /// Clears the allocator and sets the time to `T::min()`.
-    fn clear(&mut self) {
-        self.time = T::min();
-        self.edits.clear();
-        self.chains.clear();
-        self.accum.clear();
-    }
-
-    /// Introduces edits into a live accumulation.
-    fn push_edit(&mut self, edit: (D, T, R)) {
-
-        // do we need a new chain?
-        if self.edits.len() == 0 || !self.edits[self.edits.len()-1].1.le(&edit.1) {
-            let edits = self.edits.len();
-            self.chains.push((edits, edits, edits + 1));
-            self.edits.push(edit);
-        }
-        else {
-            let chains = self.chains.len();
-            self.edits.push(edit);
-            self.chains[chains-1].2 = self.edits.len();
-        }
-
-        // we may need to advance the finger of the last chain by one.
-        let finger = self.chains[self.chains.len()-1].1;
-        if self.edits[finger].1.le(&self.time) {
-            self.accum.push((self.edits[finger].0.clone(), self.edits[finger].2));
-            let chains_len = self.chains.len();
-            self.chains[chains_len-1].1 += 1;
-        }
-    }
-
-    /// Sorts `edits` and forms chains.
-    fn shackle(&mut self) {
-
-        // consolidate2(&mut self.edits);
-        consolidate(&mut self.accum);
-
-        self.edits.sort_by(|x,y| x.1.cmp(&y.1));
-
-        let mut lower = 0;
-        for upper in 1 .. self.edits.len() {
-            if !self.edits[upper-1].1.le(&self.edits[upper].1) {
-                self.chains.push((lower, lower, upper));
-                lower = upper;
+                // assert_eq!(*times, reference);
             }
         }
 
-        if self.edits.len() > 0 {
-            self.chains.push((lower, lower, self.edits.len()));
-        }
+        /// Reference implementation for `close_interesting_times`, using lots more effort than should be needed.
+        fn _close_interesting_times_reference<D, R>(&mut self, edits: &[(D, T, R)], times: &mut Vec<T>) {
 
-        for chain in 0 .. self.chains.len() {
-            let mut finger = self.chains[chain].1;
-            while finger < self.chains[chain].2 && self.edits[finger].1.le(&self.time) {
-                finger += 1;
+            // REFERENCE IMPLEMENTATION (LESS CLEVER)
+            let times_len = times.len();
+            for position in 0 .. times_len {
+                for &(_, ref time, _) in edits {
+                    if !time.le(&times[position]) {
+                        let join = time.join(&times[position]);
+                        times.push(join);
+                    }
+                }
             }
-            self.chains[chain].1 = finger;
+            
+            let mut position = 0;
+            while position < times.len() {
+                for index in 0 .. position {
+                    if !times[index].le(&times[position]) {
+                        let join = times[index].join(&times[position]);
+                        times.push(join);
+                    }
+                }
+                position += 1;
+                times[position..].sort();
+                times.dedup();
+            }
         }
-
-        // if self.chains.len() > 5 { println!("chains: {:?}", self.chains.len()); }
     }
-    
-    /// Updates the internal accumulation to correspond to `new_time`.
+
+    /// Maintains an accumulation of updates over partially ordered times.
     ///
-    /// This method traverses edits by chains, or totally ordered subsequences. It traverses
-    /// each chain at most once over the course of totally ordered updates, as it only moves
-    /// forward through each of its own internal chains. Although the method should be correct
-    /// for arbitrary sequences of times, the performance could be arbitrarily poor.
+    /// The `Accumulator` tries to cleverly partition its input edits into "chains": totally ordered contiguous 
+    /// subsequences. These chains simplify updating of accumulations, as in each chain it is relatively easy to 
+    /// understand how mnay updates must be re-considered.
+    ///
+    /// Many of the methods on `Accumulator` require understanding of how they should be used. Perhaps this can
+    /// be fixed with an `AccumulatorBuilder` helper type, but the intended life-cycle is: the `Accumulator` is 
+    /// initially valid, and `push_edit` and `update_to` may be called at will. Direct manipulation of the public
+    /// fields (which we do) requires a call to `shackle` before using the `Accumulator` again (to rebuild the 
+    /// chains and correct the accumulation).
+    struct Accumulator<D: Ord+Clone, T: Lattice+Ord, R: Ring> {
+        pub time: T,
+        pub edits: Vec<(D, T, R)>,
+        pub chains: Vec<(usize, usize, usize)>,
+        pub accum: Vec<(D, R)>,
+    }
 
-    #[inline(never)]
-    fn update_to(&mut self, new_time: T) -> &[(D, R)] {
+    impl<D: Ord+Clone, T: Lattice+Ord+Debug, R: Ring> Accumulator<D, T, R> {
 
-        // println!("updating from {:?} to {:?}", self.time, new_time);
-
-        let meet = self.time.meet(&new_time);
-        for chain in 0 .. self.chains.len() {
-
-            // finger is the first element *not* `le` this.time.
-            let mut finger = self.chains[chain].1;
-
-            // possibly move forward, adding edits while times less than `new_time`.
-            while finger < self.chains[chain].2 && self.edits[finger].1.le(&new_time) {
-                self.accum.push((self.edits[finger].0.clone(), self.edits[finger].2));
-                finger += 1;
-            }
-            // possibly move backward, subtracting edits with times not less than `new_time`.
-            while finger > self.chains[chain].0 && !self.edits[finger-1].1.le(&new_time) {
-                self.accum.push((self.edits[finger-1].0.clone(), -self.edits[finger-1].2));
-                finger -= 1;                    
-            }
-
-            let position = ::std::cmp::min(self.chains[chain].1, finger);
-            self.chains[chain].1 = finger;
-
-            // from the lower end of updates things are less certain; 
-            while position > self.chains[chain].0 && !self.edits[position-1].1.le(&meet) {
-
-                let le_prev = self.edits[position-1].1.le(&self.time);
-                let le_this = self.edits[position-1].1.le(&new_time);
-                if le_prev != le_this {
-                    if le_prev { self.accum.push((self.edits[position-1].0.clone(),-self.edits[position-1].2)); }
-                    else       { self.accum.push((self.edits[position-1].0.clone(), self.edits[position-1].2)); }
-                }
-
+        /// Allocates a new empty accumulator.
+        fn new() -> Self {
+            Accumulator {
+                time: T::min(),
+                edits: Vec::new(),
+                chains: Vec::new(),
+                accum: Vec::new(),
             }
         }
 
-        self.time = new_time;
-        consolidate(&mut self.accum);
-        &self.accum[..]
+        /// Clears the allocator and sets the time to `T::min()`.
+        fn clear(&mut self) {
+            self.time = T::min();
+            self.edits.clear();
+            self.chains.clear();
+            self.accum.clear();
+        }
+
+        /// Introduces edits into a live accumulation.
+        fn push_edit(&mut self, edit: (D, T, R)) {
+
+            // do we need a new chain?
+            if self.edits.len() == 0 || !self.edits[self.edits.len()-1].1.le(&edit.1) {
+                let edits = self.edits.len();
+                self.chains.push((edits, edits, edits + 1));
+                self.edits.push(edit);
+            }
+            else {
+                let chains = self.chains.len();
+                self.edits.push(edit);
+                self.chains[chains-1].2 = self.edits.len();
+            }
+
+            // we may need to advance the finger of the last chain by one.
+            let finger = self.chains[self.chains.len()-1].1;
+            if self.edits[finger].1.le(&self.time) {
+                self.accum.push((self.edits[finger].0.clone(), self.edits[finger].2));
+                let chains_len = self.chains.len();
+                self.chains[chains_len-1].1 += 1;
+            }
+        }
+
+        /// Sorts `edits` and forms chains.
+        fn shackle(&mut self) {
+
+            // consolidate2(&mut self.edits);
+            consolidate(&mut self.accum);
+
+            self.edits.sort_by(|x,y| x.1.cmp(&y.1));
+
+            let mut lower = 0;
+            for upper in 1 .. self.edits.len() {
+                if !self.edits[upper-1].1.le(&self.edits[upper].1) {
+                    self.chains.push((lower, lower, upper));
+                    lower = upper;
+                }
+            }
+
+            if self.edits.len() > 0 {
+                self.chains.push((lower, lower, self.edits.len()));
+            }
+
+            for chain in 0 .. self.chains.len() {
+                let mut finger = self.chains[chain].1;
+                while finger < self.chains[chain].2 && self.edits[finger].1.le(&self.time) {
+                    finger += 1;
+                }
+                self.chains[chain].1 = finger;
+            }
+
+            // if self.chains.len() > 5 { println!("chains: {:?}", self.chains.len()); }
+        }
+        
+        /// Updates the internal accumulation to correspond to `new_time`.
+        ///
+        /// This method traverses edits by chains, or totally ordered subsequences. It traverses
+        /// each chain at most once over the course of totally ordered updates, as it only moves
+        /// forward through each of its own internal chains. Although the method should be correct
+        /// for arbitrary sequences of times, the performance could be arbitrarily poor.
+
+        #[inline(never)]
+        fn update_to(&mut self, new_time: T) -> &[(D, R)] {
+
+            // println!("updating from {:?} to {:?}", self.time, new_time);
+
+            let meet = self.time.meet(&new_time);
+            for chain in 0 .. self.chains.len() {
+
+                // finger is the first element *not* `le` this.time.
+                let mut finger = self.chains[chain].1;
+
+                // possibly move forward, adding edits while times less than `new_time`.
+                while finger < self.chains[chain].2 && self.edits[finger].1.le(&new_time) {
+                    self.accum.push((self.edits[finger].0.clone(), self.edits[finger].2));
+                    finger += 1;
+                }
+                // possibly move backward, subtracting edits with times not less than `new_time`.
+                while finger > self.chains[chain].0 && !self.edits[finger-1].1.le(&new_time) {
+                    self.accum.push((self.edits[finger-1].0.clone(), -self.edits[finger-1].2));
+                    finger -= 1;                    
+                }
+
+                let position = ::std::cmp::min(self.chains[chain].1, finger);
+                self.chains[chain].1 = finger;
+
+                // from the lower end of updates things are less certain; 
+                while position > self.chains[chain].0 && !self.edits[position-1].1.le(&meet) {
+
+                    let le_prev = self.edits[position-1].1.le(&self.time);
+                    let le_this = self.edits[position-1].1.le(&new_time);
+                    if le_prev != le_this {
+                        if le_prev { self.accum.push((self.edits[position-1].0.clone(),-self.edits[position-1].2)); }
+                        else       { self.accum.push((self.edits[position-1].0.clone(), self.edits[position-1].2)); }
+                    }
+
+                }
+            }
+
+            self.time = new_time;
+            consolidate(&mut self.accum);
+            &self.accum[..]
+        }
     }
 }

--- a/src/operators/join.rs
+++ b/src/operators/join.rs
@@ -279,13 +279,13 @@ impl<G, K, V, R, T1> JoinArranged<G, K, V, R> for Arranged<G,K,V,R,T1>
             }
 
             // perform some amount of outstanding work. 
-            if todo1.len() > 0 {
+            while todo1.len() > 0 {
                 todo1[0].work(output, &|k,v2,v1| result(k,v1,v2), 1_000_000);
                 if !todo1[0].work_remains() { todo1.remove(0); }
             }
 
             // perform some amount of outstanding work. 
-            if todo2.len() > 0 {
+            while todo2.len() > 0 {
                 todo2[0].work(output, &|k,v1,v2| result(k,v1,v2), 1_000_000);
                 if !todo2[0].work_remains() { todo2.remove(0); }
             }

--- a/src/operators/min.rs
+++ b/src/operators/min.rs
@@ -1,0 +1,811 @@
+//! Group records by a key, and apply a reduction function.
+//!
+//! The `group` operators act on data that can be viewed as pairs `(key, val)`. They group records
+//! with the same key, and apply user supplied functions to the key and a list of values, which are
+//! expected to populate a list of output values.
+//!
+//! Several variants of `group` exist which allow more precise control over how grouping is done.
+//! For example, the `_by` suffixed variants take arbitrary data, but require a key-value selector
+//! to be applied to each record. The `_u` suffixed variants use unsigned integers as keys, and
+//! will use a dense array rather than a `HashMap` to store their keys.
+//!
+//! The list of values are presented as an iterator which internally merges sorted lists of values.
+//! This ordering can be exploited in several cases to avoid computation when only the first few
+//! elements are required.
+//!
+//! #Examples
+//!
+//! This example groups a stream of `(key,val)` pairs by `key`, and yields only the most frequently
+//! occurring value for each key.
+//!
+//! ```ignore
+//! stream.group(|key, vals, output| {
+//!     let (mut max_val, mut max_wgt) = vals.next().unwrap();
+//!     for (val, wgt) in vals {
+//!         if wgt > max_wgt {
+//!             max_wgt = wgt;
+//!             max_val = val;
+//!         }
+//!     }
+//!     output.push((max_val.clone(), max_wgt));
+//! })
+//! ```
+
+use std::fmt::Debug;
+use std::default::Default;
+
+use hashable::{Hashable, UnsignedWrapper};
+use ::{Data, Collection, Ring};
+
+use timely::dataflow::*;
+use timely::dataflow::operators::Unary;
+use timely::dataflow::channels::pact::Pipeline;
+use timely::dataflow::operators::Capability;
+use timely_sort::Unsigned;
+
+use operators::arrange::{Arrange, Arranged, ArrangeByKey, ArrangeBySelf, BatchWrapper, TraceHandle};
+use lattice::Lattice;
+use trace::{Batch, Cursor, Trace, Builder};
+use trace::cursor::cursor_list::CursorList;
+// use trace::implementations::hash::HashValSpine as DefaultValTrace;
+// use trace::implementations::hash::HashKeySpine as DefaultKeyTrace;
+use trace::implementations::ord::OrdValSpine as DefaultValTrace;
+use trace::implementations::ord::OrdKeySpine as DefaultKeyTrace;
+
+
+/// Extension trait for the `group` differential dataflow method.
+pub trait Group<G: Scope, K: Data, V: Data, R: Ring> where G::Timestamp: Lattice+Ord {
+    /// Groups records by their first field, and applies reduction logic to the associated values.
+    fn group<L, V2: Data, R2: Ring>(&self, logic: L) -> Collection<G, (K, V2), R2>
+        where L: Fn(&K, &[(V, R)], &mut Vec<(V2, R2)>)+'static;
+    /// Groups records by their first field, and applies reduction logic to the associated values.
+    fn group_u<L, V2: Data, R2: Ring>(&self, logic: L) -> Collection<G, (K, V2), R2>
+        where L: Fn(&K, &[(V, R)], &mut Vec<(V2, R2)>)+'static, K: Unsigned+Copy;
+}
+
+impl<G: Scope, K: Data+Default+Hashable, V: Data, R: Ring> Group<G, K, V, R> for Collection<G, (K, V), R> 
+    where G::Timestamp: Lattice+Ord+Debug, <K as Hashable>::Output: Data+Default {
+    fn group<L, V2: Data, R2: Ring>(&self, logic: L) -> Collection<G, (K, V2), R2>
+        where L: Fn(&K, &[(V, R)], &mut Vec<(V2, R2)>)+'static {
+        // self.arrange_by_key_hashed_cached()
+        self.arrange_by_key_hashed()
+            .group_arranged(move |k,s,t| logic(&k.item,s,t), DefaultValTrace::new())
+            .as_collection(|k,v| (k.item.clone(), v.clone()))
+    }
+    fn group_u<L, V2: Data, R2: Ring>(&self, logic: L) -> Collection<G, (K, V2), R2>
+        where L: Fn(&K, &[(V, R)], &mut Vec<(V2, R2)>)+'static, K: Unsigned+Copy {
+        self.map(|(k,v)| (UnsignedWrapper::from(k), v))
+            .arrange(DefaultValTrace::new())
+            .group_arranged(move |k,s,t| logic(&k.item,s,t), DefaultValTrace::new())
+            .as_collection(|k,v| (k.item.clone(), v.clone()))
+    }
+}
+
+/// Extension trait for the `distinct` differential dataflow method.
+pub trait Distinct<G: Scope, K: Data> where G::Timestamp: Lattice+Ord {
+    /// Reduces the collection to one occurrence of each distinct element.
+    fn distinct(&self) -> Collection<G, K, isize>;
+    /// Reduces the collection to one occurrence of each distinct element.
+    fn distinct_u(&self) -> Collection<G, K, isize> where K: Unsigned+Copy;
+}
+
+impl<G: Scope, K: Data+Default+Hashable> Distinct<G, K> for Collection<G, K, isize> 
+where G::Timestamp: Lattice+Ord+::std::fmt::Debug {
+    fn distinct(&self) -> Collection<G, K, isize> {
+        self.arrange_by_self()
+            .group_arranged(|_k,_s,t| t.push(((), 1)), DefaultKeyTrace::new())
+            .as_collection(|k,_| k.item.clone())
+    }
+    fn distinct_u(&self) -> Collection<G, K, isize> where K: Unsigned+Copy {
+        self.map(|k| (UnsignedWrapper::from(k), ()))
+            .arrange(DefaultKeyTrace::new())
+            .group_arranged(|_k,_s,t| t.push(((), 1)), DefaultKeyTrace::new())
+            .as_collection(|k,_| k.item.clone())
+    }
+}
+
+
+/// Extension trait for the `count` differential dataflow method.
+pub trait Count<G: Scope, K: Data, R: Ring> where G::Timestamp: Lattice+Ord {
+    /// Counts the number of occurrences of each element.
+    fn count(&self) -> Collection<G, (K, R), isize>;
+    /// Counts the number of occurrences of each element.
+    fn count_u(&self) -> Collection<G, (K, R), isize> where K: Unsigned+Copy;
+}
+
+impl<G: Scope, K: Data+Default+Hashable, R: Ring> Count<G, K, R> for Collection<G, K, R>
+ where G::Timestamp: Lattice+Ord+::std::fmt::Debug {
+    fn count(&self) -> Collection<G, (K, R), isize> {
+        self.arrange_by_self()
+            .group_arranged(|_k,s,t| t.push((s[0].1, 1)), DefaultValTrace::new())
+            .as_collection(|k,&c| (k.item.clone(), c))
+    }
+    fn count_u(&self) -> Collection<G, (K, R), isize> where K: Unsigned+Copy {
+        self.map(|k| (UnsignedWrapper::from(k), ()))
+            .arrange(DefaultKeyTrace::new())
+            .group_arranged(|_k,s,t| t.push((s[0].1, 1)), DefaultValTrace::new())
+            .as_collection(|k,&c| (k.item.clone(), c))
+    }
+}
+
+
+/// Extension trace for the group_arranged differential dataflow method.
+pub trait GroupArranged<G: Scope, K: Data, V: Data, R: Ring> where G::Timestamp: Lattice+Ord {
+    /// Applies `group` to arranged data, and returns an arrangement of output data.
+    fn group_arranged<L, V2, T2, R2>(&self, logic: L, empty: T2) -> Arranged<G, K, V2, R2, T2>
+        where
+            V2: Data,
+            R2: Ring,
+            T2: Trace<K, V2, G::Timestamp, R2>+'static,
+            L: Fn(&K, &[(V, R)], &mut Vec<(V2, R2)>)+'static
+            ; 
+}
+
+impl<G: Scope, K: Data, V: Data, T1, R: Ring> GroupArranged<G, K, V, R> for Arranged<G, K, V, R, T1>
+where 
+    G::Timestamp: Lattice+Ord,
+    T1: Trace<K, V, G::Timestamp, R>+'static {
+        
+    fn group_arranged<L, V2, T2, R2>(&self, logic: L, empty: T2) -> Arranged<G, K, V2, R2, T2>
+        where 
+            V2: Data,
+            R2: Ring,
+            T2: Trace<K, V2, G::Timestamp, R2>+'static,
+            L: Fn(&K, &[(V, R)], &mut Vec<(V2, R2)>)+'static {
+
+        let mut source_trace = self.new_handle();
+        let mut output_trace = TraceHandle::new(empty, &[G::Timestamp::min()], &[G::Timestamp::min()]);
+        let result_trace = output_trace.clone();
+
+        // let mut thinker1 = interest_accumulator::InterestAccumulator::<V, V2, G::Timestamp, R, R2>::new();
+        let mut thinker2 = value_iteration::ValueIterator::<V, V2, G::Timestamp, R, R2>::new();
+        let mut temporary = Vec::<G::Timestamp>::new();
+
+        // Our implementation maintains a list of outstanding `(key, time)` synthetic interesting times, 
+        // as well as capabilities for these times (or their lower envelope, at least).
+        let mut interesting = Vec::<(K, G::Timestamp)>::new();
+        let mut capabilities = Vec::<Capability<G::Timestamp>>::new();
+
+        // buffers and logic for computing per-key interesting times "efficiently".
+        let mut interesting_times = Vec::<G::Timestamp>::new();
+
+        // space for assembling the upper bound of times to process.
+        let mut upper_limit = Vec::<G::Timestamp>::new();
+
+        // tracks frontiers received from batches, for sanity.
+        let mut upper_received = vec![<G::Timestamp as Lattice>::min()];
+
+        // We separately track the frontiers for what we have sent, and what we have sealed. 
+        let mut lower_issued = vec![<G::Timestamp as Lattice>::min()];
+
+        let id = self.stream.scope().index();
+
+        // fabricate a data-parallel operator using the `unary_notify` pattern.
+        let stream = self.stream.unary_notify(Pipeline, "Group", Vec::new(), move |input, output, notificator| {
+
+            // The `group` operator receives fully formed batches, which each serve as an indication
+            // that the frontier has advanced to the upper bound of their description.
+            //
+            // Although we could act on each individually, several may have been sent, and it makes 
+            // sense to accumulate them first to coordinate their re-evaluation. We will need to pay
+            // attention to which times need to be collected under which capability, so that we can
+            // assemble output batches correctly. We will maintain several builders concurrently, and
+            // place output updates into the appropriate builder.
+            //
+            // It turns out we must use notificators, as we cannot await empty batches from arrange to 
+            // indicate progress, as the arrange may not hold the capability to send such. Instead, we
+            // must watch for progress here (and the upper bound of received batches) to tell us how 
+            // far we can process work.
+            // 
+            // We really want to retire all batches we receive, so we want a frontier which reflects 
+            // both information from batches as well as progress information. I think this means that 
+            // we keep times that are greater than or equal to a time in the other frontier, deduplicated.
+
+            let mut batch_cursors = Vec::new();
+
+            // Drain the input stream of batches, validating the contiguity of the batch descriptions and
+            // capturing a cursor for each of the batches as well as ensuring we hold a capability for the
+            // times in the batch.
+            input.for_each(|capability, batches| {
+
+                // In principle we could have multiple batches per message (in practice, it would be weird).
+                for batch in batches.drain(..).map(|x| x.item) {
+                    assert!(&upper_received[..] == batch.description().lower());
+                    upper_received = batch.description().upper().to_vec();
+                    batch_cursors.push(batch.cursor());                    
+                }
+
+                // Ensure that `capabilities` covers the capability of the batch.
+                capabilities.retain(|cap| !capability.time().lt(&cap.time()));
+                if !capabilities.iter().any(|cap| cap.time().le(&capability.time())) {
+                    capabilities.push(capability);
+                }
+            });
+
+            // The interval of times we can retire is upper bounded by both the most recently received batch
+            // upper bound (`upper_received`) and by the input progress frontier (`notificator.frontier(0)`).
+            // Any new changes must be at times in advance of *both* of these antichains, as both the batch 
+            // and the frontier guarantee no more updates at times not in advance of them.
+            //
+            // I think the right thing to do is define a new frontier from the joins of elements in the two
+            // antichains. Elements we will see in the future must be greater or equal to elements in both
+            // antichains, and so much be greater or equal to some pairwise join of the antichain elements.
+            // At the same time, any element greater than some pairwise join is greater than either antichain,
+            // and so could plausibly be seen in the future (and so is not safe to retire).
+            upper_limit.clear();
+            for time1 in notificator.frontier(0) {
+                for time2 in &upper_received {
+                    let join = time1.join(time2);
+                    if !upper_limit.iter().any(|t| t.le(&join)) {
+                        upper_limit.retain(|t| !join.le(t));
+                        upper_limit.push(join);
+                    }
+                }
+            }
+
+            // If we have no capabilities, then we (i) should not produce any outputs and (ii) could not send
+            // any produced outputs even if they were (incorrectly) produced. We cannot even send empty batches
+            // to indicate forward progress, and must hope that downstream operators look at progress frontiers
+            // as well as batch descriptions.
+            //
+            // We can (and should) advance source and output traces if `upper_limit` indicates this is possible.
+            if capabilities.iter().any(|c| !upper_limit.iter().any(|t| t.le(&c.time()))) {
+
+                // println!("upper: {:?}", upper_limit);
+
+                // println!("working in group; advancing from, to:");
+                // println!("  capabilities: {:?}", capabilities);
+                // println!("  upper_limit:  {:?}", upper_limit);
+                // println!("  frontier:     {:?}", notificator.frontier(0));
+                // println!("  received:     {:?}", upper_received);
+
+                // `interesting` contains "warnings" about keys and times that may need to be re-considered.
+                // We first extract those times from this list that lie in the interval we will process.
+                sort_dedup(&mut interesting);
+                let mut new_interesting = Vec::new();
+                let mut exposed = Vec::new();
+                segment(&mut interesting, &mut exposed, &mut new_interesting, |&(_, ref time)| {
+                    !upper_limit.iter().any(|t| t.le(&time))
+                });
+                interesting = new_interesting;
+
+                // Prepare an output buffer and builder for each capability. 
+                //
+                // We buffer and build separately, as outputs are produced grouped by time, whereas the 
+                // builder wants to see outputs grouped by value. While the per-key computation could 
+                // do the re-sorting itself, buffering per-key outputs lets us double check the results
+                // against other implementations for accuracy.
+                //
+                // TODO: It would be better if all updates went into one batch, but timely dataflow prevents 
+                //       this as long as it requires that there is only one capability for each message.
+                let mut buffers = Vec::<(G::Timestamp, Vec<(V2, G::Timestamp, R2)>)>::new();
+                let mut builders = Vec::new();
+                for i in 0 .. capabilities.len() {
+                    buffers.push((capabilities[i].time(), Vec::new()));
+                    builders.push(<T2::Batch as Batch<K,V2,G::Timestamp,R2>>::Builder::new());
+                }
+
+
+                // We no longer need to distinguish between the batches we have received and historical batches,
+                // so we should allow the trace to start merging them.
+                //
+                // Note: We know that there will be no further times through `upper_limit`, but we still use the
+                // earlier `upper_received` to avoid antagonizing the trace which may end up with `upper_limit`
+                // cutting through a single (largely empty, at least near `upper_limit`) batch. 
+                source_trace.distinguish_since(&upper_received[..]);
+                output_trace.distinguish_since(&upper_received[..]);
+
+                // cursors for navigating input and output traces.
+                let mut source_cursor: T1::Cursor = source_trace.cursor_through(&upper_received[..]).unwrap();
+                let mut output_cursor: T2::Cursor = output_trace.cursor(); // TODO: this panicked when as above; WHY???
+                let mut batch_cursor = CursorList::new(batch_cursors);
+
+                // // The only purpose of `lower_received` was to allow slicing off old input.
+                // lower_received = upper_received.clone();
+
+                let mut compute_counter = 0;
+                let mut output_counter = 0;
+                let timer = ::std::time::Instant::now();
+
+                // We now march through the keys we must work on, drawing from `batch_cursors` and `exposed`.
+                //
+                // We only keep valid cursors (those with more data) in `batch_cursors`, and so its length
+                // indicates whether more data remain. We move throuh `exposed` using `exposed_position`.
+                // There could perhaps be a less provocative variable name.
+
+                let mut key_count = 0;
+
+                let mut exposed_position = 0;
+                // batch_cursors.retain(|cursor| cursor.key_valid());
+                while batch_cursor.key_valid() || exposed_position < exposed.len() {
+
+                    key_count += 1;
+
+                    // Determine the next key we will work on; could be synthetic, could be from a batch.
+                    let key1 = if exposed_position < exposed.len() { Some(exposed[exposed_position].0.clone()) } else { None };
+                    let key2 = if batch_cursor.key_valid() { Some(batch_cursor.key().clone()) } else { None };
+                    let key = match (key1, key2) {
+                        (Some(key1), Some(key2)) => ::std::cmp::min(key1, key2),
+                        (Some(key1), None)       => key1,
+                        (None, Some(key2))       => key2,
+                        (None, None)             => unreachable!(),
+                    };
+
+                    // `interesting_times` contains those times between `lower_issued` and `upper_limit` 
+                    // that we need to re-consider. We now populate it, but perhaps this should be left
+                    // to the per-key computation, which may be able to avoid examining the times of some
+                    // values (for example, in the case of min/max/topk).
+                    interesting_times.clear();
+
+                    // Populate `interesting_times` with synthetic interesting times for this key.
+                    while exposed_position < exposed.len() && exposed[exposed_position].0 == key {
+                        interesting_times.push(exposed[exposed_position].1.clone());
+                        exposed_position += 1;
+                    }
+
+                    // tidy up times, removing redundancy.
+                    interesting_times.sort();
+                    interesting_times.dedup();
+
+                    // do the per-key computation.
+                    temporary.clear();
+                    let counters = thinker2.compute(
+                        &key, 
+                        &mut source_cursor, 
+                        &mut output_cursor, 
+                        &mut batch_cursor,
+                        &mut interesting_times, 
+                        &logic, 
+                        &upper_limit[..], 
+                        &mut buffers[..], 
+                        &mut temporary,
+                    );
+
+                    compute_counter += counters.0;
+                    output_counter += counters.1;
+
+                    // Record future warnings about interesting times (and assert they should be "future").
+                    for time in temporary.drain(..) { 
+                        assert!(upper_limit.iter().any(|t| t.le(&time)));
+                        interesting.push((key.clone(), time)); 
+                    }
+
+                    // Sort each buffer by value and move into the corresponding builder.
+                    // TODO: This makes assumptions about at least one of (i) the stability of `sort_by`, 
+                    //       (ii) that the buffers are time-ordered, and (iii) that the builders accept 
+                    //       arbitrarily ordered times.
+                    for index in 0 .. buffers.len() {
+                        buffers[index].1.sort_by(|x,y| x.0.cmp(&y.0));
+                        for (val, time, diff) in buffers[index].1.drain(..) {
+                            builders[index].push((key.clone(), val, time, diff));
+                        }
+                    }
+                }
+
+                // build and ship each batch (because only one capability per message).
+                for (index, builder) in builders.drain(..).enumerate() {
+                    let mut local_upper = upper_limit.clone();
+                    for capability in &capabilities[index + 1 ..] {
+                        let time = capability.time();
+                        if !local_upper.iter().any(|t| t.le(&time)) {
+                            local_upper.retain(|t| !time.lt(t));
+                            local_upper.push(time);
+                        }
+                    }
+
+                    if lower_issued != local_upper {
+                        let batch = builder.done(&lower_issued[..], &local_upper[..], &lower_issued[..]);
+                        lower_issued = local_upper;
+                        output.session(&capabilities[index]).give(BatchWrapper { item: batch.clone() });
+                        output_trace.wrapper.borrow_mut().trace.insert(batch);
+                    }
+                }
+
+                // Determine the frontier of our interesting times.
+                let mut frontier = Vec::<G::Timestamp>::new();
+                for &(_, ref time) in &interesting {                    
+                    if !frontier.iter().any(|t| t.le(time)) {
+                        frontier.retain(|t| !time.lt(t));
+                        frontier.push(time.clone());
+                    }
+                }
+
+                // Update `capabilities` to reflect interesting pairs described by `frontier`.
+                let mut new_capabilities = Vec::new();
+                for time in frontier.drain(..) {
+                    if let Some(cap) = capabilities.iter().find(|c| c.time().le(&time)) {
+                        new_capabilities.push(cap.delayed(&time));
+                    }
+                    else {
+                        println!("{}:\tfailed to find capability less than new frontier time:", id);
+                        println!("{}:\t  time: {:?}", id, time);
+                        println!("{}:\t  caps: {:?}", id, capabilities);
+                        println!("{}:\t  uppr: {:?}", id, upper_limit);
+                    }
+                }
+                capabilities = new_capabilities;
+
+                // let mut ul = upper_limit.clone();
+                // ul.sort();
+
+                // let avg_ns = if compute_counter > 0 { (timer.elapsed() / compute_counter as u32).subsec_nanos() } else { 0 };
+                // println!("(key, times) pairs:\t{:?}\t{:?}\t{:?}\tavg {:?}ns\t{:?}", compute_counter, output_counter, key_count, avg_ns, ul);
+            }
+
+            // We have processed all updates through `upper_limit` and will only use times in advance of 
+            // this frontier to compare against historical times, so we should allow the trace to start
+            // compacting batches by advancing times.
+            source_trace.advance_by(&upper_limit[..]);
+            output_trace.advance_by(&upper_limit[..]);
+
+        });
+
+        Arranged { stream: stream, trace: result_trace }
+    }
+}
+
+// Several methods are broken out here to help understand performance profiling.
+
+#[inline(never)]
+fn sort_dedup_b<T: Ord>(list: &mut Vec<T>) {
+    list.dedup();
+    list.sort();
+    list.dedup();
+}
+
+#[inline(never)]
+fn sort_dedup<T: Ord>(list: &mut Vec<T>) {
+    list.dedup();
+    list.sort();
+    list.dedup();
+}
+
+#[inline(never)]
+fn segment<T, F: Fn(&T)->bool>(source: &mut Vec<T>, dest1: &mut Vec<T>, dest2: &mut Vec<T>, pred: F) {
+    for element in source.drain(..) {
+        if pred(&element) {
+            dest1.push(element);
+        }
+        else {
+            dest2.push(element);
+        }
+    }
+}
+
+#[inline(never)]
+fn consolidate<T: Ord, R: Ring>(list: &mut Vec<(T, R)>) {
+    list.sort_by(|x,y| x.0.cmp(&y.0));
+    for index in 1 .. list.len() {
+        if list[index].0 == list[index-1].0 {
+            list[index].1 = list[index].1 + list[index-1].1;
+            list[index-1].1 = R::zero();
+        }
+    }
+    list.retain(|x| !x.1.is_zero());
+}
+
+/// Scans `vec[off..]` and consolidates differences of adjacent equivalent elements.
+// #[inline(never)]
+pub fn consolidate_from<T: Ord+Clone, R: Ring>(vec: &mut Vec<(T, R)>, off: usize) {
+
+    // We should do an insertion-sort like initial scan which builds up sorted, consolidated runs.
+    // In a world where there are not many results, we may never even need to call in to merge sort.
+
+    vec[off..].sort_by(|x,y| x.0.cmp(&y.0));
+    for index in (off + 1) .. vec.len() {
+        if vec[index].0 == vec[index - 1].0 {
+            vec[index].1 = vec[index].1 + vec[index - 1].1;
+            vec[index - 1].1 = R::zero();
+        }
+    }
+
+    let mut cursor = off;
+    for index in off .. vec.len() {
+        if !vec[index].1.is_zero() {
+            vec[cursor] = vec[index].clone();
+            cursor += 1;
+        }
+    }
+    vec.truncate(cursor);
+    
+}
+
+trait PerKeyCompute<V1, V2, T, R1, R2> 
+where
+    V1: Ord+Clone,
+    V2: Ord+Clone,
+    T: Lattice+Ord+Clone,
+    R1: Ring,
+    R2: Ring,
+{
+    fn new() -> Self;
+    fn compute<K, C1, C2, C3, L>(
+        &mut self,
+        key: &K, 
+        input: &mut C1, 
+        output: &mut C2, 
+        batch: &mut C3,
+        times: &mut Vec<T>, 
+        logic: &L, 
+        upper_limit: &[T],
+        outputs: &mut [(T, Vec<(V2, T, R2)>)],
+        new_interesting: &mut Vec<T>) -> (usize, usize)
+    where 
+        K: Eq+Clone+Debug,
+        C1: Cursor<K, V1, T, R1>, 
+        C2: Cursor<K, V2, T, R2>, 
+        C3: Cursor<K, V1, T, R1>, 
+        L: Fn(&K, &[(V1, R1)], &mut Vec<(V2, R2)>);
+}
+
+
+/// Implementation based on replaying historical and new updates together.
+mod value_iteration {
+
+    use std::fmt::Debug;
+    use std::cmp::Ordering;
+
+    use ::Ring;
+    use lattice::Lattice;
+    use trace::Cursor;
+
+    use super::{PerKeyCompute, consolidate, sort_dedup_b, consolidate_from};
+
+    /// The `ValueIterator` is a compute strategy based on moving through existing inputs, interesting times, etc in 
+    /// time order, maintaining consolidated representations of updates with respect to future interesting times.
+    pub struct ValueIterator<V1, V2, T, R1, R2> 
+    where
+        V1: Ord+Clone,
+        V2: Ord+Clone,
+        T: Lattice+Ord+Clone,
+        R1: Ring,
+        R2: Ring,
+    {
+        batch_history: CollectionHistory<V1, T, R1>,
+        input_history: CollectionHistory<V1, T, R1>,
+        output_history: CollectionHistory<V2, T, R2>,
+        input_buffer: Vec<(V1, R1)>,
+        output_buffer: Vec<(V2, R2)>,
+        output_produced: Vec<((V2, T), R2)>,
+        known_times: Vec<T>,
+        synth_times: Vec<T>,
+        meets: Vec<T>,
+        times_current: Vec<T>,
+        lower: Vec<T>,
+        temporary: Vec<T>,
+    }
+
+    impl<V1, V2, T, R1, R2> PerKeyCompute<V1, V2, T, R1, R2> for ValueIterator<V1, V2, T, R1, R2> 
+    where
+        V1: Ord+Clone+Debug,
+        V2: Ord+Clone+Debug,
+        T: Lattice+Ord+Clone+Debug,
+        R1: Ring+Debug,
+        R2: Ring+Debug,
+    {
+        fn new() -> Self {
+            ValueIterator { 
+                batch_history: CollectionHistory::new(),
+                input_history: CollectionHistory::new(),
+                output_history: CollectionHistory::new(),
+                input_buffer: Vec::new(),
+                output_buffer: Vec::new(),
+                output_produced: Vec::new(),
+                known_times: Vec::new(),
+                synth_times: Vec::new(),
+                meets: Vec::new(),
+                times_current: Vec::new(),
+                lower: Vec::new(),
+                temporary: Vec::new(),
+            }
+        }
+        #[inline(never)]
+        fn compute<K, C1, C2, C3, L>(
+            &mut self,
+            key: &K, 
+            source_cursor: &mut C1, 
+            output_cursor: &mut C2, 
+            batch_cursor: &mut C3,
+            times: &mut Vec<T>, 
+            logic: &L, 
+            upper_limit: &[T],
+            outputs: &mut [(T, Vec<(V2, T, R2)>)],
+            new_interesting: &mut Vec<T>) -> (usize, usize)
+        where 
+            K: Eq+Clone+Debug,
+            C1: Cursor<K, V1, T, R1>, 
+            C2: Cursor<K, V2, T, R2>, 
+            C3: Cursor<K, V1, T, R1>, 
+            L: Fn(&K, &[(V1, R1)], &mut Vec<(V2, R2)>) 
+        {
+
+            // Our plan is to iterate through values, in order, reproducing the output history for each value.
+            // We maintain the cumulative output history with values elided, representing the number of records
+            // in the output, which should be sufficent for us to determine for any new value where it peeks 
+            // through.
+            //
+            // There are several optimizations to this, for example:
+            //   1. We should be able to stop early if we realize that the interval is "full". I'm not exactly 
+            //      sure what this means; we need +1 in the output covering the lower bounds of the interval, 
+            //      and no negations anywhere, I would guess (or, only at points where two +s collide?). This
+            //      seems like it should have a good answer, but I haven't nailed it yet.
+            //   2. With information about the smallest values that have changed, stolen from `batch_cursor` 
+            //      and a modified `times`, we can skip all values before the smallest and just load the output 
+            //      trace and start from there.
+
+            source_cursor.seek_key(key);
+            output_cursor.seek_key(key);
+
+            self.lower.clear();
+            if batch_cursor.key_valid() && batch_cursor.key() == key {
+                while batch_cursor.val_valid() {
+                    batch_cursor.map_times(|time,_| {
+                        if !self.lower.iter().any(|t| t.le(time)) { 
+                            self.lower.retain(|t| !time.lt(t));
+                            self.lower.push(time.clone());
+                        }                
+                    });
+                    batch_cursor.step_val();
+                }
+            }
+            for time in times.iter() {
+                if !self.lower.iter().any(|t| t.le(time)) { 
+                    self.lower.retain(|t| !time.lt(t));
+                    self.lower.push(time.clone());
+                }
+            }
+
+            // All times we encounter will be at least `meet`, and so long as we just join with and compare 
+            // against interesting times, it is safe to advance all historical times by `meet`. 
+            let mut meet = self.lower.iter().fold(T::max(), |meet, time| meet.meet(time));
+
+            // All free, input, and output updates, no values.
+            let mut free_history = Vec::<(T, T, R2)>::new();
+            let mut input_history = Vec::<(T, T, R1)>::new();
+            let mut output_history = Vec::<(T, R2)>::new();     // <-- we don't need to track the meet.
+
+            // Accumulated accepted free, input, and output updates, no values.
+            let mut full_updates = Vec::<(T, R2)>::new();
+            let mut input_updates = Vec::<(T, R1)>::new();
+            let mut output_updates = Vec::<(T, R2)>::new();
+
+            while source_cursor.val_valid() {
+
+                let val: V1 = source_cursor.val().clone();
+                let mut slice = [(val, R1::zero())];
+
+                // extract the history for the current value. use `time.clone()` as initial meet, but we will fix it.
+                source_cursor.map_times(|time, diff| source_history.push(((time.join(&meet), time.join(&meet)), diff)));
+                consolidate(&mut source_history);
+
+                // We want to walk through the merged source and output histories, accepting updates to each and 
+                // reconsidering the relationship between the two at all interesting times. I am not sure if this 
+                // is any more complicated than just looking at times in the source and output histories.
+                //
+                // Some times we consider may be beyond `upper_limit`, in which case they turn in to notifications.
+                // What if anything prompts us to return to a computation later, in the absence of external changes?
+                // I suppose we revisit all values, including those traditionally at later times (e.g. large distances
+                // even at early iterations). Each update (source, output) should probably be joined against the other 
+                // accumulation to indicate noteworthy times? 
+                // 
+                // I think we are producing the join of all times in the source history with all times in the accumulated
+                // output history, which should capture any time that is a change in either of them. 
+
+                // Produced the meets of source and output times.
+                for i in (1 .. free_history.len()).rev() { free_history[i-1].1 = free_history[i-1].1.meet(&free_history[i].1); }
+                for i in (1 .. input_history.len()).rev() { input_history[i-1].1 = input_history[i-1].1.meet(&input_history[i].1); }
+
+                let mut free_index = 0;
+                let mut input_index = 0;
+
+                let mut synthetic_times = Vec::<T>::new();
+
+                let mut full_slice = &free_history[..];
+                let mut input_slice = &input_history[..];
+
+                // walk through these historic moments
+                while full_slice.len() > 0 || input_slice.len() > 0 || synthetic_times.len() > 0 {
+
+                    // determine the next time we work on
+                    let mut time = T::max();
+
+                    // Update the time to be the least of the next times.
+                    full_slice.first().map(|x| time = min(time, x.0.clone()));
+                    input_slice.first().map(|x| time = min(time, x.0.clone()));
+                    synthetic_times.first().map(|x| time = min(time, x.clone()));
+
+                    // accept updates for `time` into `full_updates`
+                    while full_slice.len() > 0 && full_slice[0].0 == time {
+                        full_updates.push((time.clone(), full_slice[0].2));
+                        full_slice = &full_slice[1..];
+                    }
+
+                    // accept updates for `time` into `input_updates`
+                    while input_slice.len() && input_slice[0].0 == time {
+                        input_updates.push((time.clone(), input_slice[0].2));
+                        input_slice = &input_slice[1..];
+                    }
+
+                    // determine the meet of times, so that we can clean up accepted updates.
+                    let mut meet = T::max();
+                    if full_slice.len() > 0 { meet = meet.meet(&full_slice[0].1); }
+                    if input_slice.len() > 0 { meet = meet.meet(&input_slice[0].1); }
+                    for time in synthetic_times.iter() { meet = meet.meet(time); }
+
+                    // bring accepted updates forward to `meet`, consolidate update collections.
+                    for update in full_updates.iter_mut() { update.0 = update.0.join(&meet); }
+                    consolidate(&mut full_updates);
+                    for update in input_updates.iter_mut() { update.0 = update.0.join(&meet); }
+                    consolidate(&mut input_updates);
+                    for update in output_updates.iter_mut() { update.0 = update.0.join(&meet); }
+                    consolidate(&mut output_updates);
+
+                    // TODO: We could delay any inspection/accumulation of input/output until this is zero.
+                    let mut full_sum = R2::zero;
+                    for &(ref t, diff) in full_updates.iter() {
+                        if t.le(&time) { full_sum += diff; }
+                        else { interesting.push(t.join(&time)); }
+                    }
+
+                    let mut input_sum = R1::zero;
+                    for &(ref t, diff) in input_updates.iter() {
+                        if t.le(&time) { input_sum += diff; }
+                        else { interesting.push(t.join(&time)); }
+                    }
+
+                    let mut output_sum = R2::zero;
+                    for &(ref t, diff) in output_updates.iter() {
+                        if t.le(&time) { output_sum += diff; }
+                        else { interesting.push(t.join(&time)); }
+                    }
+
+                    // if `full_sum` is non-zero, the output is automatically empty. 
+                    // otherwise, we call user logic on the singleton set `[(val, input_sum)]`
+                    // and subtract `output_sum` from the result.
+                    let mut temp_output = Vec::<(V2, R2)>::new();
+                    if full_sum.is_zero() && !input_sum.is_zero() {
+                        slice.1 = input_sum;
+                        logic(key, &slice[..], &mut temp_output);
+                    }
+
+                    // subtract `output_sum` from whatever we got
+                    if temp_output.len() == 0 { 
+                        temp_output.push((val.clone(), -output_sum));
+                    }
+                    else if temp_output.len() == 1 {
+                        assert!(temp_output[0].0 == val);
+                        temp_output[0].1 = temp_output[0].1 - output_sum;
+                    }
+                    else {
+                        panic!("too many outputs! {:?}", temp_output);
+                    }
+                    consolidate(&mut temp_output);
+
+                    // resolve interesting times.
+                    interesting.sort();
+                    interesting.dedup();
+                    for time in interesting.drain(..) {
+                        if !upper_limit.iter().any(|t| t.le(&time)) {
+                            synthetic_times.push(time);
+                        }
+                        else {
+                            new_interesting.push(time); // e.g. +(1,8) and +(3,0) warn about ?(3,8), even if not there yet.
+                        }
+                    }
+                    synthetic_times.sort();
+                    synthetic_times.dedup();
+
+                }
+
+                // For values <= source.val(), merge-subtract with whatever we have in output_cursor.
+                // This may include values strictly less than source.val(), which should make their subtraction easy. ;)
+                unimplemented!();
+
+                source_cursor.step_val();
+            }
+
+            // Subtract histories for all remaining values in output_cursor.
+            unimplemented!();
+        }
+    }
+}

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -8,7 +8,7 @@
 //! other ways compatible with timely dataflow. In fact, many operators are currently absent because
 //! their timely dataflow analogues are sufficient (e.g. `map`, `filter`, `concat`).
 
-pub use self::group::{Group, Distinct, Count};
+pub use self::group::{Group, Distinct, Count, consolidate_from};
 pub use self::consolidate::Consolidate;
 pub use self::iterate::Iterate;
 pub use self::join::Join;
@@ -18,3 +18,357 @@ pub mod group;
 pub mod consolidate;
 pub mod iterate;
 pub mod join;
+
+// use std::cmp::Ordering;
+
+use ::Ring;
+use lattice::Lattice;
+use trace::{Cursor, consolidate};
+
+/// Some types used to sit in front of a Cursor<K, V, T, R> titrated through a frontier, allowing compaction of times.
+///
+/// The `EditList` type is where we accept updates from the cursor, and which in a future world might hold a copy of 
+/// the cursor so that it can lazily populate its updates. The edit list only collects updates and accumulates them, 
+/// which can involve some sorting of times to collapse them down. The list can be used immediately if there are not
+/// all that many updates, or it can be wrapped in a `ValueHistory`
+///
+/// The `ValueHistory` type wraps an edit list, and presents a time-ordered view of the edits which supports accepting
+/// updates from the edit list into a running accumulation, and compacting the accumulation with frontier information.
+/// The value history also exposes the running frontier information for remaining times in the history, but do note
+/// that this is not the frontier used for compacting the trace; this is supplied by the user, as the distinction is 
+/// important in something like `join`.
+
+/// An accumulation of (value, time, diff) updates.
+pub struct EditList<V, T, R> {
+    values: Vec<(V, usize)>,
+    edits: Vec<(T, R)>,
+}
+
+impl<V, T, R> EditList<V, T, R> where T: Ord+Clone, R: Ring {
+    /// Creates an empty list of edits.
+    #[inline(always)]
+    fn new() -> Self {
+        EditList {
+            values: Vec::new(),
+            edits: Vec::new(),
+        }
+    }
+    /// Loads the contents of a cursor.
+    fn load<K, C, L>(&mut self, cursor: &mut C, logic: L)
+    where K: Eq, V: Clone, C: Cursor<K, V, T, R>, L: Fn(&T)->T { 
+        self.clear();
+        while cursor.val_valid() {
+            cursor.map_times(|time1, diff1| self.push(logic(time1), diff1));
+            self.seal(cursor.val());
+            cursor.step_val();
+        }
+    }
+    /// Clears the list of edits.
+    #[inline(always)]
+    fn clear(&mut self) { 
+        self.values.clear();
+        self.edits.clear();
+    }
+    fn len(&self) -> usize { self.edits.len() }
+    /// Inserts a new edit for an as-yet undetermined value.
+    #[inline(always)]
+    fn push(&mut self, time: T, diff: R) {
+        // TODO: Could attempt "insertion-sort" like behavior here, where we collapse if possible.
+        self.edits.push((time, diff));
+    }
+    /// Associates all edits pushed since the previous `seal_value` call with `value`.
+    #[inline(always)]
+    fn seal(&mut self, value: &V) where V: Clone {
+        let prev = self.values.last().map(|x| x.1).unwrap_or(0);
+        consolidate_from(&mut self.edits, prev);
+        if self.edits.len() > prev {
+            self.values.push((value.clone(), self.edits.len()));
+        }
+    }
+    fn map<F: FnMut(&V, &T, R)>(&self, mut logic: F) {
+        for index in 0 .. self.values.len() {
+            let lower = if index == 0 { 0 } else { self.values[index-1].1 };
+            let upper = self.values[index].1;
+            for edit in lower .. upper {
+                logic(&self.values[index].0, &self.edits[edit].0, self.edits[edit].1);
+            }
+        }
+    }
+}
+
+struct ValueHistory2<V, T, R> {
+
+    edits: EditList<V, T, R>,
+    history: Vec<(T, T, usize, usize)>,        // (time, meet, value_index, edit_offset)
+    // frontier: FrontierHistory<T>,           // tracks frontiers of remaining times.
+    buffer: Vec<((V, T), R)>,               // where we accumulate / collapse updates.
+}
+
+impl<V: Ord+Clone, T: Lattice+Ord+Clone, R: Ring> ValueHistory2<V, T, R> {
+    fn new() -> Self {
+        ValueHistory2 {
+            edits: EditList::new(), // empty; will swap out for real list later
+            history: Vec::new(),
+            buffer: Vec::new(),
+        }
+    }
+    fn clear(&mut self) {
+        self.edits.clear();
+        self.history.clear();
+        self.buffer.clear();
+    }
+    fn load<K, C, L>(&mut self, cursor: &mut C, logic: L)
+    where K: Eq, C: Cursor<K, V, T, R>, L: Fn(&T)->T { 
+        self.edits.load(cursor, logic);
+        self.order();
+    }
+    /// Organizes history based on current contents of edits.
+    fn order(&mut self) {
+
+        self.buffer.clear();
+        self.history.clear();
+        for value_index in 0 .. self.edits.values.len() {
+            let lower = if value_index > 0 { self.edits.values[value_index-1].1 } else { 0 };
+            let upper = self.edits.values[value_index].1;
+            for edit_index in lower .. upper {
+                let time = self.edits.edits[edit_index].0.clone();
+                // assert!(value_index < self.values.len());
+                // assert!(edit_index < self.edits.len());
+                self.history.push((time.clone(), time.clone(), value_index, edit_index));
+            }
+        }
+
+        self.history.sort_by(|x,y| y.cmp(x));
+        for index in 1 .. self.history.len() {
+            self.history[index].1 = self.history[index].1.meet(&self.history[index-1].1);
+        }
+    }
+    fn time(&self) -> Option<&T> { self.history.last().map(|x| &x.0) }
+    fn meet(&self) -> Option<&T> { self.history.last().map(|x| &x.1) }
+    fn edit(&self) -> Option<(&V, &T, R)> { 
+        self.history.last().map(|&(ref t, _, v, e)| (&self.edits.values[v].0, t, self.edits.edits[e].1))
+    }
+
+    fn step(&mut self) {
+        let (time, _, value_index, edit_offset) = self.history.pop().unwrap();
+        self.buffer.push(((self.edits.values[value_index].0.clone(), time), self.edits.edits[edit_offset].1));
+    }
+    fn step_while_time_is(&mut self, time: &T) -> bool {
+        let mut found = false;
+        while self.time() == Some(time) {
+            found = true;
+            self.step();
+        }
+        found
+    }
+    fn advance_buffer_by(&mut self, meet: &T) {
+        for element in self.buffer.iter_mut() {
+            (element.0).1 = (element.0).1.join(meet);
+        }
+        consolidate(&mut self.buffer, 0);
+    }
+    fn is_done(&self) -> bool { self.history.len() == 0 }
+
+    fn _print(&self) where V: ::std::fmt::Debug, T: ::std::fmt::Debug, R: ::std::fmt::Debug {
+        for value_index in 0 .. self.edits.values.len() {
+            let lower = if value_index > 0 { self.edits.values[value_index-1].1 } else { 0 };
+            let upper = self.edits.values[value_index].1;
+            for edit_index in lower .. upper {
+                println!("{:?}, {:?}, {:?}", self.edits.values[value_index].0, self.edits.edits[edit_index].0, self.edits.edits[edit_index].1);
+            }
+        }
+    }
+}
+
+
+
+// struct ValueHistory<V: Ord+Clone, T: Lattice+Ord+Clone, R: Ring> {
+//     edits: Vec<((T, V), R)>,
+//     buffer: Vec<((T, V), R)>,
+//     frontier: Vec<T>,
+//     entrance: Vec<(T, usize)>,
+//     cursor: usize,
+// }
+
+// impl<V: Ord+Clone, T: Lattice+Ord+Clone, R: Ring> ValueHistory<V, T, R> {
+//     fn new() -> Self {
+//         ValueHistory {
+//             edits: Vec::new(),
+//             buffer: Vec::new(),
+//             frontier: Vec::new(),
+//             entrance: Vec::new(),
+//             cursor: 0,
+//         }
+//     }
+
+//     /// Loads the contents of the cursor. 
+//     // TODO: Could be optimized to not `seek_key` if we know that we are already there (e.g. with batch)
+//     // TODO: Could re-wire whole thing to bind to a cursor, and load the values lazily. Later. Much later.
+//     #[inline(never)]
+//     pub fn reload<K, C>(&mut self, key: &K, cursor: &mut C, frontier: &[T]) 
+//     where K: Eq+Clone, C: Cursor<K, V, T, R> { 
+
+//         self.clear();
+
+//         cursor.seek_key(&key);
+//         if cursor.key_valid() && cursor.key() == key {
+//             while cursor.val_valid() {
+//                 let val: V = cursor.val().clone();
+//                 cursor.map_times(|time, diff| {
+//                     self.edits.push(((time.advance_by(frontier), val.clone()), diff));
+//                 });
+//                 cursor.step_val();
+//             }
+//             // cursor.step_key();
+//         }
+
+//         self.order();
+//     }
+
+//     fn clear(&mut self) {
+//         self.edits.clear();
+//         self.buffer.clear();
+//         self.frontier.clear();
+//         self.entrance.clear();
+//     }
+//     fn push(&mut self, val: V, time: T, ring: R) {
+//         self.edits.push(((time, val), ring));
+//     }
+//     fn order(&mut self) {
+        
+//         consolidate(&mut self.edits, 0);
+
+//         self.buffer.clear();
+//         self.cursor = 0;
+//         self.frontier.clear();
+//         self.entrance.clear();
+
+//         self.entrance.reserve(self.edits.len());
+//         let mut position = self.edits.len();
+//         while position > 0 {
+//             position -= 1;
+//             // "add" edits[position] and seeing who drops == who is exposed when edits[position] removed.
+//             let mut index = 0;
+//             while index < self.frontier.len() {
+//                 if (self.edits[position].0).0.le(&self.frontier[index]) {
+//                     self.entrance.push((self.frontier.swap_remove(index), position));
+//                 }
+//                 else {
+//                     index += 1;
+//                 }
+//             }
+//             self.frontier.push((self.edits[position].0).0.clone());
+//         }
+//     }
+
+//     fn advance_buffer_by(&mut self, frontier: &[T]) {
+//         if frontier.len() > 0 {
+//             for &mut ((ref mut time, _), _) in &mut self.buffer {
+//                 *time = time.advance_by(frontier);
+//             }
+//             consolidate(&mut self.buffer, 0);
+//         }
+//         else {
+//             self.buffer.clear();
+//         }
+//     }
+
+//     fn time(&self) -> Option<&T> { 
+//         if self.cursor < self.edits.len() { 
+//             Some(&(self.edits[self.cursor].0).0) 
+//         } 
+//         else { 
+//             None 
+//         } 
+//     }
+//     fn edit(&self) -> &((T, V), R) { &self.edits[self.cursor] }
+//     fn frontier(&self) -> &[T] { &self.frontier[..] }
+//     fn step(&mut self) { 
+
+//         // a. remove time from frontier; it's not there any more.
+//         let new_time = &(self.edits[self.cursor].0).0;
+//         self.frontier.retain(|x| !x.eq(new_time));
+//         // b. add any indicated elements
+//         while self.entrance.last().map(|x| x.1) == Some(self.cursor) {
+//             self.frontier.push(self.entrance.pop().unwrap().0);
+//         }
+
+//         self.buffer.push(self.edits[self.cursor].clone());
+//         self.cursor += 1; 
+//     }
+//     /// Advance history through `time` and indicate if an update occurs at `time`.
+//     pub fn step_while_time_is(&mut self, time: &T, frontier: &[T]) -> bool {
+//         let mut found = false;
+//         while self.time().map(|x| x.cmp(time)) == Some(Ordering::Equal) {
+//             found = true;
+//             self.step();
+//         }
+//         // if found {
+//         //     self.advance_buffer_by(frontier);
+//         // }
+//         found
+//     }
+//     fn not_done(&self) -> bool { self.cursor < self.edits.len() }
+//     fn is_done(&self) -> bool { self.cursor >= self.edits.len() }
+// }
+
+
+// We would like the ability to take in a large pile of updates, perhaps organized by value, and put them in 
+// a format that makes it easy to walk forward through the times, maintaining a compact representation of the 
+// accumulated updates. There are several constraints to avoid being problematic:
+//
+//   1. There could be arbitrarily many values; we should not assume that their number is relatively small.
+//   2. There can be arbitrarily many times
+//   3. While the accumulation at any point can be arbitrarily large, no magic there. 
+
+
+
+// /// Trace the frontier of all suffixes of a sequence of times.
+// ///
+// /// Capable of playing forward through 
+// /// the times with the exact frontier for each remaining suffix. Could be simplified to just track
+// /// the meet, simplifying the logic at a loss in accuracy (for non-distributive lattices at least).
+// pub struct FrontierHistory<T> {
+//     frontier: Vec<T>,
+//     entrance: Vec<(T, usize)>,
+// }
+
+// impl<T: Lattice+Clone> FrontierHistory<T> {
+//     fn new() -> Self {
+//         FrontierHistory {
+//             frontier: Vec::new(),
+//             entrance: Vec::new(),
+//         }
+//     }
+//     fn clear(&mut self) {
+//         self.frontier.clear();
+//         self.entrance.clear();
+//     }
+//     /// Loads the frontier history of sequence of pairs of decreasing positions and non-increasing times.
+//     ///
+//     /// The `length` argument should be the length of the iterator, 
+//     fn load<I: Iterator<Item=(usize,T)>>(&mut self, iterator: I) {
+//         self.frontier.clear();
+//         self.entrance.clear();
+//         for (position, time) in iterator {
+//             let mut index = 0;
+//             while index < self.frontier.len() {
+//                 if time.le(&self.frontier[index]) {
+//                     self.entrance.push((self.frontier.swap_remove(index), position));
+//                 }
+//                 else {
+//                     index += 1;
+//                 }
+//             }
+//             self.frontier.push(time);
+//         }
+//     }
+//     /// Move the frontier forward to a given position as indicated when we loaded the frontier history.
+//     fn advance_to(&mut self, position: usize) {
+//         while self.entrance.last().map(|x| x.1 == position) == Some(true) {
+//             let time = self.entrance.pop().unwrap().0;
+//             self.frontier.retain(|x| !x.le(&time));
+//             self.frontier.push(time);
+//         }
+//     }
+// }

--- a/src/ring.rs
+++ b/src/ring.rs
@@ -13,11 +13,20 @@ pub trait Ring : Add<Self, Output=Self> + Sub<Self, Output=Self> + Neg<Output=Se
 	fn zero() -> Self;
 }
 
-impl Ring for isize { 
+impl Ring for isize {
 	#[inline(always)] fn is_zero(&self) -> bool { *self == 0 }
 	#[inline(always)] fn zero() -> Self { 0 }
 }
 
+impl Ring for i64 {
+	#[inline(always)] fn is_zero(&self) -> bool { *self == 0 }
+	#[inline(always)] fn zero() -> Self { 0 }
+}
+
+impl Ring for i32 {
+	#[inline(always)] fn is_zero(&self) -> bool { *self == 0 }
+	#[inline(always)] fn zero() -> Self { 0 }
+}
 
 /// The ring defined by a pair of ring elements.
 #[derive(Copy, Ord, PartialOrd, Eq, PartialEq, Debug, Clone)]

--- a/tests/bfs.rs
+++ b/tests/bfs.rs
@@ -19,7 +19,7 @@ use differential_dataflow::lattice::Lattice;
 type Node = usize;
 type Edge = (Node, Node);
 
-#[test] fn bfs_10_20_1000() { test_sizes(10, 20, 1000); }
+#[test] fn bfs_10_20_1000() { test_sizes(10, 20, 200); }
 #[test] fn bfs_100_200_10() { test_sizes(100, 200, 10); }
 #[test] fn bfs_100_2000_1() { test_sizes(100, 2000, 1); }
 
@@ -48,6 +48,21 @@ fn test_sizes(nodes: usize, edges: usize, rounds: usize) {
     results1.sort_by(|x,y| x.1.cmp(&y.1));
     results2.sort();
     results2.sort_by(|x,y| x.1.cmp(&y.1));
+
+    if results1 != results2 {
+        println!("RESULTS INEQUAL!!!");
+        for x in &results1 { 
+            if !results2.contains(x) {
+                println!("  in seq, not diff: {:?}", x);
+            }
+        }
+        for x in &results2 { 
+            if !results1.contains(x) {
+                println!("  in diff, not seq: {:?}", x);
+            }
+        }
+
+    }
 
     assert_eq!(results1, results2);
 }

--- a/tests/join.rs
+++ b/tests/join.rs
@@ -77,6 +77,8 @@ fn antijoin() {
     assert_eq!(extracted[0].1, vec![((1,2), Default::default(),1)]);
 }
 
+#[test] fn join_scale_1() { join_scaling(1); }
+#[test] fn join_scale_10() { join_scaling(10); }
 #[test] fn join_scale_100() { join_scaling(100); }
 #[test] fn join_scale_1000() { join_scaling(1000); }
 #[test] fn join_scale_10000() { join_scaling(10000); }


### PR DESCRIPTION
This PR changes a bit about how `group` works. In particular, some care is taken to try to use internal datastructures that make no assumptions about the complexity of updates a collection experiences. Some previous attempts behave best with few distinct values, and performed relatively poorly (quadratic) with many distinct values.

The data structure has been factored out of `group` and is now also used by `join`. It should be a fine thing to look at for optimization. There is still plenty of work to do with `group`, and a start on a custom `min` operator (which unfortunately assumes few values).