### PR TITLE
TPCH-like initial check in

### DIFF
--- a/tpchlike/.gitignore
+++ b/tpchlike/.gitignore
@@ -1,0 +1,2 @@
+Cargo.lock
+/target

--- a/tpchlike/Cargo.toml
+++ b/tpchlike/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "tpchlike"
+version = "0.1.0"
+authors = ["Frank McSherry <fmcsherry@me.com>"]
+
+[dependencies.timely]
+git="https://github.com/frankmcsherry/timely-dataflow"
+
+[dependencies.differential-dataflow]
+#git="https://github.com/frankmcsherry/differential-dataflow"
+path=".."
+
+[dependencies]
+abomonation="0.4.5"

--- a/tpchlike/examples/tpch15.rs
+++ b/tpchlike/examples/tpch15.rs
@@ -1,0 +1,185 @@
+extern crate rand;
+extern crate timely;
+extern crate differential_dataflow;
+
+use std::time::Instant;
+
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+
+use timely::dataflow::*;
+use timely::dataflow::operators::*;
+
+use differential_dataflow::AsCollection;
+use differential_dataflow::operators::*;
+use differential_dataflow::input::InputSession;
+
+fn main() {
+
+    timely::execute_from_args(std::env::args().skip(4), |computation| {
+
+        let items_pattern = std::env::args().nth(1).unwrap();
+        let delimiter = std::env::args().nth(2).unwrap();
+        let batch: usize = std::env::args().nth(3).unwrap().parse().unwrap();
+
+        let comm_index = computation.index();
+        let comm_peers = computation.peers();
+
+        let timer = Instant::now();
+
+        // form the TPCH15-like query
+        let (mut items, probe) = computation.scoped::<usize,_,_>(move |builder| {
+
+            let (item_input, items) = builder.new_input::<((u32, u32, u32), _, _)>();
+
+            // restrict lineitems to those of the relevant part
+            let items = items.map(|((sup_no, price, disc), t, d)| (sup_no, t, d * (price * (100 - disc) / 100) as isize))
+                             // would put a .filter here if we care about dates
+                             .as_collection();
+
+            let probe = items.count_u()
+                             .map(|(sup_no, count)| (0u8, (count as usize, sup_no)))
+                             .group_u(|_k,s,t| {
+                                let min = (s[0].0).0;
+                                t.extend(s.iter().take_while(|x| (x.0).0 == min).map(|x| ((x.0).1, 1)));
+                             })
+                             .probe();
+
+            (item_input, probe.0)
+        });
+
+        // read the lineitems input file
+        let mut items_buffer = Vec::new();
+        let items_file = File::open(items_pattern).expect("didn't find items file");
+        let items_reader =  BufReader::new(items_file);
+        for (index, line) in items_reader.lines().enumerate() {
+            if index % comm_peers == comm_index {
+                let text = line.ok().expect("read error");
+                let mut fields = text.split(&delimiter);
+                fields.next();  // order key
+                fields.next();  // part key
+                let sup_no = fields.next().unwrap().parse::<u32>().unwrap();
+                fields.next();  // line number
+                fields.next();  // quantity
+                let extended_price = fields.next().unwrap().parse::<f64>().unwrap() as u32;
+                let discount = (fields.next().unwrap().parse::<f32>().unwrap() * 100.0) as u32;
+                items_buffer.push(((sup_no, extended_price, discount), index));
+            }
+        }
+
+        println!("data loaded at {:?}", timer.elapsed());
+        let timer = ::std::time::Instant::now();
+        let item_count = items_buffer.len();
+
+        // create an input session and start feeding items.
+        let mut session = InputSession::from(&mut items);
+        for (counter, (record, index)) in items_buffer.drain(..).enumerate() {
+            if session.time().inner < index { session.advance_to(index); }
+            session.insert(record);
+            if counter % batch == batch - 1 {
+                session.flush();
+                computation.step_while(|| probe.lt(session.time()));
+                let elapsed = timer.elapsed();
+                let nanos = 1000000000 * elapsed.as_secs() + elapsed.subsec_nanos() as u64;
+                let rate = (index as f64) / (nanos as f64 / 1000000000.0);
+                // println!("{:?}:\tprocessed {:?} elements", timer.elapsed(), counter);
+                println!("rate: {:?}", rate);
+            }
+        }
+
+        // finish session and drain computation.
+        session.flush();
+        computation.step_while(|| probe.lt(session.time()));
+
+        println!("computation finished at {:?}", timer.elapsed());
+        let elapsed = timer.elapsed();
+        let nanos = (elapsed.as_secs() * 1000000000 + elapsed.subsec_nanos() as u64) as f64;
+        println!("throughput:  {:?} elt/s", item_count as f64 / (nanos / 1000000000.0));
+        println!("avg latency: {:?} ns", nanos / ((item_count / batch) as f64));
+    }).unwrap();
+}
+
+pub struct Part {
+    part_key: usize,
+    name: [u8; 55],
+    mfgr: [u8; 25],
+    brand: [u8; 10],
+    type: [u8; 25],
+    size: i32,
+    container: [u8; 10],
+    retail_price: i64,
+    comment: [u8; 23],
+}
+
+pub struct Supplier {
+    supp_key: usize,
+    name: [u8; 25],
+    address: [u8; 40],
+    nation_key: usize,
+    phone: [u8; 15],
+    acctbal: i64,
+    comment: [u8; 101],
+}
+
+pub struct PartSupp {
+    part_key: usize,
+    supp_key: usize,
+    availqty: i32,
+    supplycost: i64,
+    comment: [u8; 199],
+}
+
+pub struct Customer {
+    cust_key: usize,
+    name: [u8; 25],
+    address: [u8; 40],
+    nation_key: usize,
+    phone: [u8; 15],
+    acctbal: i64,
+    mktsegment: [u8; 10],
+    comment: [u8; 117],
+}
+
+pub struct Orders {
+    order_key: usize,
+    cust_key: usize,
+    order_status: [u8; 1],
+    total_price: i64,
+    order_date: DateTime,
+    order_priority: [u8; 15],
+    clerk: [u8; 15],
+    ship_priority: i32,
+    comment: [u8; 79],
+}
+
+pub struct LineItem {
+    order_key: usize,
+    part_key: usize,
+    supp_key: usize,
+    line_number: i32,
+    quantity: i64,
+    extended_price: i64,
+    discount: i64,
+    tax: i64,
+    return_flag: [u8; 1],
+    line_status: [u8; 1],
+    ship_date: DateTime,
+    commit_date: DateTime,
+    receipt_date: DateTime,
+    ship_instruct: [u8; 25],
+    ship_mode: [u8; 10],
+    comment: [u8; 44],
+}
+
+pub struct Nation {
+    nation_key: usize,
+    name: [u8; 25],
+    region_key: usize,
+    comment: [u8; 152],
+}
+
+pub struct Region {
+    region_key: usize,
+    name: [u8; 25],
+    comment: [u8; 152],
+}

--- a/tpchlike/examples/tpch17.rs
+++ b/tpchlike/examples/tpch17.rs
@@ -1,0 +1,135 @@
+// extern crate rand;
+extern crate timely;
+extern crate differential_dataflow;
+
+use std::time::Instant;
+
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+
+use timely::dataflow::*;
+use timely::dataflow::operators::*;
+
+use differential_dataflow::AsCollection;
+use differential_dataflow::operators::*;
+use differential_dataflow::input::InputSession;
+
+fn main() {
+
+    timely::execute_from_args(std::env::args().skip(4), |computation| {
+
+        let parts_pattern = std::env::args().nth(1).unwrap();
+        let items_pattern = std::env::args().nth(2).unwrap();
+        let delimiter = std::env::args().nth(3).unwrap();
+        let batch: usize = std::env::args().nth(4).unwrap().parse().unwrap();
+
+        let comm_index = computation.index();
+        let comm_peers = computation.peers();
+
+        let timer = Instant::now();
+
+        // form the TPCH17-like query
+        let (mut parts, mut items, probe) = computation.scoped::<usize,_,_>(move |builder| {
+
+            let (part_input, parts) = builder.new_input::<((u32, String, String), _, _)>();
+            let (item_input, items) = builder.new_input::<((u32, u32, u64), _, _)>();
+
+            // filter parts by brand and container
+            let parts = parts.as_collection()
+                             .filter(|x| x.1 == "Brand#23" && x.2 == "MED BOX")
+                             .map(|(key, _, _)| key);
+
+            // restrict lineitems to those of the relevant part
+            let items = items.as_collection()
+                             .map(|x| (x.0, (x.1, x.2)))
+                             .semijoin_u(&parts);
+
+            // group by item id, keep way below average quantities.
+            let probe = items.group_u(|_, s, t| {
+
+                                 let sum: u32 = s.iter().map(|x| (x.0).0).sum();
+                                 let cnt = s.len() as u32;
+                                 let avg = sum / cnt as u32;
+
+                                 for &((q, price), _) in s {
+                                    if q < avg / 5 {
+                                        t.push((price, 1));
+                                    }
+                                 }
+
+                             })
+                             .probe();
+
+            (part_input, item_input, probe.0)
+        });
+
+        // read the parts input file
+        let parts_file = File::open(parts_pattern).expect("didn't find parts file");
+        if comm_index == 0 {
+            let &time = parts.time();
+            let parts_reader = BufReader::new(parts_file);
+            for (index, line) in parts_reader.lines().enumerate() {
+                if index % comm_peers == comm_index {
+                    let text = line.ok().expect("read error");
+                    let mut fields = text.split(&delimiter);
+                    let part_id = fields.next().unwrap().parse::<u32>().unwrap();
+                    fields.next();
+                    fields.next();
+                    let brand = fields.next().unwrap().to_owned();
+                    fields.next();
+                    fields.next();
+                    let container = fields.next().unwrap().to_owned();
+                    parts.send(((part_id, brand, container), time, 1));
+                }
+            }
+        }
+
+        computation.step();
+
+        // read the lineitems input file
+        let mut items_buffer = Vec::new();
+        let items_file = File::open(items_pattern).expect("didn't find items file");
+        let items_reader =  BufReader::new(items_file);
+        for (index, line) in items_reader.lines().enumerate() {
+            if index % comm_peers == comm_index {
+                let text = line.ok().expect("read error");
+                let mut fields = text.split(&delimiter);
+                fields.next();
+                let item_id = fields.next().unwrap().parse::<u32>().unwrap();
+                fields.next();
+                fields.next();
+                let quantity = fields.next().unwrap().parse::<u32>().unwrap();
+                let extended_price = fields.next().unwrap().parse::<f64>().unwrap() as u64;
+                items_buffer.push(((item_id, quantity, extended_price), index));
+            }
+        }
+
+        println!("data loaded at {:?}", timer.elapsed());
+        let timer = ::std::time::Instant::now();
+        let item_count = items_buffer.len();
+
+        // close parts so that we can make progress through items.
+        parts.close();
+
+        // create an input session and start feeding items.
+        let mut session = InputSession::from(&mut items);
+        for (counter, ((item_id, quantity, extended_price), index)) in items_buffer.drain(..).enumerate() {
+            if session.time().inner < index { session.advance_to(index); }
+            session.insert((item_id, quantity, extended_price));
+            if counter % batch == batch - 1 {
+                session.flush();
+                computation.step_while(|| probe.lt(session.time()));
+            }
+        }
+
+        // finish session and drain computation.
+        session.flush();
+        computation.step_while(|| probe.lt(session.time()));
+
+        println!("computation finished at {:?}", timer.elapsed());
+        let elapsed = timer.elapsed();
+        let nanos = (elapsed.as_secs() * 1000000000 + elapsed.subsec_nanos() as u64) as f64;
+        println!("throughput:  {:?} elt/s", item_count as f64 / (nanos / 1000000000.0));
+        println!("avg latency: {:?} ns", nanos / ((item_count / batch) as f64));
+    }).unwrap();
+}

--- a/tpchlike/src/main.rs
+++ b/tpchlike/src/main.rs
@@ -1,0 +1,254 @@
+#[macro_use]
+extern crate abomonation;
+extern crate timely;
+extern crate differential_dataflow;
+
+use std::fs::File;
+use std::io::{BufRead, BufReader, Write};
+use std::time::Instant;
+
+use timely::dataflow::*;
+use timely::dataflow::operators::*;
+
+use differential_dataflow::{Collection, AsCollection};
+use differential_dataflow::input::InputSession;
+
+mod types;
+mod queries;
+
+use types::*;
+
+fn main() {
+
+    timely::execute_from_args(std::env::args().skip(4), |computation| {
+
+        let index = computation.index();
+        let peers = computation.peers();
+
+        let prefix = ::std::env::args().nth(1).unwrap();;
+        let logical_batch = ::std::env::args().nth(2).unwrap().parse::<usize>().unwrap();
+        let physical_batch = ::std::env::args().nth(3).unwrap().parse::<usize>().unwrap();
+
+        // customer.tbl lineitem.tbl    nation.tbl  orders.tbl  part.tbl    partsupp.tbl    region.tbl  supplier.tbl
+        let mut customers = load::<Customer>(prefix.as_str(), "customer.tbl", index, peers, logical_batch).into_iter().flat_map(|x| x.into_iter()).peekable();
+        let mut lineitems = load::<LineItem>(prefix.as_str(), "lineitem.tbl", index, peers, logical_batch).into_iter().flat_map(|x| x.into_iter()).peekable();
+        let mut nations = load::<Nation>(prefix.as_str(), "nation.tbl", index, peers, logical_batch).into_iter().flat_map(|x| x.into_iter()).peekable();
+        let mut orders = load::<Order>(prefix.as_str(), "orders.tbl", index, peers, logical_batch).into_iter().flat_map(|x| x.into_iter()).peekable();
+        let mut parts = load::<Part>(prefix.as_str(), "part.tbl", index, peers, logical_batch).into_iter().flat_map(|x| x.into_iter()).peekable();
+        let mut partsupps = load::<PartSupp>(prefix.as_str(), "partsupp.tbl", index, peers, logical_batch).into_iter().flat_map(|x| x.into_iter()).peekable();
+        let mut regions = load::<Region>(prefix.as_str(), "region.tbl", index, peers, logical_batch).into_iter().flat_map(|x| x.into_iter()).peekable();
+        let mut suppliers = load::<Supplier>(prefix.as_str(), "supplier.tbl", index, peers, logical_batch).into_iter().flat_map(|x| x.into_iter()).peekable();
+
+        let (mut inputs, probes) = computation.scoped::<usize,_,_>(move |builder| {
+
+            // create new inputs to use in computations!
+            let (cust_in, cust) = builder.new_input();
+            let (line_in, line) = builder.new_input();
+            let (nats_in, nats) = builder.new_input();
+            let (ords_in, ords) = builder.new_input();
+            let (part_in, part) = builder.new_input();
+            let (psup_in, psup) = builder.new_input();
+            let (regs_in, regs) = builder.new_input();
+            let (supp_in, supp) = builder.new_input();
+
+            let collections = Collections::new(
+                cust.as_collection(),
+                line.as_collection(),
+                nats.as_collection(),
+                ords.as_collection(),
+                part.as_collection(),
+                psup.as_collection(),
+                regs.as_collection(),
+                supp.as_collection(),
+            );  
+
+            let mut probes = Vec::new();
+
+            // probes.push(queries::query01::query(&collections));
+            // probes.push(queries::query02::query(&collections));
+            probes.push(queries::query06::query(&collections));
+            // probes.push(queries::query15::query(&collections));
+            // probes.push(queries::query17::query(&collections));
+
+            // return the various input handles, and the list of probes.
+            ((cust_in, line_in, nats_in, ords_in, part_in, psup_in, regs_in, supp_in), probes)
+        });
+
+        // Create input sessions for use in simulating the input.
+        let mut customers_input = InputSession::from(&mut inputs.0);
+        let mut lineitems_input = InputSession::from(&mut inputs.1);
+        let mut nations_input = InputSession::from(&mut inputs.2);
+        let mut orders_input = InputSession::from(&mut inputs.3);
+        let mut parts_input = InputSession::from(&mut inputs.4);
+        let mut partsupps_input = InputSession::from(&mut inputs.5);
+        let mut regions_input = InputSession::from(&mut inputs.6);
+        let mut suppliers_input = InputSession::from(&mut inputs.7);
+
+        let timer = Instant::now();
+
+        for round in 0 .. (7_000_000 / physical_batch) + 2 {
+
+            let physical_round = round * physical_batch;
+
+            while customers.peek().map(|x| x.0 < physical_round) == Some(true) {
+                let (count, data) = customers.next().unwrap();
+                customers_input.advance_to(8 * count + 0);
+                customers_input.insert(data); 
+            }
+
+            while lineitems.peek().map(|x| x.0 < physical_round) == Some(true) {
+                let (count, data) = lineitems.next().unwrap();
+                lineitems_input.advance_to(8 * count + 1);
+                lineitems_input.insert(data); 
+            }
+
+            while nations.peek().map(|x| x.0 < physical_round) == Some(true) {
+                let (count, data) = nations.next().unwrap();
+                nations_input.advance_to(8 * count + 2);
+                nations_input.insert(data); 
+            }
+
+            while orders.peek().map(|x| x.0 < physical_round) == Some(true) {
+                let (count, data) = orders.next().unwrap();
+                orders_input.advance_to(8 * count + 3);
+                orders_input.insert(data); 
+            }
+
+            while parts.peek().map(|x| x.0 < physical_round) == Some(true) {
+                let (count, data) = parts.next().unwrap();
+                parts_input.advance_to(8 * count + 4);
+                parts_input.insert(data); 
+            }
+
+            while partsupps.peek().map(|x| x.0 < physical_round) == Some(true) {
+                let (count, data) = partsupps.next().unwrap();
+                partsupps_input.advance_to(8 * count + 5);
+                partsupps_input.insert(data); 
+            }
+
+            while regions.peek().map(|x| x.0 < physical_round) == Some(true) {
+                let (count, data) = regions.next().unwrap();
+                regions_input.advance_to(8 * count + 6);
+                regions_input.insert(data); 
+            }
+
+            while suppliers.peek().map(|x| x.0 < physical_round) == Some(true) {
+                let (count, data) = suppliers.next().unwrap();
+                suppliers_input.advance_to(8 * count + 7);
+                suppliers_input.insert(data); 
+            }
+
+            // catch all inputs up to the same (next) round.
+            customers_input.advance_to(8 * physical_round);
+            lineitems_input.advance_to(8 * physical_round);
+            nations_input.advance_to(8 * physical_round);
+            orders_input.advance_to(8 * physical_round);
+            parts_input.advance_to(8 * physical_round);
+            partsupps_input.advance_to(8 * physical_round);
+            regions_input.advance_to(8 * physical_round);
+            suppliers_input.advance_to(8 * physical_round);
+
+            // flush each of the sessions.
+            customers_input.flush();
+            lineitems_input.flush();
+            nations_input.flush();
+            orders_input.flush();
+            parts_input.flush();
+            partsupps_input.flush();
+            regions_input.flush();
+            suppliers_input.flush();
+
+            let time = customers_input.time(); 
+            computation.step_while(|| probes.iter().all(|p| p.lt(&time)));
+        }
+
+        println!("elapsed: {:?}", timer.elapsed());
+
+    }).unwrap();
+
+
+}
+
+pub struct Collections<G: Scope> {
+    customers: Collection<G, Customer, isize>,
+    lineitems: Collection<G, LineItem, isize>,
+    nations: Collection<G, Nation, isize>,
+    orders: Collection<G, Order, isize>,
+    parts: Collection<G, Part, isize>,
+    partsupps: Collection<G, PartSupp, isize>,
+    regions: Collection<G, Region, isize>,
+    suppliers: Collection<G, Supplier, isize>,
+}
+
+impl<G: Scope> Collections<G> {
+    fn new(
+        customers: Collection<G, Customer, isize>,
+        lineitems: Collection<G, LineItem, isize>,
+        nations: Collection<G, Nation, isize>,
+        orders: Collection<G, Order, isize>,
+        parts: Collection<G, Part, isize>,
+        partsupps: Collection<G, PartSupp, isize>,
+        regions: Collection<G, Region, isize>,
+        suppliers: Collection<G, Supplier, isize>,
+    ) -> Self {
+
+        Collections {
+            customers: customers,
+            lineitems: lineitems,
+            nations: nations,
+            orders: orders,
+            parts: parts,
+            partsupps: partsupps,
+            regions: regions,
+            suppliers: suppliers,
+        }
+    }
+}
+
+fn load<T>(prefix: &str, name: &str, index: usize, peers: usize, batch: usize) -> Vec<Vec<(usize, T)>> 
+where T: for<'a> From<&'a str> {
+
+    let mut result = Vec::new();
+    let mut buffer = Vec::new();
+
+    let path = format!("{}{}", prefix, name);
+
+    let items_file = File::open(&path).expect("didn't find items file");
+    let mut items_reader =  BufReader::new(items_file);
+    let mut count = 0;
+
+    let mut line = String::new();
+
+    while items_reader.read_line(&mut line).unwrap() > 0 { 
+
+        if count % peers == index {
+
+            let item = T::from(line.as_str());
+
+            if buffer.len() == buffer.capacity() {
+                if buffer.len() > 0 {
+                    result.push(buffer);
+                }
+                buffer = Vec::with_capacity(1 << 10);
+            }
+
+            buffer.push((count / batch, item));
+        }
+
+        if count % 10000 == 0 { 
+            print!("\rreading records from {:?}: {:?}", name, count); 
+            ::std::io::stdout().flush().ok().expect("Could not flush stdout"); 
+        }
+
+        count += 1;
+
+        line.clear();
+    }
+    println!("\rreading records from {:?}: {:?}", name, count); 
+    
+    if buffer.len() > 0 {
+        result.push(buffer);
+    }
+
+    result
+}

--- a/tpchlike/src/queries/mod.rs
+++ b/tpchlike/src/queries/mod.rs
@@ -1,0 +1,5 @@
+pub mod query01;
+pub mod query02;
+pub mod query06;
+pub mod query15;
+pub mod query17;

--- a/tpchlike/src/queries/query01.rs
+++ b/tpchlike/src/queries/query01.rs
@@ -1,0 +1,57 @@
+use timely::dataflow::*;
+use timely::dataflow::operators::*;
+use timely::dataflow::operators::probe::Handle as ProbeHandle;
+
+use differential_dataflow::AsCollection;
+use differential_dataflow::operators::*;
+use differential_dataflow::lattice::Lattice;
+use differential_dataflow::ring::RingPair;
+
+use ::Collections;
+
+// -- $ID$
+// -- TPC-H/TPC-R Pricing Summary Report Query (Q1)
+// -- Functional Query Definition
+// -- Approved February 1998
+// :x
+// :o
+// select
+//     l_returnflag,
+//     l_linestatus,
+//     sum(l_quantity) as sum_qty,
+//     sum(l_extendedprice) as sum_base_price,
+//     sum(l_extendedprice * (1 - l_discount)) as sum_disc_price,
+//     sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) as sum_charge,
+//     avg(l_quantity) as avg_qty,
+//     avg(l_extendedprice) as avg_price,
+//     avg(l_discount) as avg_disc,
+//     count(*) as count_order
+// from
+//     lineitem
+// where
+//     l_shipdate <= date '1998-12-01' - interval ':1' day (3)
+// group by
+//     l_returnflag,
+//     l_linestatus
+// order by
+//     l_returnflag,
+//     l_linestatus;
+// :n -1
+
+pub fn query<G: Scope>(collections: &Collections<G>) -> ProbeHandle<G::Timestamp> where G::Timestamp: Lattice+Ord {
+
+    collections.lineitems
+               .filter(|x| x.ship_date < ::types::create_date(1998,9,1))
+               .inner
+               .map(|(item, time, diff)| 
+                ((item.return_flag, item.line_status), time, 
+                    RingPair::new(item.quantity, 
+                    RingPair::new(item.extended_price,
+                    RingPair::new(item.extended_price * (100 - item.discount) / 100,
+                    RingPair::new(item.extended_price * (100 - item.discount) * (100 + item.tax) / 10000,
+                    RingPair::new(item.discount, diff)))))))
+               .as_collection()
+               .count()
+               .probe()
+               .0
+}

--- a/tpchlike/src/queries/query02.rs
+++ b/tpchlike/src/queries/query02.rs
@@ -1,0 +1,121 @@
+use timely::dataflow::*;
+use timely::dataflow::operators::*;
+use timely::dataflow::operators::probe::Handle as ProbeHandle;
+
+use differential_dataflow::AsCollection;
+use differential_dataflow::operators::*;
+use differential_dataflow::lattice::Lattice;
+
+use ::Collections;
+
+// -- $ID$
+// -- TPC-H/TPC-R Minimum Cost Supplier Query (Q2)
+// -- Functional Query Definition
+// -- Approved February 1998
+// :x
+// :o
+// select
+//     s_acctbal,
+//     s_name,
+//     n_name,
+//     p_partkey,
+//     p_mfgr,
+//     s_address,
+//     s_phone,
+//     s_comment
+// from
+//     part,
+//     supplier,
+//     partsupp,
+//     nation,
+//     region
+// where
+//     p_partkey = ps_partkey
+//     and s_suppkey = ps_suppkey
+//     and p_size = :1
+//     and p_type like '%:2'
+//     and s_nationkey = n_nationkey
+//     and n_regionkey = r_regionkey
+//     and r_name = ':3'
+//     and ps_supplycost = (
+//         select
+//             min(ps_supplycost)
+//         from
+//             partsupp,
+//             supplier,
+//             nation,
+//             region
+//         where
+//             p_partkey = ps_partkey
+//             and s_suppkey = ps_suppkey
+//             and s_nationkey = n_nationkey
+//             and n_regionkey = r_regionkey
+//             and r_name = ':3'
+//     )
+// order by
+//     s_acctbal desc,
+//     n_name,
+//     s_name,
+//     p_partkey;
+// :n 100
+
+fn starts_with(source: &[u8], query: &[u8]) -> bool {
+    source.len() >= query.len() && &source[..query.len()] == query
+}
+
+fn substring(source: &[u8], query: &[u8]) -> bool {
+    (0 .. (source.len() - query.len())).any(|offset| 
+        (0 .. query.len()).all(|i| source[i + offset] == query[i])
+    )
+}
+
+pub fn query<G: Scope>(collections: &Collections<G>) -> ProbeHandle<G::Timestamp> 
+where G::Timestamp: Lattice+Ord {
+
+    let regions = 
+    collections
+        .regions
+        .filter(|x| starts_with(&x.name[..], b"EUROPE"))
+        .map(|x| x.region_key);
+
+    let nations = 
+    collections
+        .nations
+        .map(|x| (x.region_key, (x.nation_key, x.name)))
+        .semijoin(&regions)
+        .map(|(regio_key, (nation_key, name))| (nation_key, name));
+
+    let suppliers = 
+    collections
+        .suppliers
+        .map(|x| (x.nation_key, (x.acctbal, x.name, x.address, x.phone, x.comment, x.supp_key)))
+        .semijoin(&nations.map(|x| x.0))
+        .map(|(nat, (acc, nam, add, phn, com, key))| (key, (nat, acc, nam, add, phn, com)));
+
+    let parts = 
+    collections
+        .parts
+        .filter(|x| substring(&x.typ[..], b"BRASS") && x.size == 15)
+        .map(|x| (x.part_key, x.mfgr));
+
+    let partsupps = 
+    collections
+        .partsupps
+        .map(|x| (x.supp_key, (x.part_key, x.supplycost)))
+        .semijoin(&suppliers.map(|x| x.0))
+        .map(|(supp, (part, supply_cost))| (part, (supply_cost, supp)))
+        .semijoin(&parts.map(|x| x.0))
+        .group(|_x, s, t| {
+            let minimum = (s[0].0).0;
+            t.extend(s.iter().take_while(|x| (x.0).0 == minimum));
+        });
+
+    partsupps
+        .join(&parts)
+        .map(|(part_key, (cost, supp), mfgr)| (supp, (cost, part_key, mfgr)))
+        .join(&suppliers)
+        .map(|(supp, (cost, part, mfgr), (nat, acc, nam, add, phn, com))| (nat, (cost, part, mfgr, acc, nam, add, phn, com)))
+        .join(&nations)
+        .probe()
+        .0
+}

--- a/tpchlike/src/queries/query06.rs
+++ b/tpchlike/src/queries/query06.rs
@@ -1,0 +1,44 @@
+use timely::dataflow::*;
+use timely::dataflow::operators::*;
+use timely::dataflow::operators::probe::Handle as ProbeHandle;
+
+use differential_dataflow::AsCollection;
+use differential_dataflow::operators::*;
+use differential_dataflow::lattice::Lattice;
+
+use ::Collections;
+
+// -- $ID$
+// -- TPC-H/TPC-R Forecasting Revenue Change Query (Q6)
+// -- Functional Query Definition
+// -- Approved February 1998
+// :x
+// :o
+// select
+//     sum(l_extendedprice * l_discount) as revenue
+// from
+//     lineitem
+// where
+//     l_shipdate >= date ':1'
+//     and l_shipdate < date ':1' + interval '1' year
+//     and l_discount between :2 - 0.01 and :2 + 0.01
+//     and l_quantity < :3;
+// :n -1
+
+pub fn query<G: Scope>(collections: &Collections<G>) -> ProbeHandle<G::Timestamp> 
+where G::Timestamp: Lattice+Ord {
+
+    collections
+        .lineitems
+        .filter(|x| x.ship_date >= ::types::create_date(1994, 1, 1) && 
+                    x.ship_date < ::types::create_date(1995, 1, 1) && 
+                    5 <= x.discount && 
+                    x.discount < 7 && 
+                    x.quantity < 24)
+        .inner
+        .map(|(x, time, diff)| ((), time, (x.extended_price * x.discount / 100) * diff as i64))
+        .as_collection()
+        .count()
+        .probe()
+        .0
+}

--- a/tpchlike/src/queries/query15.rs
+++ b/tpchlike/src/queries/query15.rs
@@ -1,0 +1,81 @@
+use timely::dataflow::*;
+use timely::dataflow::operators::*;
+use timely::dataflow::operators::probe::Handle as ProbeHandle;
+
+use differential_dataflow::AsCollection;
+use differential_dataflow::operators::*;
+use differential_dataflow::lattice::Lattice;
+
+use ::Collections;
+
+// -- $ID$
+// -- TPC-H/TPC-R Top Supplier Query (Q15)
+// -- Functional Query Definition
+// -- Approved February 1998
+// :x
+// create view revenue:s (supplier_no, total_revenue) as
+//     select
+//         l_suppkey,
+//         sum(l_extendedprice * (1 - l_discount))
+//     from
+//         lineitem
+//     where
+//         l_shipdate >= date ':1'
+//         and l_shipdate < date ':1' + interval '3' month
+//     group by
+//         l_suppkey;
+//
+// :o
+// select
+//     s_suppkey,
+//     s_name,
+//     s_address,
+//     s_phone,
+//     total_revenue
+// from
+//     supplier,
+//     revenue:s
+// where
+//     s_suppkey = supplier_no
+//     and total_revenue = (
+//         select
+//             max(total_revenue)
+//         from
+//             revenue:s
+//     )
+// order by
+//     s_suppkey;
+//
+// drop view revenue:s;
+// :n -1
+
+pub fn query<G: Scope>(collections: &Collections<G>) -> ProbeHandle<G::Timestamp> 
+where G::Timestamp: Lattice+Ord {
+
+    // revenue by supplier
+    let revenue = 
+        collections
+            .lineitems
+            .filter(|x| ::types::create_date(1996, 1, 1) <= x.ship_date && x.ship_date < ::types::create_date(1996,4,1))
+            .inner
+            .map(|(item, time, diff)| (item.supp_key, time, item.extended_price * diff as i64))
+            .as_collection()
+            .count();
+
+    // suppliers with maximum revenue
+    let top_suppliers =
+        revenue
+            .map(|(supp, total)| ((), (-total, supp)))
+            .group(|_k, s, t| {
+               let target = (s[0].0).0;    // <-- largest revenue
+               t.extend(s.iter().take_while(|x| (x.0).0 == target));
+            })
+            .map(|(_,(total, supp))| (supp, -total));
+
+    collections
+        .suppliers
+        .map(|s| (s.supp_key, (s.name, s.address, s.phone)))
+        .join(&top_suppliers)
+        .probe()
+        .0
+}

--- a/tpchlike/src/queries/query17.rs
+++ b/tpchlike/src/queries/query17.rs
@@ -1,0 +1,68 @@
+use timely::dataflow::*;
+use timely::dataflow::operators::*;
+use timely::dataflow::operators::probe::Handle as ProbeHandle;
+
+use differential_dataflow::AsCollection;
+use differential_dataflow::operators::*;
+use differential_dataflow::lattice::Lattice;
+
+use ::Collections;
+
+// -- $ID$
+// -- TPC-H/TPC-R Small-Quantity-Order Revenue Query (Q17)
+// -- Functional Query Definition
+// -- Approved February 1998
+// :x
+// :o
+// select
+//   sum(l_extendedprice) / 7.0 as avg_yearly
+// from
+//   lineitem,
+//   part
+// where
+//   p_partkey = l_partkey
+//   and p_brand = ':1'
+//   and p_container = ':2'
+//   and l_quantity < (
+//     select
+//       0.2 * avg(l_quantity)
+//     from
+//       lineitem
+//     where
+//       l_partkey = p_partkey
+//   );
+// :n -1
+
+pub fn query<G: Scope>(collections: &Collections<G>) -> ProbeHandle<G::Timestamp> 
+where G::Timestamp: Lattice+Ord {
+
+    let parts = 
+    collections
+        .parts     // We fluff out search strings to have the right lengths. \\
+        .filter(|x| &x.brand == b"Brand#2300" && &x.container == b"MED BOX000")
+        .map(|x| x.part_key);
+
+    collections
+        .lineitems
+        .map(|x| (x.part_key, (x.quantity, x.extended_price)))
+        .semijoin(&parts)
+        .group(|_k, s, t| {
+
+            // determine the total and count of quantity.
+            let total: i64 = s.iter().map(|x| (x.0).0).sum();
+            let count: i64 = s.iter().map(|x| x.1 as i64).sum();
+
+            // threshold we are asked to use.
+            let threshold = (total / count) / 7;
+
+            // produce as output those tuples with below-threshold quantity.
+            t.extend(s.iter().filter(|&&((quantity,_),_)| quantity < threshold)
+                             .map(|&((_,price),count)| (price, count)));
+        })
+        .inner
+        .map(|((_part, price), time, count)| ((), time, price * count as i64))
+        .as_collection()
+        .count()
+        .probe()
+        .0
+}

--- a/tpchlike/src/types.rs
+++ b/tpchlike/src/types.rs
@@ -1,0 +1,345 @@
+//! Types for TPCH-like queries.
+
+
+pub use self::part::Part;
+pub use self::supplier::Supplier;
+pub use self::part_supp::PartSupp;
+pub use self::customer::Customer;
+pub use self::order::Order;
+pub use self::line_item::LineItem;
+pub use self::nation::Nation;
+pub use self::region::Region;
+
+pub type Date = u32;
+
+pub fn create_date(year: u16, month: u8, day: u8) -> u32 {
+    (year as u32) << 16 + (month as u32) << 8 + (day as u32)
+}
+
+fn parse_date(date: &str) -> Date {
+    let delim = "-";
+    let mut fields = date.split(&delim);
+    let year = fields.next().unwrap().parse().unwrap();
+    let month = fields.next().unwrap().parse().unwrap();
+    let day = fields.next().unwrap().parse().unwrap();
+    create_date(year, month, day)
+}
+
+fn copy_from_to(src: &[u8], dst: &mut [u8]) {
+    let limit = if src.len() < dst.len() { src.len() } else { dst.len() };
+    for index in 0 .. limit {
+        dst[index] = src[index];
+    }
+}
+
+pub mod part {
+
+    use abomonation::Abomonation;
+    use super::copy_from_to;
+
+    unsafe_abomonate!(Part : name, comment);
+
+    #[derive(Default,Ord,PartialOrd,Eq,PartialEq,Clone,Debug,Hash)]
+    pub struct Part {
+        pub part_key: usize,
+        pub name: String,
+        pub mfgr: [u8; 25],
+        pub brand: [u8; 10],
+        pub typ: [u8; 25],
+        pub size: i32,
+        pub container: [u8; 10],
+        pub retail_price: i64,
+        pub comment: String,
+    }
+
+    impl<'a> From<&'a str> for Part {
+        fn from(text: &'a str) -> Part {
+
+            let mut result: Part = Default::default();
+            let delim = "|";
+            let mut fields = text.split(&delim);
+
+            result.part_key = fields.next().unwrap().parse().unwrap();
+            result.name = fields.next().unwrap().to_owned();
+            copy_from_to(fields.next().unwrap().as_bytes(), &mut result.mfgr);
+            copy_from_to(fields.next().unwrap().as_bytes(), &mut result.brand);
+            copy_from_to(fields.next().unwrap().as_bytes(), &mut result.typ);
+            result.size = fields.next().unwrap().parse().unwrap();
+            copy_from_to(fields.next().unwrap().as_bytes(), &mut result.container);
+            result.retail_price = (fields.next().unwrap().parse::<f64>().unwrap() * 100.0) as i64;
+            result.comment = fields.next().unwrap().to_owned();
+
+            result
+        }
+    }
+}
+
+pub mod supplier {
+
+    use abomonation::Abomonation;
+    use super::copy_from_to;
+    
+    unsafe_abomonate!(Supplier : address, comment);
+
+    #[derive(Default,Ord,PartialOrd,Eq,PartialEq,Clone,Debug,Hash)]
+    pub struct Supplier {
+        pub supp_key: usize,
+        pub name: [u8; 25],
+        pub address: String,
+        pub nation_key: usize,
+        pub phone: [u8; 15],
+        pub acctbal: i64,
+        pub comment: String,
+    }
+
+    impl<'a> From<&'a str> for Supplier {
+        fn from(text: &'a str) -> Supplier {
+
+            let mut result: Supplier = Default::default();
+            let delim = "|";
+            let mut fields = text.split(&delim);
+
+            result.supp_key = fields.next().unwrap().parse().unwrap();
+            copy_from_to(fields.next().unwrap().as_bytes(), &mut result.name);
+            result.address = fields.next().unwrap().to_owned();
+            result.nation_key = fields.next().unwrap().parse().unwrap();
+            copy_from_to(fields.next().unwrap().as_bytes(), &mut result.phone);
+            result.acctbal = (fields.next().unwrap().parse::<f64>().unwrap() * 100.0) as i64;
+            result.comment = fields.next().unwrap().to_owned();
+
+            result
+        }
+    }
+}
+
+pub mod part_supp {
+
+    use abomonation::Abomonation;
+    unsafe_abomonate!(PartSupp : comment);
+
+    #[derive(Default,Ord,PartialOrd,Eq,PartialEq,Clone,Debug,Hash)]
+    pub struct PartSupp {
+        pub part_key: usize,
+        pub supp_key: usize,
+        pub availqty: i32,
+        pub supplycost: i64,
+        pub comment: String,
+    }
+
+    impl<'a> From<&'a str> for PartSupp {
+        fn from(text: &'a str) -> PartSupp {
+
+            let mut result: PartSupp = Default::default();
+            let delim = "|";
+            let mut fields = text.split(&delim);
+
+            result.part_key = fields.next().unwrap().parse().unwrap();
+            result.supp_key = fields.next().unwrap().parse().unwrap();
+            result.availqty = fields.next().unwrap().parse().unwrap();
+            result.supplycost = (fields.next().unwrap().parse::<f64>().unwrap() * 100.0) as i64;
+            result.comment = fields.next().unwrap().to_owned();
+
+            result
+        }
+    }
+}
+
+pub mod customer {
+
+    use abomonation::Abomonation;
+    use super::copy_from_to;
+
+    unsafe_abomonate!(Customer : address, comment);
+
+    #[derive(Default,Ord,PartialOrd,Eq,PartialEq,Clone,Debug,Hash)]
+    pub struct Customer {
+        pub cust_key: usize,
+        pub name: [u8; 25],
+        pub address: String,
+        pub nation_key: usize,
+        pub phone: [u8; 15],
+        pub acctbal: i64,
+        pub mktsegment: [u8; 10],
+        pub comment: String,
+    }
+
+    impl<'a> From<&'a str> for Customer {
+        fn from(text: &'a str) -> Customer {
+
+            let mut result: Customer = Default::default();
+            let delim = "|";
+            let mut fields = text.split(&delim);
+
+            result.cust_key = fields.next().unwrap().parse().unwrap();
+            copy_from_to(fields.next().unwrap().as_bytes(), &mut result.name);
+            result.address = fields.next().unwrap().to_owned();
+            result.nation_key = fields.next().unwrap().parse().unwrap();
+            copy_from_to(fields.next().unwrap().as_bytes(), &mut result.phone);
+            result.acctbal = (fields.next().unwrap().parse::<f64>().unwrap() * 100.0) as i64;
+            copy_from_to(fields.next().unwrap().as_bytes(), &mut result.mktsegment);
+            result.comment = fields.next().unwrap().to_owned();
+
+            result
+        }
+    }
+}
+
+pub mod order {
+
+    use abomonation::Abomonation;
+    use super::{parse_date, copy_from_to, Date};
+
+    unsafe_abomonate!(Order : comment);
+
+    #[derive(Default,Ord,PartialOrd,Eq,PartialEq,Clone,Debug,Hash)]
+    pub struct Order {
+        pub order_key: usize,
+        pub cust_key: usize,
+        pub order_status: [u8; 1],
+        pub total_price: i64,
+        pub order_date: Date,
+        pub order_priority: [u8; 15],
+        pub clerk: [u8; 15],
+        pub ship_priority: i32,
+        pub comment: String,
+    }
+
+    impl<'a> From<&'a str> for Order {
+        fn from(text: &'a str) -> Order {
+
+            let mut result: Order = Default::default();
+            let delim = "|";
+            let mut fields = text.split(&delim);
+
+            result.order_key = fields.next().unwrap().parse().unwrap();
+            result.cust_key = fields.next().unwrap().parse().unwrap();
+            copy_from_to(fields.next().unwrap().as_bytes(), &mut result.order_status);
+            result.total_price = (fields.next().unwrap().parse::<f64>().unwrap() * 100.0) as i64;
+            result.order_date = parse_date(&fields.next().unwrap());
+            copy_from_to(fields.next().unwrap().as_bytes(), &mut result.order_priority);
+            copy_from_to(fields.next().unwrap().as_bytes(), &mut result.clerk);
+            result.ship_priority = fields.next().unwrap().parse().unwrap();
+            result.comment = fields.next().unwrap().to_owned();
+
+            result
+        }
+    }
+}
+
+pub mod line_item {
+
+    use abomonation::Abomonation;
+    use super::{parse_date, copy_from_to, Date};
+
+    unsafe_abomonate!(LineItem : comment);
+
+    #[derive(Default,Ord,PartialOrd,Eq,PartialEq,Clone,Debug,Hash)]
+    pub struct LineItem {
+        pub order_key: usize,
+        pub part_key: usize,
+        pub supp_key: usize,
+        pub line_number: i32,
+        pub quantity: i64,
+        pub extended_price: i64,
+        pub discount: i64,
+        pub tax: i64,
+        pub return_flag: [u8; 1],
+        pub line_status: [u8; 1],
+        pub ship_date: Date,
+        pub commit_date: Date,
+        pub receipt_date: Date,
+        pub ship_instruct: [u8; 25],
+        pub ship_mode: [u8; 10],
+        pub comment: String,
+    }
+
+    impl<'a> From<&'a str> for LineItem {
+        fn from(text: &'a str) -> LineItem {
+
+            let mut result: LineItem = Default::default();
+            let delim = "|";
+            let mut fields = text.split(&delim);
+
+            result.order_key = fields.next().unwrap().parse().unwrap();
+            result.part_key = fields.next().unwrap().parse().unwrap();
+            result.supp_key = fields.next().unwrap().parse().unwrap();
+            result.line_number = fields.next().unwrap().parse().unwrap();
+            result.quantity = (fields.next().unwrap().parse::<f64>().unwrap() * 100.0) as i64;
+            result.extended_price = (fields.next().unwrap().parse::<f64>().unwrap() * 100.0) as i64;
+            result.discount = (fields.next().unwrap().parse::<f64>().unwrap() * 100.0) as i64;
+            result.tax = (fields.next().unwrap().parse::<f64>().unwrap() * 100.0) as i64;
+            copy_from_to(fields.next().unwrap().as_bytes(), &mut result.return_flag);
+            copy_from_to(fields.next().unwrap().as_bytes(), &mut result.line_status);
+            result.ship_date = parse_date(&fields.next().unwrap());
+            result.commit_date = parse_date(&fields.next().unwrap());
+            result.receipt_date = parse_date(&fields.next().unwrap());
+            copy_from_to(fields.next().unwrap().as_bytes(), &mut result.ship_instruct);
+            copy_from_to(fields.next().unwrap().as_bytes(), &mut result.ship_mode);
+            result.comment = fields.next().unwrap().to_owned();
+
+            result
+        }
+    }
+}
+
+pub mod nation {
+
+    use abomonation::Abomonation;
+    use super::copy_from_to;
+
+    unsafe_abomonate!(Nation : comment);
+
+    #[derive(Default,Ord,PartialOrd,Eq,PartialEq,Clone,Debug,Hash)]
+    pub struct Nation {
+        pub nation_key: usize,
+        pub name: [u8; 25],
+        pub region_key: usize,
+        pub comment: String,
+    }
+
+    impl<'a> From<&'a str> for Nation {
+        fn from(text: &'a str) -> Nation {
+
+            let mut result: Nation = Default::default();
+            let delim = "|";
+            let mut fields = text.split(&delim);
+
+            result.nation_key = fields.next().unwrap().parse().unwrap();
+            copy_from_to(fields.next().unwrap().as_bytes(), &mut result.name);
+            result.region_key = fields.next().unwrap().parse().unwrap();
+            result.comment = fields.next().unwrap().to_owned();
+
+            result
+        }
+    }
+}
+
+pub mod region {
+
+    use abomonation::Abomonation;
+    use super::copy_from_to;
+
+    unsafe_abomonate!(Region : comment);
+
+    #[derive(Default,Ord,PartialOrd,Eq,PartialEq,Clone,Debug,Hash)]
+    pub struct Region {
+        pub region_key: usize,
+        pub name: [u8; 25],
+        pub comment: String,
+    }
+
+    impl<'a> From<&'a str> for Region {
+        fn from(text: &'a str) -> Region {
+
+            let mut result: Region = Default::default();
+            let delim = "|";
+            let mut fields = text.split(&delim);
+
+            result.region_key = fields.next().unwrap().parse().unwrap();
+            copy_from_to(fields.next().unwrap().as_bytes(), &mut result.name);
+            result.comment = fields.next().unwrap().to_owned();
+
+            result
+        }
+    }
+}


### PR DESCRIPTION
This starts up a sub-project in `tpchlike/` which has implementations of several tpch-like tasks. This is mostly to get a sense for how expressive differential dataflow is, and to demonstrate how "more traditional" queries might look. We also get a sense for their performance, and make things public so that people can yell at us if the queries are wrong for some reason.