### PR TITLE
Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,11 @@ An implementation of [differential dataflow](http://www.cidrdb.org/cidr2013/Pape
 
 Differential dataflow is a data-parallel programming framework designed to efficiently process large volumes of data and to quickly respond to arbitrary changes in input collections. 
 
-Differential dataflow programs are written as transformations of collections of data, using familiar operators like `map`, `filter`, `join`, and `group`. Additionally, differential dataflow includes perhaps less familiar operators like `iterate`, which repeatedly applies a differential dataflow fragment to a collection. The programs are compiled down to [timely dataflow](https://github.com/frankmcsherry/timely-dataflow) computations.
+Differential dataflow programs are written as functional transformations of collections of data, using familiar operators like `map`, `filter`, `join`, and `group`. Differential dataflow also includes more exotic operators such as `iterate`, which repeatedly applies a differential dataflow fragment to a collection. The programs are compiled down to [timely dataflow](https://github.com/frankmcsherry/timely-dataflow) computations.
 
 Once written, a differential dataflow responds to arbitrary changes to its initially empty input collections, reporting the corresponding changes to each of its output collections. Differential dataflow can react quickly because it only acts where changes in collections occur, and does no work elsewhere.
+
+Be sure to check out the [differential dataflow documentation](http://www.frankmcsherry.org/differential-dataflow/differential_dataflow/index.html), which is continually improving.
 
 ## An example: counting degrees in a graph.
 

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -1,3 +1,5 @@
+//! Types and traits associated with collections of data.
+
 use std::hash::Hash;
 
 use timely::Data;
@@ -11,13 +13,25 @@ use ::Diff;
 
 /// A mutable collection of values of type `D`
 ///
-/// The collection is additionally parameterized by a type `R` implementing the `Ring` trait.
-/// This `R` defaults to `isize`, and most often can be thought of as "the change in count". 
-/// However, this can be more general, which is useful when one wants to accumulate values 
-/// other than counts, for example the sums of various quantities (e.g. computing an average).
+/// The `Collection` type is the core abstraction in differential dataflow programs. As you write your
+/// differential dataflow computation, you write as if the collection is a static dataset to which you
+/// apply functional transformations, creating new collections. Once your computation is written, you 
+/// are able to mutate the collection (by inserting and removing elements); differential dataflow will
+/// propagate changes through your functional computation and report the corresponding changes to the 
+/// output collections.
+///
+/// Each collection has three generic parameters. The parameter `G` is for the scope in which the 
+/// collection exists; as you write more complicated programs you may wish to introduce nested scopes 
+/// (e.g. for iteration) and this parameter tracks the scope (for timely dataflow's benefit). The `D`
+/// parameter is the type of data in your collection, for example `String`, or `(u32, Vec<Option<()>>)`.
+/// The `R` parameter represents the types of changes that the data undergo, and is most commonly (and
+/// defaults to) `isize`, representing changes to the occurrence count of each record.
 #[derive(Clone)]
 pub struct Collection<G: Scope, D, R: Diff = isize> {
-    /// Underlying timely dataflow stream.
+    /// The underlying timely dataflow stream.
+    ///
+    /// This field is exposed to support direct timely dataflow manipulation when required, but it is 
+    /// not intended to be the idiomatic way to work with the collection.
     pub inner: Stream<G, (D, G::Timestamp, R)>
 }
 
@@ -26,33 +40,49 @@ impl<G: Scope, D: Data, R: Diff> Collection<G, D, R> where G::Timestamp: Data {
     pub fn new(stream: Stream<G, (D, G::Timestamp, R)>) -> Collection<G, D, R> {
         Collection { inner: stream }
     }
-    /// Applies the supplied function to each element of the Collection.
+    /// Creates a new collection by applying the supplied function to each input element.
     pub fn map<D2: Data, L: Fn(D) -> D2 + 'static>(&self, logic: L) -> Collection<G, D2, R> {
         self.inner.map(move |(data, time, delta)| (logic(data), time, delta))
                   .as_collection()
     }
-    /// Applies the supplied function to each element of the Collection, re-using allocated memory.
+    /// Creates a new collection by applying the supplied function to each input element.
+    ///
+    /// Although the name suggests in-place mutation, this function does not change the source collection, 
+    /// but rather re-uses the underlying allocations in its implementation. The method is semantically 
+    /// equivalent to `map`, but can be more efficient.
     pub fn map_in_place<L: Fn(&mut D) + 'static>(&self, logic: L) -> Collection<G, D, R> {
         self.inner.map_in_place(move |&mut (ref mut data, _, _)| logic(data))
                   .as_collection()
     }
-    /// Applies the supplied function to each element of the Collection.
+    /// Creates a new collection by applying the supplied function to each input element and accumulating the results.
+    ///
+    /// This method extracts an iterator from each input element, and extracts the full contents of the iterator. Be 
+    /// warned that if the iterators produce substantial amounts of data, they are currently fully drained before attempting
+    /// to consolidate the results.
     pub fn flat_map<D2: Data, I: IntoIterator<Item=D2>, L: Fn(D) -> I + 'static>(&self, logic: L) -> Collection<G, D2, R> 
         where G::Timestamp: Clone {
         self.inner.flat_map(move |(data, time, delta)| logic(data).into_iter().map(move |x| (x, time.clone(), delta)))
                   .as_collection()
     }
-    /// Negates the counts of each element in the Collection.
+    /// Creates a new collection whose counts are the negation of those in the input.
+    ///
+    /// This method is most commonly used with `concat` to get those element in one collection but not another. 
+    /// However, differential dataflow computations are still defined for all values of the difference type `R`, 
+    /// including negative counts.
     pub fn negate(&self) -> Collection<G, D, R> {
         self.inner.map_in_place(|x| x.2 = -x.2)
                   .as_collection()
     }
-    /// Retains only the elements of the Collection satisifying the supplied predicate.
+    /// Creates a new collection containing those input records satisfying the supplied predicate.
     pub fn filter<L: Fn(&D) -> bool + 'static>(&self, logic: L) -> Collection<G, D, R> {
         self.inner.filter(move |&(ref data, _, _)| logic(data))
                   .as_collection()
     }
-    /// Adds the counts of elements from each Collection.
+    /// Creates a new collection accumulating the contents of the two collections.
+    ///
+    /// Despite the name, differential dataflow collections are unordered. This method is so named because the 
+    /// implementation is the concatenation of the stream of updates, but it corresponds to the addition of the
+    /// two collections.
     pub fn concat(&self, other: &Collection<G, D, R>) -> Collection<G, D, R> {
         self.inner.concat(&other.inner)
                   .as_collection()
@@ -70,10 +100,9 @@ impl<G: Scope, D: Data, R: Diff> Collection<G, D, R> where G::Timestamp: Data {
     where F: Fn(&D) -> T + 'static,
           G::Timestamp: Hash, T: Hash {
 
-            let initial1 = ::std::rc::Rc::new(initial);
-            let initial2 = initial1.clone();
+        let initial1 = ::std::rc::Rc::new(initial);
+        let initial2 = initial1.clone();
 
-            // TODO: Need to wrap initial in Rc, to share with `enter_at` and `map`.
         self.inner.enter_at(child, move |x| (*initial1)(&x.0))
                   .map(move |(data, time, diff)| {
                       let new_time = Product::new(time, (*initial2)(&data));
@@ -81,12 +110,24 @@ impl<G: Scope, D: Data, R: Diff> Collection<G, D, R> where G::Timestamp: Data {
                   })
                   .as_collection()
     }
-    /// Applies a supplied function to each update. Diagnostic.
+    /// Applies a supplied function to each update.
+    ///
+    /// This method is most commonly used to report information back to the user, often for debugging purposes. 
+    /// Any function can be used here, but be warned that the incremental nature of differential dataflow does
+    /// not guarantee that it will be called as many times as you might expect.
+    ///
+    /// The `(data, time, diff)` triples indicate a change `diff` to the frequency of `data` which takes effect
+    /// at the logical time `time`. When times are totally ordered (for example, `usize`), these updates reflect
+    /// the changes along the sequence of collections. For partially ordered times, the mathematics are more 
+    /// interesting and less intuitive, unfortunately. 
     pub fn inspect<F: FnMut(&(D, G::Timestamp, R))+'static>(&self, func: F) -> Collection<G, D, R> {
         self.inner.inspect(func)
                   .as_collection()
     }
-    /// Applies a supplied function to each batch of updates. Diagnostic.
+    /// Applies a supplied function to each batch of updates.
+    ///
+    /// This method is analogous to `inspect`, but operates on batches and reveals the timely dataflow capability
+    /// associated with the batch of updates.
     pub fn inspect_batch<F: FnMut(&G::Timestamp, &[(D, G::Timestamp, R)])+'static>(&self, func: F) -> Collection<G, D, R> {
         self.inner.inspect_batch(func)
                   .as_collection()
@@ -100,8 +141,10 @@ impl<G: Scope, D: Data, R: Diff> Collection<G, D, R> where G::Timestamp: Data {
     }
     /// Attaches a timely dataflow probe to the output of a Collection.
     ///
-    /// This probe is used to determine when the state of the Collection has stabilized and can
-    /// be read out. 
+    /// This probe is used to determine when the state of the Collection has stabilized and all updates observed.
+    /// In addition, a probe is also often use to limit the number of rounds of input in flight at any moment; a
+    /// computation can wait until the probe has caught up to the input before introducing more rounds of data, to
+    /// avoid swamping the system.
     pub fn probe_with(&self, handle: &mut ::timely::dataflow::operators::probe::Handle<G::Timestamp>) -> Collection<G, D, R> {
         self.inner.probe_with(handle).as_collection()
     }
@@ -122,7 +165,7 @@ impl<'a, G: Scope, T: Timestamp, D: Data, R: Diff> Collection<Child<'a, G, T>, D
 
 /// Conversion to a differential dataflow Collection.
 pub trait AsCollection<G: Scope, D: Data, R: Diff> {
-    /// Conversion to a differential dataflow Collection.
+    /// Converts the type to a differential dataflow collection.
     fn as_collection(&self) -> Collection<G, D, R>;
 }
 

--- a/src/lattice.rs
+++ b/src/lattice.rs
@@ -1,4 +1,8 @@
 //! Partially ordered elements with a least upper bound.
+//!
+//! Lattices form the basis of differential dataflow's efficient execution in the presence of 
+//! iterative sub-computations. All logical times in differential dataflow must implement the 
+//! `Lattice` trait, and all reasoning in operators are done it terms of `Lattice` methods.
 
 use timely::order::PartialOrder;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,105 +1,56 @@
 //! Differential dataflow is a high-throughput, low-latency data-parallel programming framework.
 //!
-//! Differential dataflow programs are written in a collection-oriented style, where multisets of
-//! records are transformed and combined using primitives operations like `map`, `filter`,
-//! `join`, and `group_by`. Differential dataflow also includes a higher-order operation `iterate`.
+//! Differential dataflow programs are written in a collection-oriented style, where you transform
+//! collections of records using traditional operations like `map`, `filter`, `join`, and `group_by`. 
+//! Differential dataflow also includes the less traditional operation `iterate`, which allows you
+//! to repeatedly apply differential dataflow transformations to collections.
 //!
-//! Having defined a differential dataflow computation, you may then add or remove records from its
-//! inputs, and the system will automatically update the computation's outputs with the appropriate
-//! corresponding additions and removals.
+//! Once you have defined a differential dataflow computation, you may then add records to or remove 
+//! records from its inputs; the system will automatically update the computation's outputs with the 
+//! appropriate corresponding additions and removals, and report these changes to you.
 //!
-//! Differential dataflow is built on the timely dataflow framework for data-parallel programming
-//! and so is automatically parallelizable across multiple threads, processes, and computers.
-//! Moreover, because it uses timely dataflow's primitives, it seamlessly inter-operates with other
-//! timely dataflow computations.
+//! Differential dataflow is built on the [timely dataflow](https://github.com/frankmcsherry/timely-dataflow) 
+//! framework for data-parallel programming which automatically parallelizes across multiple threads, 
+//! processes, and computers. Furthermore, because it uses timely dataflow's primitives, it seamlessly 
+//! inter-operates with other timely dataflow computations.
 //!
 //! Differential dataflow is still very much a work in progress, with features and ergonomics still
 //! wildly in development. It is generally improving, though.
 //!
 //! # Examples
 //!
+//! This fragment creates a collection of pairs of integers, imagined as graph edges, and then counts 
+//! first the number of times the source coordinate occurs, and then the number of times each count 
+//! occurs, giving us a sense for the distribution of degrees in the graph.
+//! 
 //! ```ignore
-//! extern crate timely;
-//! use timely::*;
-//! use timely::dataflow::Scope;
-//! use timely::dataflow::operators::{Input, Inspect};
+//! // create a a degree counting differential dataflow
+//! let (mut input, probe) = worker.dataflow(|scope| {
 //!
-//! use differential_dataflow::operators::*;
+//!     // create edge input, count a few ways.
+//!     let (input, edges) = scope.new_input();
+//!     let mut edges = edges.as_collection();
 //!
-//! // construct and execute a timely dataflow
-//! timely::execute(Configuration::Thread, |root| {
+//!     // extract the source field, and then count.
+//!     let degrs = edges.map(|(src, _dst)| src)
+//!                      .count();
 //!
-//!     // construct an input and group its records
-//!     // keeping only the smallest values.
-//!     let mut input = root.scoped(|scope| {
-//!         let (handle, stream) = scope.new_input();
-//!         stream.group(|key, vals, output| output.push(vals.next().unwrap()))
-//!               .inspect(|val| println!("observed: {:?}", val));
+//!     // extract the count field, and then count them.
+//!     let distr = degrs.map(|(_src, cnt)| cnt)
+//!                      .count();
 //!
-//!         handle
-//!     });
+//!     // report the changes to the count collection, notice when done.
+//!     let probe = distr.inspect(|x| println!("observed: {:?}", x))
+//!                      .probe();
 //!
-//!     // introduce many records
-//!     for i in 0..1000 {
-//!         input.send((i % 10, i % 3));
-//!         input.advance_to(i + 1);
-//!         root.step();
-//!     }
+//!     (input, probe)
 //! });
 //! ```
-//!
-//!
-//!
-//! For a more complicated example, the following fragment computes the breadth-first-search depth
-//! in a graph.
-//!
-//! ```ignore
-//! extern crate timely;
-//! use timely::*;
-//! use timely::dataflow::Scope;
-//! use timely::dataflow::operators::{Input, Inspect};
-//!
-//! use differential_dataflow::operators::*;
-//!
-//! // construct and execute a timely dataflow
-//! timely::execute(Configuration::Thread, |root| {
-//!
-//!     let (edges, roots) = root.scoped(|scope| {
-//!
-//!         let (e_in, edges) = scope.new_input(); // ((u32, u32), isize);
-//!         let (r_in, roots) = scope.new_input(); // (u32, isize);
-//!
-//!         // initialize roots at distance 0
-//!         let start = roots.map(|(x, w)| ((x, 0), w));
-//!
-//!         // repeatedly update minimal distances to each node,
-//!         // by describing how to do one round of updates, and then repeating.
-//!         let limit = start.iterate(|dists| {
-//!
-//!             // bring the invariant edges into the loop
-//!             let edges = edges.enter(&dists.scope());
-//!
-//!             // join current distances with edges to get +1 distances,
-//!             // include the current distances in the set as well,
-//!             // group by node id and keep minimum distance.
-//!             dists.join_map(&edges, |_,&d,&n| (n,d+1))
-//!                  .concat(&dists)
-//!                  .group(|_, s, t| t.push((s[0].0, 1))
-//!         });
-//!
-//!         // inspect distances!
-//!         limit.inspect(|x| println!("observed: {:?}", x));
-//!
-//!         (e_in, r_in)
-//!     });
-//!
-//!     edges.send(((0,1), 1));
-//!     edges.send(((1,2), 1));
-//!     edges.send(((2,3), 1));
-//!
-//!     roots.send((0, 1));
-//! });
-//! ```
+//! 
+//! Now assembled, we can drive the computation like a timely dataflow computation, by pushing update
+//! records (triples of data, time, and change in count) at the `input` stream handle. The `probe` is
+//! how timely dataflow tells us that we have seen all corresponding output updates (in case there are
+//! none).
 
 #![forbid(missing_docs)]
 
@@ -111,21 +62,14 @@ pub use difference::Diff;
 
 /// A composite trait for data types usable in differential dataflow.
 ///
-/// This trait differs from Rust's `Hash` trait, which is designed to allow general hash functions 
-/// to operate over a type. Here, instead, we are just about providing a value, and allowing the 
-/// type to override that behavior if appropriate.
-///
-/// The trait also requires the specification of an output type. This can be helpful in situations 
-/// where we want to cache the hash value, or in situations like radix sorting where we can more 
-/// efficiently sort data if we know there are fewer bytes in the integer keys.
+/// Most differential dataflow operators require the ability to cancel corresponding updates, and the
+/// way that they do this is by putting the data in a canonical form. The `Ord` trait allows us to sort
+/// the data, at which point we can consolidate updates for equivalent records.
 pub trait Data : timely::ExchangeData + Ord + Debug { }
 impl<T: timely::ExchangeData + Ord + Debug> Data for T { }
 
 extern crate fnv;
 extern crate timely;
-// extern crate vec_map;
-// extern crate itertools;
-// extern crate linear_map;
 extern crate timely_sort;
 extern crate timely_communication;
 extern crate abomonation;
@@ -136,5 +80,4 @@ pub mod lattice;
 pub mod trace;
 pub mod input;
 pub mod difference;
-mod collection;
-
+pub mod collection;

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -1,12 +1,8 @@
-//! Timely dataflow operators specific to differential dataflow.
+//! Specialize differential dataflow operators.
 //!
-//! Differential dataflow introduces a small number of specialized operators, designed to apply to
-//! streams of *typed updates*, records of the form `(T, Delta)` indicating that the frequency of the
-//! associated record of type `T` has changed.
-//!
-//! These operators have specialized implementations to make them work efficiently, but are in all
-//! other ways compatible with timely dataflow. In fact, many operators are currently absent because
-//! their timely dataflow analogues are sufficient (e.g. `map`, `filter`, `concat`).
+//! Differential dataflow introduces a small number of specialized operators on collections. These 
+//! operators have specialized implementations to make them work efficiently, and are in addition 
+//! to several operations defined directly on the `Collection` type (e.g. `map` and `filter`).
 
 pub use self::group::{Group, Distinct, Count, consolidate_from};
 pub use self::consolidate::Consolidate;
@@ -18,8 +14,6 @@ pub mod group;
 pub mod consolidate;
 pub mod iterate;
 pub mod join;
-
-// use std::cmp::Ordering;
 
 use ::Diff;
 use lattice::Lattice;
@@ -39,7 +33,7 @@ use trace::{Cursor, consolidate};
 /// important in something like `join`.
 
 /// An accumulation of (value, time, diff) updates.
-pub struct EditList<V, T, R> {
+struct EditList<V, T, R> {
     values: Vec<(V, usize)>,
     edits: Vec<(T, R)>,
 }


### PR DESCRIPTION
Comments added to many top level types and traits describing their nature, and their intended use. Not so many examples, as doc-tests for differential are difficult with the dependence on timely methods (we could re-export several of them as differential methods, just for the purposes of examples and testing).