### PR TITLE
Join opts

### DIFF
--- a/examples/arrange.rs
+++ b/examples/arrange.rs
@@ -10,7 +10,7 @@ use rand::{Rng, SeedableRng, StdRng};
 use differential_dataflow::AsCollection;
 use differential_dataflow::operators::arrange::ArrangeByKey;
 use differential_dataflow::operators::group::Group;
-use differential_dataflow::operators::join::JoinArranged;
+use differential_dataflow::operators::join::JoinCore;
 use differential_dataflow::operators::Iterate;
 use differential_dataflow::operators::Consolidate;
 
@@ -120,7 +120,7 @@ fn main() {
                 let edges = edges.enter(&dists.scope());
                 let roots = roots.enter(&dists.scope());
 
-                dists.join_arranged(&edges, |_k,l,d| (*d, l+1))
+                dists.join_core(&edges, |_k,l,d| Some((*d, l+1)))
                      .concat(&roots)
                      .group_u(|_, s, t| t.push((s[0].0, 1)))
             })
@@ -139,11 +139,11 @@ fn main() {
             let query = query.as_collection();
 
             query.map(|x| (x, x))
-                 .join_arranged(&edges, |_n, &q, &d| (d, q))
+                 .join_core(&edges, |_n, &q, &d| Some((d, q)))
                  // .inspect(|x| println!("reachable @ 1: {:?}", x))
-                 .join_arranged(&edges, |_n, &q, &d| (d, q))
+                 .join_core(&edges, |_n, &q, &d| Some((d, q)))
                  // .inspect(|x| println!("reachable @ 2: {:?}", x))
-                 .join_arranged(&edges, |_n, &q, &d| (d, q))
+                 .join_core(&edges, |_n, &q, &d| Some((d, q)))
                  .map(|(_node, query)| query)
                  .consolidate()
                  // .inspect(|x| println!("neighbors @ 3: {:?}", x))

--- a/examples/deals.rs
+++ b/examples/deals.rs
@@ -17,7 +17,7 @@ use timely::dataflow::operators::*;
 use differential_dataflow::Collection;
 use differential_dataflow::operators::*;
 use differential_dataflow::operators::arrange::{ArrangeByKey, ArrangeBySelf};
-use differential_dataflow::operators::join::JoinArranged;
+// use differential_dataflow::operators::join::JoinArranged;
 use differential_dataflow::lattice::Lattice;
 
 use graph_map::GraphMMap;
@@ -121,9 +121,9 @@ where G::Timestamp: Lattice+Ord {
     let query = query.arrange_by_self();
 
     // restrict attention to edges from query nodes
-    edges.join_arranged(&query, |k,v,_| (v.clone(), k.item.clone()))
+    edges.join_core(&query, |k,v,_| Some((v.clone(), k.item.clone())))
          .arrange_by_key_hashed()
-         .join_arranged(&edges, |_,x,y| (x.clone(), y.clone()))
+         .join_core(&edges, |_,x,y| Some((x.clone(), y.clone())))
          // the next thing is the "topk" worker. sorry!
          .group(move |_,s,t| {
              t.extend(s.iter().map(|&(x,y)| (x,y)));       // propose all inputs as outputs

--- a/examples/degrees.rs
+++ b/examples/degrees.rs
@@ -12,7 +12,7 @@ use rand::{Rng, SeedableRng, StdRng};
 use differential_dataflow::trace::Trace;
 use differential_dataflow::{Collection, AsCollection};
 use differential_dataflow::operators::*;
-use differential_dataflow::operators::join::JoinArranged;
+// use differential_dataflow::operators::join::JoinArranged;
 use differential_dataflow::operators::group::GroupArranged;
 use differential_dataflow::operators::arrange::{ArrangeByKey, ArrangeBySelf};
 use differential_dataflow::lattice::Lattice;
@@ -146,10 +146,10 @@ where G::Timestamp: Lattice+::std::hash::Hash+Ord {
         // restrict edges active vertices, return result
         edges.enter(&inner.scope())
              .arrange_by_key_hashed()
-             .join_arranged(&active, |k,v,_| (k.item.clone(), v.clone()))
+             .join_core(&active, |k,v,_| Some((k.item.clone(), v.clone())))
              .map(|(src,dst)| (dst,src))
              .arrange_by_key_hashed()
-             .join_arranged(&active, |k,v,_| (k.item.clone(), v.clone()))
+             .join_core(&active, |k,v,_| Some((k.item.clone(), v.clone())))
              .map(|(dst,src)| (src,dst))
     })
 }

--- a/examples/scc.rs
+++ b/examples/scc.rs
@@ -14,7 +14,7 @@ use differential_dataflow::operators::*;
 use differential_dataflow::lattice::Lattice;
 
 use differential_dataflow::trace::Trace;
-use differential_dataflow::operators::join::JoinArranged;
+// use differential_dataflow::operators::join::JoinArranged;
 use differential_dataflow::operators::group::GroupArranged;
 use differential_dataflow::operators::arrange::Arrange;
 use differential_dataflow::hashable::UnsignedWrapper;
@@ -134,7 +134,7 @@ where G::Timestamp: Lattice+Ord+Hash {
         graph.enter(&edges.scope())
              .map(|(k,v)| (UnsignedWrapper::from(k), v))
              .arrange(HashSpine::new())
-             .join_arranged(&active, |k,v,_| (k.item.clone(), v.clone()))
+             .join_core(&active, |k,v,_| Some((k.item.clone(), v.clone())))
 
         // let active = edges.map(|(_,dst)| dst).distinct_u();
         // graph.enter(&edges.scope())

--- a/src/operators/join.rs
+++ b/src/operators/join.rs
@@ -549,8 +549,10 @@ where
                     );
 
                     // TODO: This consolidation is optional, and it may not be very 
-                    //       helpful. We might try harder to understand whether we 
+                    //       helpful. We might try harder to understand whether we
                     //       should do this work here, or downstream at consumers.
+                    // TODO: Perhaps `thinker` should have the buffer, do smarter
+                    //       consolidation, and then deposit results in `session`.
                     consolidate(temp, 0);
 
                     effort += temp.len();
@@ -603,6 +605,12 @@ where V1: Debug, V2: Debug, T: Debug
 
             self.history1.order();
             self.history2.order();
+
+            // TODO: It seems like there is probably a good deal of redundant `advance_buffer_by`
+            //       in here. If a time is ever repeated, for example, the call will be identical
+            //       and accomplish nothing. If only a single record has been added, it may not
+            //       be worth the time to collapse (advance, re-sort) the data when a linear scan
+            //       is sufficient.
 
             while !self.history1.is_done() && !self.history2.is_done() {
 

--- a/src/operators/join.rs
+++ b/src/operators/join.rs
@@ -61,11 +61,6 @@ pub trait Join<G: Scope, K: Data, V: Data, R: Diff> {
     {
         self.join_map(other, |k,v,v2| (k.clone(),v.clone(),v2.clone()))
     }
-    /// Like `join`, but with an randomly distributed unsigned key.
-    fn join_u<V2: Data, R2: Diff>(&self, other: &Collection<G, (K,V2), R2>) -> Collection<G, (K,V,V2), <R as Mul<R2>>::Output>
-    where K: Unsigned+Copy, R: Mul<R2>, <R as Mul<R2>>::Output: Diff {
-        self.join_map_u(other, |k,v,v2| (k.clone(),v.clone(),v2.clone()))
-    }
     /// Matches pairs `(key,val1)` and `(key,val2)` based on `key` and then applies a function.
     ///
     /// #Examples
@@ -89,11 +84,12 @@ pub trait Join<G: Scope, K: Data, V: Data, R: Diff> {
     /// ```
     fn join_map<V2, R2: Diff, D, L>(&self, other: &Collection<G, (K,V2), R2>, logic: L) -> Collection<G, D, <R as Mul<R2>>::Output>
     where V2: Data, R: Mul<R2>, <R as Mul<R2>>::Output: Diff, D: Data, L: Fn(&K, &V, &V2)->D+'static;
-    /// Like `join_map`, but with a randomly distributed unsigned key.
-    fn join_map_u<V2, R2: Diff, D, L>(&self, other: &Collection<G, (K,V2), R2>, logic: L) -> Collection<G, D, <R as Mul<R2>>::Output> 
-    where K: Unsigned+Copy, R: Mul<R2>, <R as Mul<R2>>::Output: Diff, V2: Data, D: Data, L: Fn(&K, &V, &V2)->D+'static;
-    /// Matches pairs `(key,val1)` and `key` based on `key`, filtering the first collection by values present in the second.
+    /// Matches pairs `(key, val)` and `key` based on `key`, producing the former with frequencies multiplied.
     ///
+    /// When the second collection contains frequencies that are either zero or one this is the more traditional
+    /// relational semijoin. When the second collection may contain multiplicities, this operation may scale up
+    /// the counts of the records in the first input.
+    /// 
     /// #Examples
     /// ```ignore
     /// extern crate timely;
@@ -115,10 +111,7 @@ pub trait Join<G: Scope, K: Data, V: Data, R: Diff> {
     /// ```
     fn semijoin<R2>(&self, other: &Collection<G, K, R2>) -> Collection<G, (K, V), <R as Mul<R2>>::Output> 
     where R2: Diff, R: Mul<R2>, <R as Mul<R2>>::Output: Diff;
-    /// Like `semijoin`, but with a randomly distributed unsigned key.    
-    fn semijoin_u<R2>(&self, other: &Collection<G, K, R2>) -> Collection<G, (K, V), <R as Mul<R2>>::Output> 
-    where K: Unsigned+Copy, R2: Diff, R: Mul<R2>, <R as Mul<R2>>::Output: Diff;
-    /// Matches pairs `(key,val1)` and `key` based on `key`, discarding values 
+    /// Matches pairs `(key, val)` and `key` based on `key`, discarding values 
     /// in the first collection if their key is present in the second.
     ///
     /// #Examples
@@ -142,11 +135,107 @@ pub trait Join<G: Scope, K: Data, V: Data, R: Diff> {
     /// ```
     fn antijoin<R2>(&self, other: &Collection<G, K, R2>) -> Collection<G, (K, V), R>
     where R2: Diff, R: Mul<R2, Output = R>;
-    /// Like `antijoin`, but with a randomly distributed unsigned key.
-    fn antijoin_u<R2>(&self, other: &Collection<G, K, R2>) -> Collection<G, (K, V), R>
-    where K: Unsigned+Copy, R2: Diff, R: Mul<R2, Output=R>;
 } 
 
+/// Join implementations for `(key,val)` data.
+pub trait JoinUnsigned<G: Scope, K: Data, V: Data, R: Diff> {
+
+    /// Matches pairs `(key,val1)` and `(key,val2)` based on `key` and then applies a function.
+    ///
+    /// #Examples
+    /// ```ignore
+    /// extern crate timely;
+    /// use timely::dataflow::operators::{ToStream, Capture};
+    /// use timely::dataflow::operators::capture::Extract;
+    /// use differential_dataflow::operators::Join;
+    ///
+    /// let data = timely::example(|scope| {
+    ///     let col1 = vec![((0,0),1),((1,2),1)].into_iter().to_stream(scope);
+    ///     let col2 = vec![((0,'a'),1),((1,'B'),1)].into_iter().to_stream(scope);
+    ///
+    ///     // should produce records `(0 + 0,'a')` and `(1 + 2,'B')`.
+    ///     col1.join_map_u(&col2, |k,v1,v2| (*k + *v1, *v2)).capture();
+    /// });
+    ///
+    /// let extracted = data.extract();
+    /// assert_eq!(extracted.len(), 1);
+    /// assert_eq!(extracted[0].1, vec![((0,'a'),1), ((3,'B'),1)]);
+    /// ```
+    fn join_u<V2: Data, R2: Diff>(&self, other: &Collection<G, (K,V2), R2>) -> Collection<G, (K,V,V2), <R as Mul<R2>>::Output>
+    where R: Mul<R2>, <R as Mul<R2>>::Output: Diff {
+        self.join_map_u(other, |k,v,v2| (k.clone(),v.clone(),v2.clone()))
+    }
+    /// Matches pairs `(key,val1)` and `(key,val2)` based on `key` and then applies a function.
+    ///
+    /// #Examples
+    /// ```ignore
+    /// extern crate timely;
+    /// use timely::dataflow::operators::{ToStream, Capture};
+    /// use timely::dataflow::operators::capture::Extract;
+    /// use differential_dataflow::operators::Join;
+    ///
+    /// let data = timely::example(|scope| {
+    ///     let col1 = vec![((0,0),1),((1,2),1)].into_iter().to_stream(scope);
+    ///     let col2 = vec![((0,'a'),1),((1,'B'),1)].into_iter().to_stream(scope);
+    ///
+    ///     // should produce records `(0 + 0,'a')` and `(1 + 2,'B')`.
+    ///     col1.join_map_u(&col2, |k,v1,v2| (*k + *v1, *v2)).capture();
+    /// });
+    ///
+    /// let extracted = data.extract();
+    /// assert_eq!(extracted.len(), 1);
+    /// assert_eq!(extracted[0].1, vec![((0,'a'),1), ((3,'B'),1)]);
+    /// ```
+    fn join_map_u<V2, R2: Diff, D, L>(&self, other: &Collection<G, (K,V2), R2>, logic: L) -> Collection<G, D, <R as Mul<R2>>::Output> 
+    where R: Mul<R2>, <R as Mul<R2>>::Output: Diff, V2: Data, D: Data, L: Fn(&K, &V, &V2)->D+'static;
+    /// Matches pairs `(key,val1)` and `key` based on `key`, filtering the first collection by values present in the second.
+    ///
+    /// #Examples
+    /// ```ignore
+    /// extern crate timely;
+    /// use timely::dataflow::operators::{ToStream, Capture};
+    /// use timely::dataflow::operators::capture::Extract;
+    /// use differential_dataflow::operators::Join;
+    ///
+    /// let data = timely::example(|scope| {
+    ///     let col1 = vec![((0,0),1),((1,2),1)].into_iter().to_stream(scope);
+    ///     let col2 = vec![(0,1)].into_iter().to_stream(scope);
+    ///
+    ///     // should retain record `(0,0)` and discard `(1,2)`.
+    ///     col1.semijoin_u(&col2).capture();
+    /// });
+    ///
+    /// let extracted = data.extract();
+    /// assert_eq!(extracted.len(), 1);
+    /// assert_eq!(extracted[0].1, vec![((0,0),1)]);
+    /// ```
+    fn semijoin_u<R2>(&self, other: &Collection<G, K, R2>) -> Collection<G, (K, V), <R as Mul<R2>>::Output> 
+    where R2: Diff, R: Mul<R2>, <R as Mul<R2>>::Output: Diff;
+    /// Matches pairs `(key,val1)` and `key` based on `key`, discarding values 
+    /// in the first collection if their key is present in the second.
+    ///
+    /// #Examples
+    /// ```ignore
+    /// extern crate timely;
+    /// use timely::dataflow::operators::{ToStream, Capture};
+    /// use timely::dataflow::operators::capture::Extract;
+    /// use differential_dataflow::operators::Join;
+    ///
+    /// let data = timely::example(|scope| {
+    ///     let col1 = vec![((0,0),1),((1,2),1)].into_iter().to_stream(scope);
+    ///     let col2 = vec![(0,1)].into_iter().to_stream(scope);
+    ///
+    ///     // should retain record `(1,2)` and discard `(0,0)`.
+    ///     col1.antijoin_u(&col2).consolidate().capture();
+    /// });
+    ///
+    /// let extracted = data.extract();
+    /// assert_eq!(extracted.len(), 1);
+    /// assert_eq!(extracted[0].1, vec![((1,2),1)]);
+    /// ```
+    fn antijoin_u<R2>(&self, other: &Collection<G, K, R2>) -> Collection<G, (K, V), R>
+    where R2: Diff, R: Mul<R2, Output=R>;
+} 
 
 impl<G, K, V, R> Join<G, K, V, R> for Collection<G, (K, V), R>
 where
@@ -160,37 +249,50 @@ where
     where R: Mul<R2>, <R as Mul<R2>>::Output: Diff, L: Fn(&K, &V, &V2)->D+'static {
         let arranged1 = self.arrange_by_key_hashed();
         let arranged2 = other.arrange_by_key_hashed();
-        arranged1.join_arranged(&arranged2, move |k,v1,v2| logic(&k.item,v1,v2))
+        arranged1.join_core(&arranged2, move |k,v1,v2| Some(logic(&k.item,v1,v2)))
     }
+
     fn semijoin<R2: Diff>(&self, other: &Collection<G, K, R2>) -> Collection<G, (K, V), <R as Mul<R2>>::Output> 
     where R: Mul<R2>, <R as Mul<R2>>::Output: Diff {
         let arranged1 = self.arrange_by_key_hashed();
         let arranged2 = other.arrange_by_self();
-        arranged1.join_arranged(&arranged2, |k,v,_| (k.item.clone(), v.clone()))
+        arranged1.join_core(&arranged2, |k,v,_| Some((k.item.clone(), v.clone())))
     }
+
     fn antijoin<R2: Diff>(&self, other: &Collection<G, K, R2>) -> Collection<G, (K, V), R>
     where R: Mul<R2, Output=R> {
         self.concat(&self.semijoin(other).negate())
     }
+}
 
+impl<G, K, V, R> JoinUnsigned<G, K, V, R> for Collection<G, (K, V), R>
+where
+    G: Scope, 
+    K: Data+Default+Hashable+Unsigned+Copy, 
+    V: Data,
+    R: Diff,
+    G::Timestamp: Lattice+Ord,
+{
     fn join_map_u<V2, R2, D, L>(&self, other: &Collection<G, (K, V2), R2>, logic: L) -> Collection<G, D, <R as Mul<R2>>::Output>
-    where K: Unsigned+Copy, V2: Data, R2: Diff, R: Mul<R2>, <R as Mul<R2>>::Output: Diff, D: Data, L: Fn(&K, &V, &V2)->D+'static {
+    where V2: Data, R2: Diff, R: Mul<R2>, <R as Mul<R2>>::Output: Diff, D: Data, L: Fn(&K, &V, &V2)->D+'static {
         let arranged1 = self.map(|(k,v)| (UnsignedWrapper::from(k), v))
                             .arrange(DefaultValTrace::new());
         let arranged2 = other.map(|(k,v)| (UnsignedWrapper::from(k), v))
                              .arrange(DefaultValTrace::new());
-        arranged1.join_arranged(&arranged2, move |k,v1,v2| logic(&k.item,v1,v2))
+        arranged1.join_core(&arranged2, move |k,v1,v2| Some(logic(&k.item,v1,v2)))
     }
+
     fn semijoin_u<R2>(&self, other: &Collection<G, K, R2>) -> Collection<G, (K, V), <R as Mul<R2>>::Output>
-    where K: Unsigned+Copy, R2: Diff, R: Mul<R2>, <R as Mul<R2>>::Output: Diff {
+    where R2: Diff, R: Mul<R2>, <R as Mul<R2>>::Output: Diff {
         let arranged1 = self.map(|(k,v)| (UnsignedWrapper::from(k), v))
                             .arrange(DefaultValTrace::new());
         let arranged2 = other.map(|k| (UnsignedWrapper::from(k), ()))
                              .arrange(DefaultKeyTrace::new());
-        arranged1.join_arranged(&arranged2, |k,v,_| (k.item.clone(), v.clone()))
+        arranged1.join_core(&arranged2, |k,v,_| Some((k.item.clone(), v.clone())))
     }
+
     fn antijoin_u<R2>(&self, other: &Collection<G, K, R2>) -> Collection<G, (K, V), R>
-    where K: Unsigned+Copy, R2: Diff, R: Mul<R2, Output=R> {
+    where R2: Diff, R: Mul<R2, Output=R> {
         self.concat(&self.semijoin_u(other).negate())
     }
 }
@@ -200,15 +302,15 @@ where
 /// This method is used by the various `join` implementations, but it can also be used 
 /// directly in the event that one has a handle to an `Arranged<G,T>`, perhaps because
 /// the arrangement is available for re-use, or from the output of a `group` operator.
-pub trait JoinArranged<G: Scope, K: 'static, V: 'static, R: Diff> where G::Timestamp: Lattice+Ord {
+pub trait JoinCore<G: Scope, K: 'static, V: 'static, R: Diff> where G::Timestamp: Lattice+Ord {
     /// Joins two arranged collections with the same key type.
     ///
     /// Each matching pair of records `(key, val1)` and `(key, val2)` are subjected to the `result` function, 
-    /// producing a corresponding output record.
+    /// which produces something implementing `IntoIterator`, where the output collection will have 
     ///
     /// This trait is implemented for arrangements (`Arranged<G, T>`) rather than collections. The `Join` trait 
     /// contains the implementations for collections.
-    fn join_arranged<V2,T2,R2,D,L> (&self, stream2: &Arranged<G,K,V2,R2,T2>, result: L) -> Collection<G,D,<R as Mul<R2>>::Output>
+    fn join_core<V2,T2,R2,I,L> (&self, stream2: &Arranged<G,K,V2,R2,T2>, result: L) -> Collection<G,I::Item,<R as Mul<R2>>::Output>
     where 
         V2: Ord+Clone+Debug+'static,
         T2: TraceReader<K, V2, G::Timestamp, R2>+Clone+'static,
@@ -216,12 +318,14 @@ pub trait JoinArranged<G: Scope, K: 'static, V: 'static, R: Diff> where G::Times
         R2: Diff,
         R: Mul<R2>,
         <R as Mul<R2>>::Output: Diff,
-        D: Data,
-        L: Fn(&K,&V,&V2)->D+'static;
+        I: IntoIterator,
+        I::Item: Data,
+        L: Fn(&K,&V,&V2)->I+'static,
+        ;
 }
 
 
-impl<G, K, V, R> JoinArranged<G, OrdWrapper<K>, V, R> for Collection<G, (K, V), R>
+impl<G, K, V, R> JoinCore<G, OrdWrapper<K>, V, R> for Collection<G, (K, V), R>
 where
     G: Scope, 
     K: Data+Default+Hashable, 
@@ -229,7 +333,7 @@ where
     R: Diff,
     G::Timestamp: Lattice+Ord,
 {
-    fn join_arranged<V2,T2,R2,D,L> (&self, stream2: &Arranged<G,OrdWrapper<K>,V2,R2,T2>, result: L) -> Collection<G,D,<R as Mul<R2>>::Output>
+    fn join_core<V2,T2,R2,I,L> (&self, stream2: &Arranged<G,OrdWrapper<K>,V2,R2,T2>, result: L) -> Collection<G,I::Item,<R as Mul<R2>>::Output>
     where 
         V2: Ord+Clone+Debug+'static,
         T2: TraceReader<OrdWrapper<K>, V2, G::Timestamp, R2>+Clone+'static,
@@ -237,16 +341,16 @@ where
         R2: Diff,
         R: Mul<R2>,
         <R as Mul<R2>>::Output: Diff,
-        D: Data,
-        L: Fn(&OrdWrapper<K>,&V,&V2)->D+'static {
+        I: IntoIterator,
+        I::Item: Data,
+        L: Fn(&OrdWrapper<K>,&V,&V2)->I+'static {
 
         self.arrange_by_key_hashed()
-            .join_arranged(stream2, result)
-
+            .join_core(stream2, result)
     }
 }
 
-impl<G, K, V, R1, T1> JoinArranged<G, K, V, R1> for Arranged<G,K,V,R1,T1> 
+impl<G, K, V, R1, T1> JoinCore<G, K, V, R1> for Arranged<G,K,V,R1,T1> 
     where 
         K: Ord,
         G: Scope, 
@@ -256,7 +360,7 @@ impl<G, K, V, R1, T1> JoinArranged<G, K, V, R1> for Arranged<G,K,V,R1,T1>
         R1: Diff,
         T1: TraceReader<K,V,G::Timestamp, R1>+Clone+'static,
         T1::Batch: BatchReader<K,V,G::Timestamp,R1>+'static+Debug {
-    fn join_arranged<V2,T2,R2,D,L>(&self, other: &Arranged<G,K,V2,R2,T2>, result: L) -> Collection<G,D,<R1 as Mul<R2>>::Output> 
+    fn join_core<V2,T2,R2,I,L>(&self, other: &Arranged<G,K,V2,R2,T2>, result: L) -> Collection<G,I::Item,<R1 as Mul<R2>>::Output> 
     where 
         V2: Ord+Clone+Debug+'static,
         T2: TraceReader<K,V2,G::Timestamp,R2>+Clone+'static,
@@ -264,8 +368,9 @@ impl<G, K, V, R1, T1> JoinArranged<G, K, V, R1> for Arranged<G,K,V,R1,T1>
         R2: Diff,
         R1: Mul<R2>,
         <R1 as Mul<R2>>::Output: Diff,
-        D: Data,
-        L: Fn(&K,&V,&V2)->D+'static {
+        I: IntoIterator,
+        I::Item: Data,
+        L: Fn(&K,&V,&V2)->I+'static {
 
         // handles to shared trace data structures.
         let mut trace1 = Some(self.trace.clone());
@@ -409,8 +514,8 @@ where
 
     /// Process keys until at least `limit` output tuples produced, or the work is exhausted.
     #[inline(never)]
-    fn work<L>(&mut self, output: &mut OutputHandle<T, (D, T, R3), Tee<T, (D, T, R3)>>, logic: &L, fuel: &mut usize) 
-    where L: Fn(&K, &V1, &V2)->D {
+    fn work<L, I>(&mut self, output: &mut OutputHandle<T, (D, T, R3), Tee<T, (D, T, R3)>>, logic: &L, fuel: &mut usize) 
+    where I: IntoIterator<Item=D>, L: Fn(&K, &V1, &V2)->I {
 
         let meet = self.capability.time();
 
@@ -437,8 +542,15 @@ where
                     assert_eq!(temp.len(), 0);
 
                     // populate `temp` with the results in the best way we know how.
-                    thinker.think(|v1,v2,t,r1,r2| temp.push(((logic(batch.key(), v1, v2), t), mult(r1,r2))));
+                    thinker.think(|v1,v2,t,r1,r2| 
+                        for result in logic(batch.key(), v1, v2) {
+                            temp.push(((result, t.clone()), mult(r1, r2)));
+                        }
+                    );
 
+                    // TODO: This consolidation is optional, and it may not be very 
+                    //       helpful. We might try harder to understand whether we 
+                    //       should do this work here, or downstream at consumers.
                     consolidate(temp, 0);
 
                     effort += temp.len();

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -7,7 +7,7 @@
 pub use self::group::{Group, Distinct, Count, consolidate_from};
 pub use self::consolidate::Consolidate;
 pub use self::iterate::Iterate;
-pub use self::join::Join;
+pub use self::join::{Join, JoinUnsigned, JoinCore};
 
 pub mod arrange;
 pub mod group;

--- a/tpchlike/src/queries/query04.rs
+++ b/tpchlike/src/queries/query04.rs
@@ -5,7 +5,7 @@ use timely::dataflow::operators::probe::Handle as ProbeHandle;
 // use differential_dataflow::AsCollection;
 use differential_dataflow::operators::*;
 use differential_dataflow::operators::arrange::Arrange;
-use differential_dataflow::operators::join::JoinArranged;
+// use differential_dataflow::operators::join::JoinArranged;
 use differential_dataflow::operators::group::GroupArranged;
 use differential_dataflow::trace::Trace;
 use differential_dataflow::trace::implementations::ord::OrdKeySpine as DefaultKeyTrace;
@@ -63,7 +63,7 @@ where G::Timestamp: Lattice+Ord {
             else { None }
         )
         .arrange(DefaultValTrace::new())
-        .join_arranged(&lineitems, |k,v,_| (k.item.clone(), v.clone()))
+        .join_core(&lineitems, |k,v,_| Some((k.item.clone(), v.clone())))
         .map(|o| o.1)
         .count()
         .probe()

--- a/tpchlike/src/queries/query18.rs
+++ b/tpchlike/src/queries/query18.rs
@@ -5,7 +5,7 @@ use timely::dataflow::operators::probe::Handle as ProbeHandle;
 use differential_dataflow::AsCollection;
 use differential_dataflow::operators::*;
 use differential_dataflow::operators::arrange::Arrange;
-use differential_dataflow::operators::join::JoinArranged;
+// use differential_dataflow::operators::join::JoinArranged;
 use differential_dataflow::operators::group::GroupArranged;
 use differential_dataflow::trace::Trace;
 use differential_dataflow::trace::implementations::ord::OrdKeySpine as DefaultKeyTrace;
@@ -71,7 +71,7 @@ where G::Timestamp: Lattice+Ord {
         .as_collection()
         .arrange(DefaultKeyTrace::new())
         .group_arranged(|_k,s,t| t.push((s[0].1, 1)), DefaultValTrace::new())
-        .join_arranged(&orders, |k,v1,v2| (k.item.clone(), v1.clone(), v2.clone()))
+        .join_core(&orders, |k,v1,v2| Some((k.item.clone(), v1.clone(), v2.clone())))
         .filter(|x| x.1 > 300)
         .map(|(okey, quantity, (custkey, date, price))| (custkey, (okey, date, price, quantity)))
         .join_u(&collections.customers().map(|c| (c.cust_key, c.name.to_string())))


### PR DESCRIPTION
This PR slightly re-organizes the join traits, and provides some performance improvements.

1. The `Join` trait is broken into `Join` and `JoinUnsigned`. The reasoning is that while the unsigned methods can be implemented with conditions for `Collection`, the same is not true for other types like `Arranged`, for whom only some key parameters (those of the form `UnsignedWrapper<K>`) lead to valid implementations. Separating the two should make it possible for arranged collections to implement the trait (though this has not yet happened).

2. The `JoinArranged` trait is renamed `JoinCore` and changed slightly. The intent here is to highlight the fact that the trait is not just "join on arranged collections", but the lowest level join primitive that all others build upon. It should probably be considered unstable to build upon.

    As an example, the `join_core` method is changed to take any reduction function that produces an implementor of `IntoIterator`, allowing the join logic to perform filtering and transformation. This was previously very painful for operators that performed join to co-locate values and thresholds, and then filter based on logic and drop the threshold (viz TPCH Q22). Before this change the outputs of the join operator could change wildly, now the output only changes much less (though internally a great deal of unnecessary work is still done).

The join operator was also improved to re-use memory across multiple calls to `work`, and could be further improved by integrating the queue of work into the `Deferred` type, allowing re-use across deferred work (but serializing the work, which is probably fine).