### PR TITLE
Total order

### DIFF
--- a/src/operators/count.rs
+++ b/src/operators/count.rs
@@ -35,12 +35,12 @@ use ::{Data, Collection, Diff};
 use hashable::{Hashable, UnsignedWrapper};
 use collection::AsCollection;
 use operators::arrange::{Arrange, Arranged, ArrangeBySelf};
-use lattice::Lattice;
+use lattice::TotalOrder;
 use trace::{BatchReader, Cursor, Trace, TraceReader};
 use trace::implementations::ord::OrdKeySpine as DefaultKeyTrace;
 
 /// Extension trait for the `count` differential dataflow method.
-pub trait CountTotal<G: Scope, K: Data, R: Diff> where G::Timestamp: Lattice+Ord {
+pub trait CountTotal<G: Scope, K: Data, R: Diff> where G::Timestamp: TotalOrder+Ord {
     /// Counts the number of occurrences of each element.
     fn count_total(&self) -> Collection<G, (K, R), isize>;
     /// Counts the number of occurrences of each element.
@@ -50,7 +50,7 @@ pub trait CountTotal<G: Scope, K: Data, R: Diff> where G::Timestamp: Lattice+Ord
 }
 
 impl<G: Scope, K: Data+Default+Hashable, R: Diff> CountTotal<G, K, R> for Collection<G, K, R>
-where G::Timestamp: Lattice+Ord+::std::fmt::Debug {
+where G::Timestamp: TotalOrder+Ord {
     fn count_total(&self) -> Collection<G, (K, R), isize> {
         self.arrange_by_self()
             .count_total_core()
@@ -66,7 +66,7 @@ where G::Timestamp: Lattice+Ord+::std::fmt::Debug {
 
 
 /// Extension trait for the `group_arranged` differential dataflow method.
-pub trait CountTotalCore<G: Scope, K: Data, R: Diff> where G::Timestamp: Lattice+Ord {
+pub trait CountTotalCore<G: Scope, K: Data, R: Diff> where G::Timestamp: TotalOrder+Ord {
     /// Applies `group` to arranged data, and returns an arrangement of output data.
     ///
     /// This method is used by the more ergonomic `group`, `distinct`, and `count` methods, although
@@ -74,9 +74,9 @@ pub trait CountTotalCore<G: Scope, K: Data, R: Diff> where G::Timestamp: Lattice
     fn count_total_core(&self) -> Collection<G, (K, R), isize>;
 }
 
-impl<G: Scope, K: Data, T1, R: Diff> CountTotalCore<G, K, R> for Arranged<G, K, (), R, T1>
+impl<G: Scope, K: Data, R: Diff, T1> CountTotalCore<G, K, R> for Arranged<G, K, (), R, T1>
 where 
-    G::Timestamp: Lattice+Ord,
+    G::Timestamp: TotalOrder+Ord,
     T1: TraceReader<K, (), G::Timestamp, R>+Clone+'static,
     T1::Batch: BatchReader<K, (), G::Timestamp, R> {
 

--- a/tpchlike/src/queries/query01.rs
+++ b/tpchlike/src/queries/query01.rs
@@ -4,7 +4,7 @@ use timely::dataflow::operators::probe::Handle as ProbeHandle;
 
 use differential_dataflow::AsCollection;
 use differential_dataflow::operators::*;
-use differential_dataflow::lattice::Lattice;
+use differential_dataflow::lattice::TotalOrder;
 use differential_dataflow::difference::DiffPair;
 
 use ::Collections;
@@ -38,7 +38,7 @@ use ::Collections;
 //     l_linestatus;
 // :n -1
 
-pub fn query<G: Scope>(collections: &mut Collections<G>) -> ProbeHandle<G::Timestamp> where G::Timestamp: Lattice+Ord {
+pub fn query<G: Scope>(collections: &mut Collections<G>) -> ProbeHandle<G::Timestamp> where G::Timestamp: TotalOrder+Ord {
 
     collections
         .lineitems()

--- a/tpchlike/src/queries/query02.rs
+++ b/tpchlike/src/queries/query02.rs
@@ -4,7 +4,7 @@ use timely::dataflow::operators::probe::Handle as ProbeHandle;
 
 // use differential_dataflow::AsCollection;
 use differential_dataflow::operators::*;
-use differential_dataflow::lattice::Lattice;
+use differential_dataflow::lattice::TotalOrder;
 
 use ::Collections;
 
@@ -70,7 +70,7 @@ fn substring(source: &[u8], query: &[u8]) -> bool {
 }
 
 pub fn query<G: Scope>(collections: &mut Collections<G>) -> ProbeHandle<G::Timestamp> 
-where G::Timestamp: Lattice+Ord {
+where G::Timestamp: TotalOrder+Ord {
 
     let regions = 
     collections

--- a/tpchlike/src/queries/query03.rs
+++ b/tpchlike/src/queries/query03.rs
@@ -4,7 +4,7 @@ use timely::dataflow::operators::probe::Handle as ProbeHandle;
 
 use differential_dataflow::AsCollection;
 use differential_dataflow::operators::*;
-use differential_dataflow::lattice::Lattice;
+use differential_dataflow::lattice::TotalOrder;
 
 use ::Collections;
 use ::types::create_date;
@@ -45,7 +45,7 @@ fn starts_with(source: &[u8], query: &[u8]) -> bool {
 }
 
 pub fn query<G: Scope>(collections: &mut Collections<G>) -> ProbeHandle<G::Timestamp> 
-where G::Timestamp: Lattice+Ord {
+where G::Timestamp: TotalOrder+Ord {
 
     let customers =
     collections

--- a/tpchlike/src/queries/query04.rs
+++ b/tpchlike/src/queries/query04.rs
@@ -10,7 +10,7 @@ use differential_dataflow::operators::group::GroupArranged;
 use differential_dataflow::trace::Trace;
 use differential_dataflow::trace::implementations::ord::OrdKeySpine as DefaultKeyTrace;
 use differential_dataflow::trace::implementations::ord::OrdValSpine as DefaultValTrace;
-use differential_dataflow::lattice::Lattice;
+use differential_dataflow::lattice::TotalOrder;
 use differential_dataflow::hashable::UnsignedWrapper;
 
 use ::Collections;
@@ -45,7 +45,7 @@ use ::Collections;
 // :n -1
 
 pub fn query<G: Scope>(collections: &mut Collections<G>) -> ProbeHandle<G::Timestamp> 
-where G::Timestamp: Lattice+Ord {
+where G::Timestamp: TotalOrder+Ord {
 
     println!("TODO: Q04 could use count_u for [u8;15] 'priority'");
 

--- a/tpchlike/src/queries/query05.rs
+++ b/tpchlike/src/queries/query05.rs
@@ -4,7 +4,7 @@ use timely::dataflow::operators::probe::Handle as ProbeHandle;
 
 use differential_dataflow::AsCollection;
 use differential_dataflow::operators::*;
-use differential_dataflow::lattice::Lattice;
+use differential_dataflow::lattice::TotalOrder;
 
 use ::Collections;
 use ::types::create_date;
@@ -46,7 +46,7 @@ fn starts_with(source: &[u8], query: &[u8]) -> bool {
 }
 
 pub fn query<G: Scope>(collections: &mut Collections<G>) -> ProbeHandle<G::Timestamp> 
-where G::Timestamp: Lattice+Ord {
+where G::Timestamp: TotalOrder+Ord {
 
     let regions = 
     collections

--- a/tpchlike/src/queries/query06.rs
+++ b/tpchlike/src/queries/query06.rs
@@ -4,7 +4,7 @@ use timely::dataflow::operators::probe::Handle as ProbeHandle;
 
 use differential_dataflow::AsCollection;
 use differential_dataflow::operators::*;
-use differential_dataflow::lattice::Lattice;
+use differential_dataflow::lattice::TotalOrder;
 
 use ::Collections;
 use ::types::create_date;
@@ -27,9 +27,9 @@ use ::types::create_date;
 // :n -1
 
 pub fn query<G: Scope>(collections: &mut Collections<G>) -> ProbeHandle<G::Timestamp> 
-where G::Timestamp: Lattice+Ord {
+where G::Timestamp: TotalOrder+Ord {
 
-    println!("TODO: query 06 does a global aggregation with 0u8 as a key rather than ().");
+    println!("TODO: Q06 does a global aggregation with 0u8 as a key rather than ().");
 
     collections
         .lineitems()

--- a/tpchlike/src/queries/query07.rs
+++ b/tpchlike/src/queries/query07.rs
@@ -4,7 +4,7 @@ use timely::dataflow::operators::probe::Handle as ProbeHandle;
 
 use differential_dataflow::AsCollection;
 use differential_dataflow::operators::*;
-use differential_dataflow::lattice::Lattice;
+use differential_dataflow::lattice::TotalOrder;
 
 use ::Collections;
 use ::types::create_date;
@@ -61,7 +61,7 @@ fn starts_with(source: &[u8], query: &[u8]) -> bool {
 }
 
 pub fn query<G: Scope>(collections: &mut Collections<G>) -> ProbeHandle<G::Timestamp> 
-where G::Timestamp: Lattice+Ord {
+where G::Timestamp: TotalOrder+Ord {
 
     println!("TODO: Q07 could use `join_core` to fuse map and filter");
 

--- a/tpchlike/src/queries/query08.rs
+++ b/tpchlike/src/queries/query08.rs
@@ -4,7 +4,7 @@ use timely::dataflow::operators::probe::Handle as ProbeHandle;
 
 use differential_dataflow::AsCollection;
 use differential_dataflow::operators::*;
-use differential_dataflow::lattice::Lattice;
+use differential_dataflow::lattice::TotalOrder;
 use differential_dataflow::difference::DiffPair;
 
 use ::Collections;
@@ -60,7 +60,7 @@ fn starts_with(source: &[u8], query: &[u8]) -> bool {
 }
 
 pub fn query<G: Scope>(collections: &mut Collections<G>) -> ProbeHandle<G::Timestamp> 
-where G::Timestamp: Lattice+Ord {
+where G::Timestamp: TotalOrder+Ord {
 
     let regions = collections.regions().filter(|r| starts_with(&r.name, b"AMERICA")).map(|r| r.region_key);
     let nations1 = collections.nations().map(|n| (n.region_key, n.nation_key)).semijoin_u(&regions).map(|x| x.1);

--- a/tpchlike/src/queries/query09.rs
+++ b/tpchlike/src/queries/query09.rs
@@ -4,7 +4,7 @@ use timely::dataflow::operators::probe::Handle as ProbeHandle;
 
 use differential_dataflow::AsCollection;
 use differential_dataflow::operators::*;
-use differential_dataflow::lattice::Lattice;
+use differential_dataflow::lattice::TotalOrder;
 
 use ::Collections;
 
@@ -55,7 +55,7 @@ fn substring(source: &[u8], query: &[u8]) -> bool {
 }
 
 pub fn query<G: Scope>(collections: &mut Collections<G>) -> ProbeHandle<G::Timestamp> 
-where G::Timestamp: Lattice+Ord {
+where G::Timestamp: TotalOrder+Ord {
 
     println!("TODO: Q09 join order may be pessimal; could pivot to put lineitems last");
 

--- a/tpchlike/src/queries/query10.rs
+++ b/tpchlike/src/queries/query10.rs
@@ -4,7 +4,7 @@ use timely::dataflow::operators::probe::Handle as ProbeHandle;
 
 use differential_dataflow::AsCollection;
 use differential_dataflow::operators::*;
-use differential_dataflow::lattice::Lattice;
+use differential_dataflow::lattice::TotalOrder;
 
 use ::Collections;
 use ::types::create_date;
@@ -53,7 +53,7 @@ fn starts_with(source: &[u8], query: &[u8]) -> bool {
 }
 
 pub fn query<G: Scope>(collections: &mut Collections<G>) -> ProbeHandle<G::Timestamp> 
-where G::Timestamp: Lattice+Ord {
+where G::Timestamp: TotalOrder+Ord {
 
     let lineitems = 
     collections

--- a/tpchlike/src/queries/query11.rs
+++ b/tpchlike/src/queries/query11.rs
@@ -4,7 +4,7 @@ use timely::dataflow::operators::probe::Handle as ProbeHandle;
 
 use differential_dataflow::AsCollection;
 use differential_dataflow::operators::*;
-use differential_dataflow::lattice::Lattice;
+use differential_dataflow::lattice::TotalOrder;
 
 use ::Collections;
 
@@ -48,9 +48,9 @@ fn starts_with(source: &[u8], query: &[u8]) -> bool {
 }
 
 pub fn query<G: Scope>(collections: &mut Collections<G>) -> ProbeHandle<G::Timestamp> 
-where G::Timestamp: Lattice+Ord {
+where G::Timestamp: TotalOrder+Ord {
 
-    println!("TODO: query 11 does a global aggregation with 0u8 as a key rather than ().");
+    println!("TODO: Q11 does a global aggregation with 0u8 as a key rather than ().");
 
     let nations =
     collections

--- a/tpchlike/src/queries/query12.rs
+++ b/tpchlike/src/queries/query12.rs
@@ -4,7 +4,7 @@ use timely::dataflow::operators::probe::Handle as ProbeHandle;
 
 use differential_dataflow::AsCollection;
 use differential_dataflow::operators::*;
-use differential_dataflow::lattice::Lattice;
+use differential_dataflow::lattice::TotalOrder;
 use differential_dataflow::difference::DiffPair;
 
 use ::Collections;
@@ -51,9 +51,9 @@ fn starts_with(source: &[u8], query: &[u8]) -> bool {
 }
 
 pub fn query<G: Scope>(collections: &mut Collections<G>) -> ProbeHandle<G::Timestamp> 
-where G::Timestamp: Lattice+Ord {
+where G::Timestamp: TotalOrder+Ord {
 
-    println!("TODO: query 12 does contortions because isize doesn't implement Mul<DiffPair<isize, isize>>.");
+    println!("TODO: Q12 does contortions because isize doesn't implement Mul<DiffPair<isize, isize>>.");
 
     let orders = 
     collections

--- a/tpchlike/src/queries/query13.rs
+++ b/tpchlike/src/queries/query13.rs
@@ -4,7 +4,7 @@ use timely::dataflow::operators::probe::Handle as ProbeHandle;
 
 // use differential_dataflow::AsCollection;
 use differential_dataflow::operators::*;
-use differential_dataflow::lattice::Lattice;
+use differential_dataflow::lattice::TotalOrder;
 
 use ::Collections;
 
@@ -44,7 +44,7 @@ fn substring2(source: &[u8], query1: &[u8], query2: &[u8]) -> bool {
 }
 
 pub fn query<G: Scope>(collections: &mut Collections<G>) -> ProbeHandle<G::Timestamp> 
-where G::Timestamp: Lattice+Ord {
+where G::Timestamp: TotalOrder+Ord {
 
     let orders =
     collections

--- a/tpchlike/src/queries/query14.rs
+++ b/tpchlike/src/queries/query14.rs
@@ -4,7 +4,7 @@ use timely::dataflow::operators::probe::Handle as ProbeHandle;
 
 use differential_dataflow::AsCollection;
 use differential_dataflow::operators::*;
-use differential_dataflow::lattice::Lattice;
+use differential_dataflow::lattice::TotalOrder;
 use differential_dataflow::difference::DiffPair;
 
 use ::Collections;
@@ -36,7 +36,7 @@ fn starts_with(source: &[u8], query: &[u8]) -> bool {
 }
 
 pub fn query<G: Scope>(collections: &mut Collections<G>) -> ProbeHandle<G::Timestamp> 
-where G::Timestamp: Lattice+Ord {
+where G::Timestamp: TotalOrder+Ord {
 
     println!("TODO: we add a () value because there is no semijoin for value-free collections");
 

--- a/tpchlike/src/queries/query15.rs
+++ b/tpchlike/src/queries/query15.rs
@@ -4,7 +4,7 @@ use timely::dataflow::operators::probe::Handle as ProbeHandle;
 
 use differential_dataflow::AsCollection;
 use differential_dataflow::operators::*;
-use differential_dataflow::lattice::Lattice;
+use differential_dataflow::lattice::TotalOrder;
 
 use ::Collections;
 use ::types::create_date;
@@ -51,7 +51,7 @@ use ::types::create_date;
 // :n -1
 
 pub fn query<G: Scope>(collections: &mut Collections<G>) -> ProbeHandle<G::Timestamp> 
-where G::Timestamp: Lattice+Ord {
+where G::Timestamp: TotalOrder+Ord {
 
     println!("TODO: query 15 takes a global aggregate with key 0u8, instead of ().");
 

--- a/tpchlike/src/queries/query16.rs
+++ b/tpchlike/src/queries/query16.rs
@@ -1,10 +1,8 @@
 use timely::dataflow::*;
-// use timely::dataflow::operators::*;
 use timely::dataflow::operators::probe::Handle as ProbeHandle;
 
-// use differential_dataflow::AsCollection;
 use differential_dataflow::operators::*;
-use differential_dataflow::lattice::Lattice;
+use differential_dataflow::lattice::TotalOrder;
 
 use ::Collections;
 
@@ -58,7 +56,7 @@ fn substring2(source: &[u8], query1: &[u8], query2: &[u8]) -> bool {
 }
 
 pub fn query<G: Scope>(collections: &mut Collections<G>) -> ProbeHandle<G::Timestamp> 
-where G::Timestamp: Lattice+Ord {
+where G::Timestamp: TotalOrder+Ord {
 
     println!("TODO: query 16 could use a count_u if it joins after to re-collect its attributes");
 
@@ -86,7 +84,6 @@ where G::Timestamp: Lattice+Ord {
                 Some((p.part_key, (p.brand, p.typ.to_string(), p.size)))
             }
             else { None }
-
         )
         .semijoin_u(&parts)
         .count_total()

--- a/tpchlike/src/queries/query17.rs
+++ b/tpchlike/src/queries/query17.rs
@@ -4,7 +4,7 @@ use timely::dataflow::operators::probe::Handle as ProbeHandle;
 
 use differential_dataflow::AsCollection;
 use differential_dataflow::operators::*;
-use differential_dataflow::lattice::Lattice;
+use differential_dataflow::lattice::TotalOrder;
 
 use ::Collections;
 
@@ -34,7 +34,7 @@ use ::Collections;
 // :n -1
 
 pub fn query<G: Scope>(collections: &mut Collections<G>) -> ProbeHandle<G::Timestamp> 
-where G::Timestamp: Lattice+Ord {
+where G::Timestamp: TotalOrder+Ord {
 
     println!("TODO: Q17 gets a global count with key 0u8, rather than ().");
 

--- a/tpchlike/src/queries/query18.rs
+++ b/tpchlike/src/queries/query18.rs
@@ -5,12 +5,11 @@ use timely::dataflow::operators::probe::Handle as ProbeHandle;
 use differential_dataflow::AsCollection;
 use differential_dataflow::operators::*;
 use differential_dataflow::operators::arrange::Arrange;
-// use differential_dataflow::operators::join::JoinArranged;
 use differential_dataflow::operators::group::GroupArranged;
 use differential_dataflow::trace::Trace;
 use differential_dataflow::trace::implementations::ord::OrdKeySpine as DefaultKeyTrace;
 use differential_dataflow::trace::implementations::ord::OrdValSpine as DefaultValTrace;
-use differential_dataflow::lattice::Lattice;
+use differential_dataflow::lattice::TotalOrder;
 use differential_dataflow::hashable::UnsignedWrapper;
 
 use ::Collections;
@@ -56,7 +55,7 @@ use ::Collections;
 // :n 100
 
 pub fn query<G: Scope>(collections: &mut Collections<G>) -> ProbeHandle<G::Timestamp> 
-where G::Timestamp: Lattice+Ord {
+where G::Timestamp: TotalOrder+Ord {
 
     println!("TODO: Q18 could use filter trace wrapper (eval vs filter in `join_core`)");
     println!("TODO: Q18 uses `group_arranged` to get arrangement, but could use count_total");

--- a/tpchlike/src/queries/query19.rs
+++ b/tpchlike/src/queries/query19.rs
@@ -4,11 +4,9 @@ use timely::dataflow::operators::probe::Handle as ProbeHandle;
 
 use differential_dataflow::AsCollection;
 use differential_dataflow::operators::*;
-use differential_dataflow::lattice::Lattice;
-// use differential_dataflow::difference::DiffPair;
+use differential_dataflow::lattice::TotalOrder;
 
 use ::Collections;
-// use ::types::create_date;
 
 // -- $ID$
 // -- TPC-H/TPC-R Discounted Revenue Query (Q19)
@@ -59,7 +57,7 @@ fn starts_with(source: &[u8], query: &[u8]) -> bool {
 }
 
 pub fn query<G: Scope>(collections: &mut Collections<G>) -> ProbeHandle<G::Timestamp> 
-where G::Timestamp: Lattice+Ord {
+where G::Timestamp: TotalOrder+Ord {
 
     println!("TODO: Q19 joins have spurious () value, because `intersect` doesn't exist");
 

--- a/tpchlike/src/queries/query20.rs
+++ b/tpchlike/src/queries/query20.rs
@@ -6,7 +6,7 @@ use differential_dataflow::AsCollection;
 use differential_dataflow::operators::*;
 use differential_dataflow::operators::arrange::Arrange;
 use differential_dataflow::operators::group::GroupArranged;
-use differential_dataflow::lattice::Lattice;
+use differential_dataflow::lattice::TotalOrder;
 use differential_dataflow::trace::Trace;
 use differential_dataflow::trace::implementations::ord::OrdKeySpine as DefaultKeyTrace;
 use differential_dataflow::trace::implementations::ord::OrdValSpine as DefaultValTrace;
@@ -65,7 +65,7 @@ fn starts_with(source: &[u8], query: &[u8]) -> bool {
 }
 
 pub fn query<G: Scope>(collections: &mut Collections<G>) -> ProbeHandle<G::Timestamp> 
-where G::Timestamp: Lattice+Ord {
+where G::Timestamp: TotalOrder+Ord {
 
     println!("TODO: Q20 uses a `group_arranged` to get an arrangement, but could use `count_total`");
 

--- a/tpchlike/src/queries/query21.rs
+++ b/tpchlike/src/queries/query21.rs
@@ -4,7 +4,7 @@ use timely::dataflow::operators::probe::Handle as ProbeHandle;
 
 // use differential_dataflow::AsCollection;
 use differential_dataflow::operators::*;
-use differential_dataflow::lattice::Lattice;
+use differential_dataflow::lattice::TotalOrder;
 
 use ::Collections;
 
@@ -61,7 +61,7 @@ fn starts_with(source: &[u8], query: &[u8]) -> bool {
 }
 
 pub fn query<G: Scope>(collections: &mut Collections<G>) -> ProbeHandle<G::Timestamp> 
-where G::Timestamp: Lattice+Ord {
+where G::Timestamp: TotalOrder+Ord {
 
     let orders =
     collections

--- a/tpchlike/src/queries/query22.rs
+++ b/tpchlike/src/queries/query22.rs
@@ -4,7 +4,7 @@ use timely::dataflow::operators::probe::Handle as ProbeHandle;
 
 use differential_dataflow::AsCollection;
 use differential_dataflow::operators::*;
-use differential_dataflow::lattice::Lattice;
+use differential_dataflow::lattice::TotalOrder;
 use differential_dataflow::difference::DiffPair;
 use differential_dataflow::operators::arrange::Arrange;
 // use differential_dataflow::operators::join::JoinArranged;
@@ -63,7 +63,7 @@ use ::Collections;
 // :n -1
 
 pub fn query<G: Scope>(collections: &mut Collections<G>) -> ProbeHandle<G::Timestamp> 
-where G::Timestamp: Lattice+Ord {
+where G::Timestamp: TotalOrder+Ord {
 
     println!("TODO: Q22 uses a `group` for counting to get an arrangement; could use `count_total`");
 


### PR DESCRIPTION
This PR introduces the `lattice::TotalOrder` trait. The trait is a "carrier trait" in the sense that it introduces no new functionality over `Lattice`, but rather is implemented for only a subset of implementors of `Lattice`. It is meant to indicate which lattices are in fact total orders, and admit more efficient implementations of various operators.

The `TotalOrder` trait is implemented for integers, empty types (e.g. `RootTimestamp` and `()`), and products of empty types with other types that implement `TotalOrder`. I may have the implementations backwards, so that `((), (), (), u64)` doesn't end up totally ordered, but fixing this seems to require a new `Empty` trait, which is fine and maybe we will get to that if anyone notices.