### PR TITLE
Explode

### DIFF
--- a/src/collection.rs
+++ b/src/collection.rs
@@ -107,7 +107,7 @@ impl<G: Scope, D: Data, R: Diff> Collection<G, D, R> where G::Timestamp: Data {
     /// // moves `salary` to accumulable data, and results 
     /// // in the total salary for people by name (e.g. how
     /// // much do people named "Frank" get paid).
-    /// employees.explode(|(name, salary)| (name, salary))
+    /// employees.explode(|(name, salary)| Some((name, salary)))
     ///          .count();
     /// ```
     pub fn explode<D2, R2, I, L>(&self, logic: L) -> Collection<G, D2, <R2 as Mul<R>>::Output> 

--- a/tpchlike/src/queries/query02.rs
+++ b/tpchlike/src/queries/query02.rs
@@ -1,8 +1,6 @@
 use timely::dataflow::*;
-// use timely::dataflow::operators::*;
 use timely::dataflow::operators::probe::Handle as ProbeHandle;
 
-// use differential_dataflow::AsCollection;
 use differential_dataflow::operators::*;
 use differential_dataflow::lattice::TotalOrder;
 

--- a/tpchlike/src/queries/query03.rs
+++ b/tpchlike/src/queries/query03.rs
@@ -1,8 +1,6 @@
 use timely::dataflow::*;
-use timely::dataflow::operators::*;
 use timely::dataflow::operators::probe::Handle as ProbeHandle;
 
-use differential_dataflow::AsCollection;
 use differential_dataflow::operators::*;
 use differential_dataflow::lattice::TotalOrder;
 
@@ -55,14 +53,12 @@ where G::Timestamp: TotalOrder+Ord {
     let lineitems = 
     collections
         .lineitems()
-        .inner
-        .flat_map(|(l,t,d)| 
+        .explode(|l| 
             if l.ship_date > create_date(1995, 3, 15) {
-                Some((l.order_key, t, (l.extended_price * (100 - l.discount) / 100) as isize * d))
+                Some((l.order_key, (l.extended_price * (100 - l.discount) / 100) as isize))
             }
             else { None }
-        )
-        .as_collection();
+        );
 
     let orders = 
     collections

--- a/tpchlike/src/queries/query04.rs
+++ b/tpchlike/src/queries/query04.rs
@@ -1,11 +1,8 @@
 use timely::dataflow::*;
-// use timely::dataflow::operators::*;
 use timely::dataflow::operators::probe::Handle as ProbeHandle;
 
-// use differential_dataflow::AsCollection;
 use differential_dataflow::operators::*;
 use differential_dataflow::operators::arrange::Arrange;
-// use differential_dataflow::operators::join::JoinArranged;
 use differential_dataflow::operators::group::GroupArranged;
 use differential_dataflow::trace::Trace;
 use differential_dataflow::trace::implementations::ord::OrdKeySpine as DefaultKeyTrace;

--- a/tpchlike/src/queries/query05.rs
+++ b/tpchlike/src/queries/query05.rs
@@ -1,8 +1,6 @@
 use timely::dataflow::*;
-use timely::dataflow::operators::*;
 use timely::dataflow::operators::probe::Handle as ProbeHandle;
 
-use differential_dataflow::AsCollection;
 use differential_dataflow::operators::*;
 use differential_dataflow::lattice::TotalOrder;
 
@@ -85,9 +83,7 @@ where G::Timestamp: TotalOrder+Ord {
 
     let lineitems = collections
         .lineitems()
-        .inner
-        .map(|(l,t,d)| ((l.order_key, l.supp_key), t, d * (l.extended_price * (100 - l.discount) / 100) as isize))
-        .as_collection()
+        .explode(|l| Some(((l.order_key, l.supp_key), (l.extended_price * (100 - l.discount) / 100) as isize)))
         .semijoin_u(&orders)
         .map(|(_order, supp)| supp);
 

--- a/tpchlike/src/queries/query06.rs
+++ b/tpchlike/src/queries/query06.rs
@@ -1,8 +1,6 @@
 use timely::dataflow::*;
-use timely::dataflow::operators::*;
 use timely::dataflow::operators::probe::Handle as ProbeHandle;
 
-use differential_dataflow::AsCollection;
 use differential_dataflow::operators::*;
 use differential_dataflow::lattice::TotalOrder;
 
@@ -33,14 +31,12 @@ where G::Timestamp: TotalOrder+Ord {
 
     collections
         .lineitems()
-        .inner
-        .flat_map(|(x, time, diff)| 
+        .explode(|x|
             if create_date(1994, 1, 1) <= x.ship_date && x.ship_date < create_date(1995, 1, 1) && 5 <= x.discount && x.discount < 7 && x.quantity < 24 {
-                Some((0u8, time, (x.extended_price * x.discount / 100) * diff as i64))
+                Some((0u8, (x.extended_price * x.discount / 100) as isize))
             }
             else { None }
         )
-        .as_collection()
         .count_total_u()
         .probe()
 }

--- a/tpchlike/src/queries/query10.rs
+++ b/tpchlike/src/queries/query10.rs
@@ -1,8 +1,6 @@
 use timely::dataflow::*;
-use timely::dataflow::operators::*;
 use timely::dataflow::operators::probe::Handle as ProbeHandle;
 
-use differential_dataflow::AsCollection;
 use differential_dataflow::operators::*;
 use differential_dataflow::lattice::TotalOrder;
 
@@ -58,14 +56,12 @@ where G::Timestamp: TotalOrder+Ord {
     let lineitems = 
     collections
         .lineitems()
-        .inner
-        .flat_map(|(x,t,d)| 
+        .explode(|x| 
             if starts_with(&x.return_flag, b"R") {
-                Some((x.order_key, t, (x.extended_price * (100 - x.discount)) as isize * d))
+                Some((x.order_key, (x.extended_price * (100 - x.discount)) as isize))
             }
             else { None }
-        )
-        .as_collection();
+        );
 
     let orders =
     collections

--- a/tpchlike/src/queries/query11.rs
+++ b/tpchlike/src/queries/query11.rs
@@ -1,8 +1,6 @@
 use timely::dataflow::*;
-use timely::dataflow::operators::*;
 use timely::dataflow::operators::probe::Handle as ProbeHandle;
 
-use differential_dataflow::AsCollection;
 use differential_dataflow::operators::*;
 use differential_dataflow::lattice::TotalOrder;
 
@@ -67,9 +65,7 @@ where G::Timestamp: TotalOrder+Ord {
 
     collections
         .partsupps()
-        .inner
-        .map(|(x,t,d)| ((x.supp_key, x.part_key), t, ((x.supplycost as isize) * (x.availqty as isize) * d)))
-        .as_collection()
+        .explode(|x| Some(((x.supp_key, x.part_key), (x.supplycost as isize) * (x.availqty as isize))))
         .semijoin_u(&suppliers)
         .map(|(_, part_key)| (0u8, part_key))
         .group_u(|_part_key, s, t| {

--- a/tpchlike/src/queries/query13.rs
+++ b/tpchlike/src/queries/query13.rs
@@ -1,8 +1,6 @@
 use timely::dataflow::*;
-// use timely::dataflow::operators::*;
 use timely::dataflow::operators::probe::Handle as ProbeHandle;
 
-// use differential_dataflow::AsCollection;
 use differential_dataflow::operators::*;
 use differential_dataflow::lattice::TotalOrder;
 

--- a/tpchlike/src/queries/query15.rs
+++ b/tpchlike/src/queries/query15.rs
@@ -1,8 +1,6 @@
 use timely::dataflow::*;
-use timely::dataflow::operators::*;
 use timely::dataflow::operators::probe::Handle as ProbeHandle;
 
-use differential_dataflow::AsCollection;
 use differential_dataflow::operators::*;
 use differential_dataflow::lattice::TotalOrder;
 
@@ -59,14 +57,12 @@ where G::Timestamp: TotalOrder+Ord {
     let revenue = 
         collections
             .lineitems()
-            .inner
-            .flat_map(|(item, time, diff)| 
+            .explode(|item|
                 if create_date(1996, 1, 1) <= item.ship_date && item.ship_date < create_date(1996,4,1) {
-                    Some((item.supp_key, time, (item.extended_price * (100 - item.discount) / 100) as isize * diff))
+                    Some((item.supp_key, (item.extended_price * (100 - item.discount) / 100) as isize))
                 }
                 else { None }
-            )
-            .as_collection();
+            );
 
     // suppliers with maximum revenue
     let top_suppliers =

--- a/tpchlike/src/queries/query17.rs
+++ b/tpchlike/src/queries/query17.rs
@@ -1,8 +1,6 @@
 use timely::dataflow::*;
-use timely::dataflow::operators::*;
 use timely::dataflow::operators::probe::Handle as ProbeHandle;
 
-use differential_dataflow::AsCollection;
 use differential_dataflow::operators::*;
 use differential_dataflow::lattice::TotalOrder;
 
@@ -65,9 +63,7 @@ where G::Timestamp: TotalOrder+Ord {
             t.extend(s.iter().filter(|&&((quantity,_),_)| quantity < threshold)
                              .map(|&((_,price),count)| (price, count)));
         })
-        .inner
-        .map(|((_part, price), time, count)| (0u8, time, price * count as i64))
-        .as_collection()
+        .explode(|(_part, price)| Some((0u8, price as isize)))
         .count_total_u()
         .probe()
 }

--- a/tpchlike/src/queries/query18.rs
+++ b/tpchlike/src/queries/query18.rs
@@ -1,8 +1,6 @@
 use timely::dataflow::*;
-use timely::dataflow::operators::*;
 use timely::dataflow::operators::probe::Handle as ProbeHandle;
 
-use differential_dataflow::AsCollection;
 use differential_dataflow::operators::*;
 use differential_dataflow::operators::arrange::Arrange;
 use differential_dataflow::operators::group::GroupArranged;
@@ -68,9 +66,7 @@ where G::Timestamp: TotalOrder+Ord {
 
     collections
         .lineitems()
-        .inner
-        .map(|(l, t, d)| ((UnsignedWrapper::from(l.order_key), ()), t, (l.quantity as isize) * d))
-        .as_collection()
+        .explode(|l| Some(((UnsignedWrapper::from(l.order_key), ()), l.quantity as isize)))
         .arrange(DefaultKeyTrace::new())
         .group_arranged(|_k,s,t| t.push((s[0].1, 1)), DefaultValTrace::new())
         .join_core(&orders, |&o_key, &quant, &(cust_key, date, price)| 

--- a/tpchlike/src/queries/query20.rs
+++ b/tpchlike/src/queries/query20.rs
@@ -1,8 +1,6 @@
 use timely::dataflow::*;
-use timely::dataflow::operators::*;
 use timely::dataflow::operators::probe::Handle as ProbeHandle;
 
-use differential_dataflow::AsCollection;
 use differential_dataflow::operators::*;
 use differential_dataflow::operators::arrange::Arrange;
 use differential_dataflow::operators::group::GroupArranged;
@@ -79,9 +77,7 @@ where G::Timestamp: TotalOrder+Ord {
             else { None }
         )
         .semijoin_u(&partkeys)
-        .inner
-        .map(|(l, t, d)| ((UnsignedWrapper::from(((l.0 as u64) << 32) + (l.1).0 as u64), ()), t, (l.1).1 as isize * d))
-        .as_collection()
+        .explode(|l| Some(((UnsignedWrapper::from(((l.0 as u64) << 32) + (l.1).0 as u64), ()), (l.1).1 as isize)))
         .arrange(DefaultKeyTrace::new())
         .group_arranged(|_k,s,t| t.push((s[0].1, 1)), DefaultValTrace::new());
 

--- a/tpchlike/src/queries/query21.rs
+++ b/tpchlike/src/queries/query21.rs
@@ -1,8 +1,6 @@
 use timely::dataflow::*;
-// use timely::dataflow::operators::*;
 use timely::dataflow::operators::probe::Handle as ProbeHandle;
 
-// use differential_dataflow::AsCollection;
 use differential_dataflow::operators::*;
 use differential_dataflow::lattice::TotalOrder;
 


### PR DESCRIPTION
This PR introduces the `explode` operator, whose role in life is to move parts of the data that can be aggregated into the `diff` component, which differential dataflow will aggregate in-place. For example, if we had a collection of `(name, salary)` pairs and wanted the total salaries by name, the only way to do this within differential dataflow was

```rust
employees.group(|_name, salaries, output| 
    let sum = salaries.iter().map(|(sal,cnt)| sal * cnt).sum();
    output.push((sum, 1));
)
```

This is horrible for several reasons. Other than being verbose, differential dataflow is obliged to maintain the collection of salaries as distinct elements, because we could be computing the median or something horrible like that. We would prefer a way to explain to differential dataflow that it can accumulate the `salary` components.

The `explode` operator does this, mapping each input datum into a sequence of pairs (data, diff), and producing the collection that is the accumulation of all of the diffs for each of the datas produced. The example above would become

```rust
employees.explode(|(name, salary)| Some((name, salary)))
         .count();
```

In addition to being more efficient, this is meant to be more idiomatic, in that our program does not need to understand the underlying differences, etc. It also means that we can introduce other operators, `filter`, `map`, `join`, etc before doing the final `count` accumulation.

It may be that we need a more idiomatic name, but I'm not entirely sure what to use (`accumulate`, because the result in an accumulation?). Any thoughts here would be welcome.