### PR TITLE
add input and new_collection

### DIFF
--- a/examples/dataflog.rs
+++ b/examples/dataflog.rs
@@ -7,7 +7,8 @@ use timely::dataflow::scopes::Child;
 use timely::dataflow::operators::*;
 use timely::dataflow::operators::feedback::Handle;
 
-use differential_dataflow::{Data, Collection, AsCollection, Hashable};
+use differential_dataflow::input::Input;
+use differential_dataflow::{Data, Collection, Hashable};
 use differential_dataflow::operators::*;
 use differential_dataflow::lattice::Lattice;
 
@@ -64,12 +65,12 @@ fn main() {
         worker.dataflow::<u64,_,_>(move |outer| {
 
             // inputs for base facts; currently not used because no data on hand.
-            let (_cin, c) = outer.new_input::<((u32,u32,u32),_,isize)>(); let c = c.as_collection();
-            let (_pin, p) = outer.new_input::<((u32,u32),_,isize)>(); let p = p.as_collection();
-            let (_qin, q) = outer.new_input::<((u32,u32,u32),_,isize)>(); let q = q.as_collection();
-            let (_rin, r) = outer.new_input::<((u32,u32,u32),_,isize)>(); let r = r.as_collection();
-            let (_sin, s) = outer.new_input::<((u32,u32),_,isize)>(); let s = s.as_collection();
-            let (_uin, u) = outer.new_input::<((u32,u32,u32),_,isize)>(); let u = u.as_collection();
+            let (_cin, c) = outer.new_collection::<(u32,u32,u32),isize>();
+            let (_pin, p) = outer.new_collection::<(u32,u32),isize>();
+            let (_qin, q) = outer.new_collection::<(u32,u32,u32),isize>();
+            let (_rin, r) = outer.new_collection::<(u32,u32,u32),isize>();
+            let (_sin, s) = outer.new_collection::<(u32,u32),isize>();
+            let (_uin, u) = outer.new_collection::<(u32,u32,u32),isize>();
 
             // construct iterative derivation scope
             let (_p, _q) = outer.scoped::<u64,_,_>(|inner| {

--- a/examples/deals.rs
+++ b/examples/deals.rs
@@ -12,12 +12,11 @@ use std::mem;
 use rand::{Rng, SeedableRng, StdRng};
 
 use timely::dataflow::*;
-use timely::dataflow::operators::*;
 
+use differential_dataflow::input::Input;
 use differential_dataflow::Collection;
 use differential_dataflow::operators::*;
 use differential_dataflow::operators::arrange::{ArrangeByKey, ArrangeBySelf};
-// use differential_dataflow::operators::join::JoinArranged;
 use differential_dataflow::lattice::Lattice;
 
 use graph_map::GraphMMap;
@@ -41,11 +40,8 @@ fn main() {
 
         let (mut input, mut query, probe) = worker.dataflow::<u64,_,_>(|scope| {
 
-            let (input, stream1) = scope.new_input();
-            let (rootz, stream2) = scope.new_input();
-
-            let graph = Collection::new(stream1);
-            let query = Collection::new(stream2);
+            let (input, graph) = scope.new_collection();
+            let (rootz, query) = scope.new_collection();
 
             let probe = match program.as_str() {
                 "reach" => _reach(&graph, &query).probe(),
@@ -62,11 +58,10 @@ fn main() {
         let timer = Instant::now();
 
         // start loading up the graph
-        let &time = input.time();
         for node in 0..graph.nodes() {
             if node % peers == index {
                 for &edge in graph.edges(node) {
-                    input.send(((node as u32, edge), time, 1));
+                    input.insert((node as u32, edge));
                 }
             }
         }
@@ -87,10 +82,9 @@ fn main() {
         let mut rng: StdRng = SeedableRng::from_seed(seed);    // rng for edge additions
 
         for _count in 0..latencies.capacity() {
-            let &time = query.time();
             let timer = Instant::now();
             if index == 0 {
-                query.send((rng.gen_range(0, graph.nodes() as u32), time, 1));
+                query.insert((rng.gen_range(0, graph.nodes() as u32)));
             }
             let next = query.epoch() + 1;
             input.advance_to(next);

--- a/tests/bfs.rs
+++ b/tests/bfs.rs
@@ -7,11 +7,11 @@ use rand::{Rng, SeedableRng, StdRng};
 use std::sync::{Arc, Mutex};
 
 use timely::dataflow::*;
-use timely::dataflow::operators::*;
 use timely::dataflow::operators::Capture;
 use timely::dataflow::operators::capture::Extract;
 
-use differential_dataflow::{Collection, AsCollection};
+use differential_dataflow::input::Input;
+use differential_dataflow::Collection;
 
 use differential_dataflow::operators::*;
 use differential_dataflow::lattice::Lattice;
@@ -157,11 +157,8 @@ fn bfs_differential(
 
             let send = send.lock().unwrap().clone();
 
-            let (root_input, roots) = scope.new_input();
-            let (edge_input, edges) = scope.new_input();
-
-            let roots = roots.as_collection();
-            let edges = edges.as_collection();
+            let (root_input, roots) = scope.new_collection();
+            let (edge_input, edges) = scope.new_collection();
 
             bfs(&edges, &roots).map(|(_, dist)| dist)
                                .count()
@@ -175,9 +172,6 @@ fn bfs_differential(
         // sort by decreasing insertion time.
         roots_list.sort_by(|x,y| y.1.cmp(&x.1));
         edges_list.sort_by(|x,y| y.1.cmp(&x.1));
-
-        let mut roots = differential_dataflow::input::InputSession::from(&mut roots);
-        let mut edges = differential_dataflow::input::InputSession::from(&mut edges);
 
         let mut round = 0;
         while roots_list.len() > 0 || edges_list.len() > 0 {

--- a/tests/import.rs
+++ b/tests/import.rs
@@ -115,7 +115,6 @@ fn test_import_completed_dataflow() {
                     input.send(((src, dst), time, w));
                 }
             }
-            let input_time = input.time().clone();
             input.close();
 
             worker.step_while(|| !probe.done());


### PR DESCRIPTION
This PR works with the `inputs::` module a bit. The `InputSession` type is modified to own its timely dataflow handle, which seems to simplify everything. It proxies each of the timely methods (except perhaps `send_batch`?), and in converting examples over, everything became simpler.

**Caveat**: The main thing to look for is that, unlike with the timely input handle, calling `advance_to` does not flush the progress information from a differential input session. This is intentional, and part of differential dataflow's support for hi-res times. Make sure to call `flush()` before expecting the progress information to be reflected by progress tracking (e.g. in a `probe`).

There is also a new trait `input::Input`, which provides a `new_collection` method, paralleling `new_input` for timely dataflow. The result is a differential input session and a collection, which can save a bunch of random boilerplate. Again, converting examples over everything generally got simpler.