### PR TITLE
examples/bfs: flush graph input after advancing to time=1

### DIFF
--- a/examples/bfs.rs
+++ b/examples/bfs.rs
@@ -75,6 +75,7 @@ fn main() {
         println!("loaded; elapsed: {:?}", timer.elapsed());
 
         graph.advance_to(1);
+        graph.flush();
         worker.step_while(|| probe.less_than(graph.time()));
 
         for round in 0 .. rounds {


### PR DESCRIPTION
I've added a missing `.flush()` in the bfs example.