### PR TITLE
No `Rc`s in layers, fixes #61

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ abomonation="0.4.4"
 timely_sort="0.1.6"
 timely_communication="0.1.5"
 fnv="1.0.2"
+owning_ref="^0.3"
 
 [features]
 default = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,7 @@ extern crate timely;
 extern crate timely_sort;
 extern crate timely_communication;
 extern crate abomonation;
+extern crate owning_ref;
 
 pub mod hashable;
 pub mod operators;

--- a/src/trace/implementations/hash.rs
+++ b/src/trace/implementations/hash.rs
@@ -48,8 +48,8 @@ where K: Clone+Default+HashOrdered, V: Clone+Ord, T: Lattice+Ord+Clone+Default, 
 	type Cursor = HashValCursor<K, V, T, R>;
 	fn cursor(&self) -> Self::Cursor { 
 		HashValCursor {
-            cursor: self.layer.cursor(OwningRef::new(self.clone()).map(|x| &x.layer)),
-	}
+			cursor: self.layer.cursor(OwningRef::new(self.clone()).map(|x| &x.layer)),
+		}
 	}
 	fn len(&self) -> usize { <HashedLayer<K, OrderedLayer<V, UnorderedLayer<(T, R)>>> as Trie<HashValBatch<K, V, T, R>>>::tuples(&self.layer) }
 	fn description(&self) -> &Description<T> { &self.desc }
@@ -72,10 +72,10 @@ where K: Clone+Default+HashOrdered, V: Clone+Ord, T: Lattice+Ord+Clone+Default, 
 			self.desc.since()
 		};
 		
-        Rc::new(HashValBatch {
-            layer: <HashedLayer<K, OrderedLayer<V, UnorderedLayer<(T, R)>>> as Trie<HashValBatch<K, V, T, R>>>::merge(&self.layer, &other.layer),
-            desc: Description::new(self.desc.lower(), other.desc.upper(), since),
-        })
+		Rc::new(HashValBatch {
+			layer: <HashedLayer<K, OrderedLayer<V, UnorderedLayer<(T, R)>>> as Trie<HashValBatch<K, V, T, R>>>::merge(&self.layer, &other.layer),
+			desc: Description::new(self.desc.lower(), other.desc.upper(), since),
+		})
 	}
 }
 
@@ -141,10 +141,10 @@ where K: Clone+Default+HashOrdered, V: Ord+Clone, T: Lattice+Ord+Clone+Default, 
 
 	#[inline(never)]
 	fn done(self, lower: &[T], upper: &[T], since: &[T]) -> Rc<HashValBatch<K, V, T, R>> {
-        Rc::new(HashValBatch {
-            layer: self.builder.done(),
-            desc: Description::new(lower, upper, since)
-        })
+		Rc::new(HashValBatch {
+			layer: self.builder.done(),
+			desc: Description::new(lower, upper, since)
+		})
 	}
 }
 
@@ -165,10 +165,10 @@ where K: Clone+Default+HashOrdered, T: Lattice+Ord+Clone+Default, R: Diff {
 	type Cursor = HashKeyCursor<K, T, R>;
 	fn cursor(&self) -> Self::Cursor { 
 		HashKeyCursor {
-            empty: (),
-            valid: true,
-            cursor: self.layer.cursor(OwningRef::new(self.clone()).map(|x| &x.layer)),
-        } 
+			empty: (),
+			valid: true,
+			cursor: self.layer.cursor(OwningRef::new(self.clone()).map(|x| &x.layer)),
+		} 
 	}
 	fn len(&self) -> usize { <HashedLayer<K, UnorderedLayer<(T, R)>> as Trie<HashKeyBatch<K, T, R>>>::tuples(&self.layer) }
 	fn description(&self) -> &Description<T> { &self.desc }
@@ -191,10 +191,10 @@ where K: Clone+Default+HashOrdered, T: Lattice+Ord+Clone+Default, R: Diff {
 			self.desc.since()
 		};
 		
-        Rc::new(HashKeyBatch {
-            layer: <HashedLayer<K, UnorderedLayer<(T, R)>> as Trie<HashKeyBatch<K, T, R>>>::merge(&self.layer, &other.layer),
-            desc: Description::new(self.desc.lower(), other.desc.upper(), since),
-        })
+		Rc::new(HashKeyBatch {
+			layer: <HashedLayer<K, UnorderedLayer<(T, R)>> as Trie<HashKeyBatch<K, T, R>>>::merge(&self.layer, &other.layer),
+			desc: Description::new(self.desc.lower(), other.desc.upper(), since),
+		})
 	}
 }
 
@@ -262,10 +262,10 @@ where K: Clone+Default+HashOrdered, T: Lattice+Ord+Clone+Default, R: Diff {
 
 	#[inline(never)]
 	fn done(self, lower: &[T], upper: &[T], since: &[T]) -> Rc<HashKeyBatch<K, T, R>> {
-        Rc::new(HashKeyBatch {
-            layer: self.builder.done(),
-            desc: Description::new(lower, upper, since)
-        })
+		Rc::new(HashKeyBatch {
+			layer: self.builder.done(),
+			desc: Description::new(lower, upper, since)
+		})
 	}
 }
 

--- a/src/trace/implementations/hash.rs
+++ b/src/trace/implementations/hash.rs
@@ -9,6 +9,7 @@
 //! and should consume fewer resources (computation and memory) when it applies.
 
 use std::rc::Rc;
+use owning_ref::OwningRef;
 
 use ::Diff;
 use hashable::HashOrdered;
@@ -46,9 +47,11 @@ impl<K, V, T, R> BatchReader<K, V, T, R> for Rc<HashValBatch<K, V, T, R>>
 where K: Clone+Default+HashOrdered, V: Clone+Ord, T: Lattice+Ord+Clone+Default, R: Diff {
 	type Cursor = HashValCursor<K, V, T, R>;
 	fn cursor(&self) -> Self::Cursor { 
-		HashValCursor { cursor: self.clone().layer.cursor() } 
+		HashValCursor {
+            cursor: self.layer.cursor(OwningRef::new(self.clone()).map(|x| &x.layer)),
 	}
-	fn len(&self) -> usize { self.layer.tuples() }
+	}
+	fn len(&self) -> usize { <HashedLayer<K, OrderedLayer<V, UnorderedLayer<(T, R)>>> as Trie<HashValBatch<K, V, T, R>>>::tuples(&self.layer) }
 	fn description(&self) -> &Description<T> { &self.desc }
 }
 
@@ -70,7 +73,7 @@ where K: Clone+Default+HashOrdered, V: Clone+Ord, T: Lattice+Ord+Clone+Default, 
 		};
 		
         Rc::new(HashValBatch {
-            layer: self.layer.merge(&other.layer),
+            layer: <HashedLayer<K, OrderedLayer<V, UnorderedLayer<(T, R)>>> as Trie<HashValBatch<K, V, T, R>>>::merge(&self.layer, &other.layer),
             desc: Description::new(self.desc.lower(), other.desc.upper(), since),
         })
 	}
@@ -88,7 +91,7 @@ where K: Clone+Default+HashOrdered, V: Clone+Ord, T: Lattice+Ord+Clone+Default, 
 /// A cursor for navigating a single layer.
 #[derive(Debug)]
 pub struct HashValCursor<K: Clone+HashOrdered, V: Ord+Clone, T: Lattice+Ord+Clone, R: Copy> {
-	cursor: HashedCursor<K, OrderedCursor<V, UnorderedCursor<(T, R)>>>,
+	cursor: HashedCursor<HashValBatch<K, V, T, R>, K, OrderedCursor<HashValBatch<K, V, T, R>, V, UnorderedCursor<HashValBatch<K, V, T, R>, (T, R)>>>,
 }
 
 impl<K: Clone+HashOrdered, V: Ord+Clone, T: Lattice+Ord+Clone, R: Copy> Cursor<K, V, T, R> for HashValCursor<K, V, T, R> {
@@ -113,8 +116,8 @@ impl<K: Clone+HashOrdered, V: Ord+Clone, T: Lattice+Ord+Clone, R: Copy> Cursor<K
 
 
 /// A builder for creating layers from unsorted update tuples.
-pub struct HashValBuilder<K: HashOrdered, V: Ord, T: Ord, R: Diff> {
-	builder: HashedBuilder<K, OrderedBuilder<V, UnorderedBuilder<(T, R)>>>,
+pub struct HashValBuilder<K: HashOrdered, V: Ord, T: Ord+Lattice, R: Diff> {
+	builder: HashedBuilder<HashValBatch<K, V, T, R>, K, OrderedBuilder<HashValBatch<K, V, T, R>, V, UnorderedBuilder<(T, R)>>>,
 }
 
 impl<K, V, T, R> Builder<K, V, T, R, Rc<HashValBatch<K, V, T, R>>> for HashValBuilder<K, V, T, R> 
@@ -122,12 +125,12 @@ where K: Clone+Default+HashOrdered, V: Ord+Clone, T: Lattice+Ord+Clone+Default, 
 
 	fn new() -> Self { 
 		HashValBuilder { 
-			builder: HashedBuilder::<K, OrderedBuilder<V, UnorderedBuilder<(T, R)>>>::new() 
+			builder: HashedBuilder::<HashValBatch<K, V, T, R>, K, OrderedBuilder<HashValBatch<K, V, T, R>, V, UnorderedBuilder<(T, R)>>>::new() 
 		} 
 	}
 	fn with_capacity(cap: usize) -> Self { 
 		HashValBuilder { 
-			builder: HashedBuilder::<K, OrderedBuilder<V, UnorderedBuilder<(T, R)>>>::with_capacity(cap) 
+			builder: HashedBuilder::<HashValBatch<K, V, T, R>, K, OrderedBuilder<HashValBatch<K, V, T, R>, V, UnorderedBuilder<(T, R)>>>::with_capacity(cap) 
 		} 
 	}
 
@@ -161,9 +164,13 @@ impl<K, T, R> BatchReader<K, (), T, R> for Rc<HashKeyBatch<K, T, R>>
 where K: Clone+Default+HashOrdered, T: Lattice+Ord+Clone+Default, R: Diff {
 	type Cursor = HashKeyCursor<K, T, R>;
 	fn cursor(&self) -> Self::Cursor { 
-		HashKeyCursor { empty: (), valid: true, cursor: self.clone().layer.cursor() } 
+		HashKeyCursor {
+            empty: (),
+            valid: true,
+            cursor: self.layer.cursor(OwningRef::new(self.clone()).map(|x| &x.layer)),
+        } 
 	}
-	fn len(&self) -> usize { self.layer.tuples() }
+	fn len(&self) -> usize { <HashedLayer<K, UnorderedLayer<(T, R)>> as Trie<HashKeyBatch<K, T, R>>>::tuples(&self.layer) }
 	fn description(&self) -> &Description<T> { &self.desc }
 }
 
@@ -185,7 +192,7 @@ where K: Clone+Default+HashOrdered, T: Lattice+Ord+Clone+Default, R: Diff {
 		};
 		
         Rc::new(HashKeyBatch {
-            layer: self.layer.merge(&other.layer),
+            layer: <HashedLayer<K, UnorderedLayer<(T, R)>> as Trie<HashKeyBatch<K, T, R>>>::merge(&self.layer, &other.layer),
             desc: Description::new(self.desc.lower(), other.desc.upper(), since),
         })
 	}
@@ -205,7 +212,7 @@ where K: Clone+Default+HashOrdered, T: Lattice+Ord+Clone+Default, R: Diff {
 pub struct HashKeyCursor<K: Clone+HashOrdered, T: Lattice+Ord+Clone, R: Copy> {
 	valid: bool,
 	empty: (),
-	cursor: HashedCursor<K, UnorderedCursor<(T, R)>>,
+	cursor: HashedCursor<HashKeyBatch<K, T, R>, K, UnorderedCursor<HashKeyBatch<K, T, R>, (T, R)>>,
 }
 
 impl<K: Clone+HashOrdered, T: Lattice+Ord+Clone, R: Copy> Cursor<K, (), T, R> for HashKeyCursor<K, T, R> {
@@ -230,8 +237,8 @@ impl<K: Clone+HashOrdered, T: Lattice+Ord+Clone, R: Copy> Cursor<K, (), T, R> fo
 
 
 /// A builder for creating layers from unsorted update tuples.
-pub struct HashKeyBuilder<K: HashOrdered, T: Ord, R: Diff> {
-	builder: HashedBuilder<K, UnorderedBuilder<(T, R)>>,
+pub struct HashKeyBuilder<K: HashOrdered, T: Ord+Lattice, R: Diff> {
+	builder: HashedBuilder<HashKeyBatch<K, T, R>, K, UnorderedBuilder<(T, R)>>,
 }
 
 impl<K, T, R> Builder<K, (), T, R, Rc<HashKeyBatch<K, T, R>>> for HashKeyBuilder<K, T, R> 
@@ -239,12 +246,12 @@ where K: Clone+Default+HashOrdered, T: Lattice+Ord+Clone+Default, R: Diff {
 
 	fn new() -> Self { 
 		HashKeyBuilder { 
-			builder: HashedBuilder::<K, UnorderedBuilder<(T, R)>>::new() 
+			builder: HashedBuilder::<HashKeyBatch<K, T, R>, K, UnorderedBuilder<(T, R)>>::new() 
 		} 
 	}
 	fn with_capacity(cap: usize) -> Self { 
 		HashKeyBuilder { 
-			builder: HashedBuilder::<K, UnorderedBuilder<(T, R)>>::with_capacity(cap) 
+			builder: HashedBuilder::<HashKeyBatch<K, T, R>, K, UnorderedBuilder<(T, R)>>::with_capacity(cap) 
 		} 
 	}
 

--- a/src/trace/implementations/hash.rs
+++ b/src/trace/implementations/hash.rs
@@ -79,15 +79,6 @@ where K: Clone+Default+HashOrdered, V: Clone+Ord, T: Lattice+Ord+Clone+Default, 
 	}
 }
 
-// impl<K: HashOrdered, V: Ord, T: Lattice+Ord+Clone, R> Clone for HashValBatch<K, V, T, R> {
-// 	fn clone(&self) -> Self {
-// 		HashValBatch {
-// 			layer: self.layer.clone(),
-// 			desc: self.desc.clone(),
-// 		}
-// 	}
-// }
-
 /// A cursor for navigating a single layer.
 #[derive(Debug)]
 pub struct HashValCursor<K: Clone+HashOrdered, V: Ord+Clone, T: Lattice+Ord+Clone, R: Copy> {
@@ -197,15 +188,6 @@ where K: Clone+Default+HashOrdered, T: Lattice+Ord+Clone+Default, R: Diff {
 		})
 	}
 }
-
-// impl<K: HashOrdered, T: Lattice+Ord+Clone, R> Clone for HashKeyBatch<K, T, R> {
-// 	fn clone(&self) -> Self {
-// 		HashKeyBatch {
-// 			layer: self.layer.clone(),
-// 			desc: self.desc.clone(),
-// 		}
-// 	}
-// }
 
 /// A cursor for navigating a single layer.
 #[derive(Debug)]

--- a/src/trace/implementations/mod.rs
+++ b/src/trace/implementations/mod.rs
@@ -50,3 +50,4 @@ pub mod hash;
 
 // pub mod rhh;
 // pub mod rhh_k;
+//

--- a/src/trace/implementations/ord.rs
+++ b/src/trace/implementations/ord.rs
@@ -47,8 +47,8 @@ where K: Ord+Clone+HashOrdered, V: Ord+Clone, T: Lattice+Ord+Clone, R: Diff {
 	type Cursor = OrdValCursor<K, V, T, R>;
 	fn cursor(&self) -> Self::Cursor { 
 		OrdValCursor {
-            cursor: self.layer.cursor(OwningRef::new(self.clone()).map(|x| &x.layer))
-	}
+			cursor: self.layer.cursor(OwningRef::new(self.clone()).map(|x| &x.layer))
+		}
 	}
 	fn len(&self) -> usize { <OrderedLayer<K, OrderedLayer<V, OrderedLeaf<T, R>>> as Trie<OrdValBatch<K, V, T, R>>>::tuples(&self.layer) }
 	fn description(&self) -> &Description<T> { &self.desc }
@@ -71,10 +71,10 @@ where K: Ord+Clone+HashOrdered, V: Ord+Clone, T: Lattice+Ord+Clone, R: Diff {
 			self.desc.since()
 		};
 		
-        Rc::new(OrdValBatch {
-            layer: <OrderedLayer<K, OrderedLayer<V, OrderedLeaf<T, R>>> as Trie<OrdValBatch<K, V, T, R>>>::merge(&self.layer, &other.layer),  //self.layer.merge(&other.layer),
-            desc: Description::new(self.desc.lower(), other.desc.upper(), since),
-        })
+		Rc::new(OrdValBatch {
+			layer: <OrderedLayer<K, OrderedLayer<V, OrderedLeaf<T, R>>> as Trie<OrdValBatch<K, V, T, R>>>::merge(&self.layer, &other.layer),  //self.layer.merge(&other.layer),
+			desc: Description::new(self.desc.lower(), other.desc.upper(), since),
+		})
 	}
 }
 
@@ -141,10 +141,10 @@ where K: Ord+Clone+HashOrdered, V: Ord+Clone, T: Lattice+Ord+Clone, R: Diff {
 
 	#[inline(never)]
 	fn done(self, lower: &[T], upper: &[T], since: &[T]) -> Rc<OrdValBatch<K, V, T, R>> {
-        Rc::new(OrdValBatch {
-            layer: self.builder.done(),
-            desc: Description::new(lower, upper, since)
-        })
+		Rc::new(OrdValBatch {
+			layer: self.builder.done(),
+			desc: Description::new(lower, upper, since)
+		})
 	}
 }
 
@@ -165,10 +165,10 @@ where K: Ord+Clone+HashOrdered, T: Lattice+Ord+Clone, R: Diff {
 	type Cursor = OrdKeyCursor<K, T, R>;
 	fn cursor(&self) -> Self::Cursor { 
 		OrdKeyCursor {
-            empty: (),
-            valid: true,
-            cursor: self.layer.cursor(OwningRef::new(self.clone()).map(|x| &x.layer)),
-        } 
+			empty: (),
+			valid: true,
+			cursor: self.layer.cursor(OwningRef::new(self.clone()).map(|x| &x.layer)),
+		} 
 	}
 	fn len(&self) -> usize { <OrderedLayer<K, OrderedLeaf<T, R>> as Trie<OrdKeyBatch<K, T, R>>>::tuples(&self.layer) }
 	fn description(&self) -> &Description<T> { &self.desc }
@@ -191,10 +191,10 @@ where K: Ord+Clone+HashOrdered, T: Lattice+Ord+Clone, R: Diff {
 			self.desc.since()
 		};
 		
-        Rc::new(OrdKeyBatch {
-            layer: <OrderedLayer<K, OrderedLeaf<T, R>> as Trie<OrdKeyBatch<K, T, R>>>::merge(&self.layer, &other.layer),
-            desc: Description::new(self.desc.lower(), other.desc.upper(), since),
-        })
+		Rc::new(OrdKeyBatch {
+			layer: <OrderedLayer<K, OrderedLeaf<T, R>> as Trie<OrdKeyBatch<K, T, R>>>::merge(&self.layer, &other.layer),
+			desc: Description::new(self.desc.lower(), other.desc.upper(), since),
+		})
 	}
 }
 
@@ -263,10 +263,10 @@ where K: Ord+Clone+HashOrdered, T: Lattice+Ord+Clone, R: Diff {
 
 	#[inline(never)]
 	fn done(self, lower: &[T], upper: &[T], since: &[T]) -> Rc<OrdKeyBatch<K, T, R>> {
-        Rc::new(OrdKeyBatch {
-            layer: self.builder.done(),
-            desc: Description::new(lower, upper, since)
-        })
+		Rc::new(OrdKeyBatch {
+			layer: self.builder.done(),
+			desc: Description::new(lower, upper, since)
+		})
 	}
 }
 

--- a/src/trace/implementations/ord.rs
+++ b/src/trace/implementations/ord.rs
@@ -78,15 +78,6 @@ where K: Ord+Clone+HashOrdered, V: Ord+Clone, T: Lattice+Ord+Clone, R: Diff {
 	}
 }
 
-// impl<K: Ord+HashOrdered, V: Ord, T: Lattice+Ord+Clone, R> Clone for Rc<OrdValBatch<K, V, T, R>> {
-// 	fn clone(&self) -> Self {
-// 		OrdValBatch {
-// 			layer: self.layer.clone(),
-// 			desc: self.desc.clone(),
-// 		}
-// 	}
-// }
-
 /// A cursor for navigating a single layer.
 #[derive(Debug)]
 pub struct OrdValCursor<K: Ord+Clone+HashOrdered, V: Ord+Clone, T: Lattice+Ord+Clone, R: Copy> {
@@ -197,15 +188,6 @@ where K: Ord+Clone+HashOrdered, T: Lattice+Ord+Clone, R: Diff {
 		})
 	}
 }
-
-// impl<K: Ord+HashOrdered, T: Lattice+Ord+Clone, R> Clone for OrdKeyBatch<K, T, R> {
-// 	fn clone(&self) -> Self {
-// 		OrdKeyBatch {
-// 			layer: self.layer.clone(),
-// 			desc: self.desc.clone(),
-// 		}
-// 	}
-// }
 
 /// A cursor for navigating a single layer.
 #[derive(Debug)]

--- a/src/trace/implementations/spine.rs
+++ b/src/trace/implementations/spine.rs
@@ -140,8 +140,8 @@ where
 		//       Little is currently known about whether this is important ...
 		while self.pending.len() > 0 && 
 		      self.through_frontier.iter().all(|t1| self.pending[0].upper().iter().any(|t2| t2.less_equal(t1))) 
-        {
-        	// this could be a VecDeque, if we ever notice this.
+		{
+			// this could be a VecDeque, if we ever notice this.
 			let batch = self.pending.remove(0);
 
 			// while last two elements exist, both less than batch.len()

--- a/src/trace/layers/hashed.rs
+++ b/src/trace/layers/hashed.rs
@@ -7,6 +7,8 @@ use std::rc::Rc;
 use std::default::Default;
 // use std::hash::Hasher;
 
+use owning_ref::OwningRef;
+
 use timely_sort::Unsigned;
 
 use ::hashable::{Hashable, HashOrdered};
@@ -40,7 +42,7 @@ const BLOAT_FACTOR : f64 = 1.1;
 #[derive(Debug)]
 pub struct HashedLayer<K: HashOrdered, L> {
 	/// Keys and offsets for the keys.
-	pub keys: Rc<Vec<Entry<K>>>,	// track upper and lower bounds, because trickery is hard.
+	pub keys: Vec<Entry<K>>,	// track upper and lower bounds, because trickery is hard.
 	/// A lower layer containing ranges of values.
 	pub vals: L,
 }
@@ -51,15 +53,15 @@ impl<K: HashOrdered, L> HashedLayer<K, L> {
 	fn upper(&self, index: usize) -> usize { self.keys[index].get_upper() }
 }
 
-impl<K: Clone+HashOrdered+Default, L: Trie> Trie for HashedLayer<K, L> {
+impl<B, K: Clone+HashOrdered+Default, L: Trie<B>> Trie<B> for HashedLayer<K, L> {
 	type Item = (K, L::Item);
-	type Cursor = HashedCursor<K, L::Cursor>;
-	type MergeBuilder = HashedBuilder<K, L::MergeBuilder>;
-	type TupleBuilder = HashedBuilder<K, L::TupleBuilder>;
+	type Cursor = HashedCursor<B, K, L::Cursor>;
+	type MergeBuilder = HashedBuilder<B, K, L::MergeBuilder>;
+	type TupleBuilder = HashedBuilder<B, K, L::TupleBuilder>;
 
 	fn keys(&self) -> usize { self.keys.len() }
 	fn tuples(&self) -> usize { self.vals.tuples() }
-	fn cursor_from(&self, lower: usize, upper: usize) -> Self::Cursor {
+	fn cursor_from(&self, owned_self: OwningRef<Rc<B>, Self>, lower: usize, upper: usize) -> Self::Cursor {
 
 		if lower < upper {
 
@@ -78,8 +80,8 @@ impl<K: Clone+HashOrdered+Default, L: Trie> Trie for HashedLayer<K, L> {
 				shift: shift,
 				bounds: (lower, upper),
 				pos: pos,
-				keys: self.keys.clone(),
-				child: self.vals.cursor_from(self.keys[pos].get_lower(), self.keys[pos].get_upper())
+				keys: owned_self.clone().map(|x| &x.keys),
+				child: self.vals.cursor_from(owned_self.map(|x| &x.vals), self.keys[pos].get_lower(), self.keys[pos].get_upper())
 			}
 		}
 		else {
@@ -87,8 +89,8 @@ impl<K: Clone+HashOrdered+Default, L: Trie> Trie for HashedLayer<K, L> {
 				shift: 0,
 				bounds: (0, 0),
 				pos: 0,
-				keys: self.keys.clone(),
-				child: self.vals.cursor_from(0, 0),
+				keys: owned_self.clone().map(|x| &x.keys), // &self.keys,
+				child: self.vals.cursor_from(owned_self.map(|x| &x.vals), 0, 0),
 			}
 		}
 	}
@@ -121,15 +123,16 @@ impl<K: HashOrdered> Entry<K> {
 }
 
 /// Assembles a layer of this 
-pub struct HashedBuilder<K: HashOrdered, L> {
+pub struct HashedBuilder<B, K: HashOrdered, L> {
 	temp: Vec<Entry<K>>,		// staging for building; densely packed here and then re-laid out in self.keys.
 	/// Entries in the hash map.
 	pub keys: Vec<Entry<K>>,	// keys and offs co-located because we expect to find the right answers fast.
 	/// A builder for the layer below.
 	pub vals: L,
+    _b: ::std::marker::PhantomData<B>,
 }
 
-impl<K: HashOrdered+Clone+Default, L> HashedBuilder<K, L> {
+impl<B, K: HashOrdered+Clone+Default, L> HashedBuilder<B, K, L> {
 
 	#[inline(always)]
 	fn _lower(&self, index: usize) -> usize {
@@ -141,7 +144,7 @@ impl<K: HashOrdered+Clone+Default, L> HashedBuilder<K, L> {
 	}
 }
 
-impl<K: HashOrdered+Clone+Default, L: Builder> Builder for HashedBuilder<K, L> {
+impl<B, K: HashOrdered+Clone+Default, L: Builder<B>> Builder<B> for HashedBuilder<B, K, L> {
 	type Trie = HashedLayer<K, L::Trie>;
 
 
@@ -220,19 +223,20 @@ impl<K: HashOrdered+Clone+Default, L: Builder> Builder for HashedBuilder<K, L> {
 		}
 
 		HashedLayer {
-			keys: Rc::new(self.keys),
+			keys: self.keys,
 			vals: vals,
 		}
 	}
 }
 
-impl<K: HashOrdered+Clone+Default, L: MergeBuilder> MergeBuilder for HashedBuilder<K, L> {
+impl<B, K: HashOrdered+Clone+Default, L: MergeBuilder<B>> MergeBuilder<B> for HashedBuilder<B, K, L> {
 
 	fn with_capacity(other1: &Self::Trie, other2: &Self::Trie) -> Self {
 		HashedBuilder {
 			temp: Vec::new(),
 			keys: Vec::with_capacity(other1.keys() + other2.keys()),
 			vals: L::with_capacity(&other1.vals, &other2.vals),
+            _b: ::std::marker::PhantomData,
 		}
 	}
 	/// Copies fully formed ranges (note plural) of keys from another trie.
@@ -313,15 +317,16 @@ impl<K: HashOrdered+Clone+Default, L: MergeBuilder> MergeBuilder for HashedBuild
 }
 
 
-impl<K: HashOrdered+Clone+Default, L: TupleBuilder> TupleBuilder for HashedBuilder<K, L> {
+impl<B, K: HashOrdered+Clone+Default, L: TupleBuilder<B>> TupleBuilder<B> for HashedBuilder<B, K, L> {
 
 	type Item = (K, L::Item);
-	fn new() -> Self { HashedBuilder { temp: Vec::new(), keys: Vec::new(), vals: L::new() } }
+	fn new() -> Self { HashedBuilder { temp: Vec::new(), keys: Vec::new(), vals: L::new(), _b: ::std::marker::PhantomData } }
 	fn with_capacity(cap: usize) -> Self { 
 		HashedBuilder { 
 			temp: Vec::with_capacity(cap), 
 			keys: Vec::with_capacity(cap), 
-			vals: L::with_capacity(cap) 
+			vals: L::with_capacity(cap),
+            _b: ::std::marker::PhantomData,
 		} 
 	}
 	#[inline(always)]
@@ -342,7 +347,7 @@ impl<K: HashOrdered+Clone+Default, L: TupleBuilder> TupleBuilder for HashedBuild
 	}
 }
 
-impl<K: HashOrdered+Clone+Default, L: MergeBuilder> HashedBuilder<K, L> {
+impl<B, K: HashOrdered+Clone+Default, L: MergeBuilder<B>> HashedBuilder<B, K, L> {
 	/// Moves other stuff into self.temp. Returns number of element consumed.
 	fn push_while_less(&mut self, other: &HashedLayer<K, L::Trie>, lower: usize, upper: usize, vs: &K) -> usize {
 
@@ -398,17 +403,17 @@ impl<K: HashOrdered+Clone+Default, L: MergeBuilder> HashedBuilder<K, L> {
 
 /// A cursor with a child cursor that is updated as we move.
 #[derive(Debug)]
-pub struct HashedCursor<K: HashOrdered, L: Cursor> {
+pub struct HashedCursor<B, K: HashOrdered, L: Cursor> {
 	shift: usize,			// amount by which to shift hashes.
 	bounds: (usize, usize),	// bounds of slice of self.keys.
 	pos: usize,				// <-- current cursor position.
 
-	keys: Rc<Vec<Entry<K>>>,
+	keys: OwningRef<Rc<B>, Vec<Entry<K>>>,
 	/// A cursor for the layer below this one.
 	pub child: L,
 }
 
-impl<K: HashOrdered, L: Cursor> Cursor for HashedCursor<K, L> {
+impl<B, K: HashOrdered, L: Cursor> Cursor for HashedCursor<B, K, L> {
 	type Key = K;
 	fn key(&self) -> &Self::Key { &self.keys[self.pos].key }
 	fn step(&mut self) {

--- a/src/trace/layers/hashed.rs
+++ b/src/trace/layers/hashed.rs
@@ -129,7 +129,7 @@ pub struct HashedBuilder<B, K: HashOrdered, L> {
 	pub keys: Vec<Entry<K>>,	// keys and offs co-located because we expect to find the right answers fast.
 	/// A builder for the layer below.
 	pub vals: L,
-    _b: ::std::marker::PhantomData<B>,
+	_b: ::std::marker::PhantomData<B>,
 }
 
 impl<B, K: HashOrdered+Clone+Default, L> HashedBuilder<B, K, L> {
@@ -236,7 +236,7 @@ impl<B, K: HashOrdered+Clone+Default, L: MergeBuilder<B>> MergeBuilder<B> for Ha
 			temp: Vec::new(),
 			keys: Vec::with_capacity(other1.keys() + other2.keys()),
 			vals: L::with_capacity(&other1.vals, &other2.vals),
-            _b: ::std::marker::PhantomData,
+			_b: ::std::marker::PhantomData,
 		}
 	}
 	/// Copies fully formed ranges (note plural) of keys from another trie.
@@ -326,7 +326,7 @@ impl<B, K: HashOrdered+Clone+Default, L: TupleBuilder<B>> TupleBuilder<B> for Ha
 			temp: Vec::with_capacity(cap), 
 			keys: Vec::with_capacity(cap), 
 			vals: L::with_capacity(cap),
-            _b: ::std::marker::PhantomData,
+			_b: ::std::marker::PhantomData,
 		} 
 	}
 	#[inline(always)]

--- a/src/trace/layers/ordered.rs
+++ b/src/trace/layers/ordered.rs
@@ -66,7 +66,7 @@ pub struct OrderedBuilder<B, K: Ord, L> {
 	pub offs: Vec<usize>,
 	/// The next layer down
 	pub vals: L,
-    _b: ::std::marker::PhantomData<B>,
+	_b: ::std::marker::PhantomData<B>,
 }
 
 impl<B, K: Ord+Clone, L: Builder<B>> Builder<B> for OrderedBuilder<B, K, L> {
@@ -95,7 +95,7 @@ impl<B, K: Ord+Clone, L: MergeBuilder<B>> MergeBuilder<B> for OrderedBuilder<B, 
 			keys: Vec::with_capacity(other1.keys() + other2.keys()),
 			offs: offs,
 			vals: L::with_capacity(&other1.vals, &other2.vals),
-            _b: ::std::marker::PhantomData,
+			_b: ::std::marker::PhantomData,
 		}
 	}
 	fn copy_range(&mut self, other: &Self::Trie, lower: usize, upper: usize) {
@@ -172,7 +172,7 @@ impl<B, K: Ord+Clone, L: TupleBuilder<B>> TupleBuilder<B> for OrderedBuilder<B, 
 			keys: Vec::with_capacity(cap), 
 			offs: offs, 
 			vals: L::with_capacity(cap),
-            _b: ::std::marker::PhantomData,
+			_b: ::std::marker::PhantomData,
 		}
 	}
 	#[inline(always)]

--- a/src/trace/layers/ordered.rs
+++ b/src/trace/layers/ordered.rs
@@ -2,6 +2,7 @@
 
 use std::rc::Rc;
 use super::{Trie, Cursor, Builder, MergeBuilder, TupleBuilder};
+use owning_ref::OwningRef;
 
 /// A level of the trie, with keys and offsets into a lower layer.
 ///
@@ -9,25 +10,25 @@ use super::{Trie, Cursor, Builder, MergeBuilder, TupleBuilder};
 #[derive(Debug)]
 pub struct OrderedLayer<K: Ord, L> {
 	/// The keys of the layer.
-	pub keys: Rc<Vec<K>>,
+	pub keys: Vec<K>,
 	/// The offsets associate with each key.
 	///
 	/// The bounds for `keys[i]` are `(offs[i], offs[i+1]`). The offset array is guaranteed to be one
 	/// element longer than the keys array, ensuring that these accesses do not panic.
-	pub offs: Rc<Vec<usize>>,
+	pub offs: Vec<usize>,
 	/// The ranges of values associated with the keys.
 	pub vals: L,
 }
 
-impl<K: Ord+Clone, L: Trie> Trie for OrderedLayer<K, L> {
+impl<B, K: Ord+Clone, L: Trie<B>> Trie<B> for OrderedLayer<K, L> {
 	type Item = (K, L::Item);
-	type Cursor = OrderedCursor<K, L::Cursor>;
-	type MergeBuilder = OrderedBuilder<K, L::MergeBuilder>;
-	type TupleBuilder = OrderedBuilder<K, L::TupleBuilder>;
+	type Cursor = OrderedCursor<B, K, L::Cursor>;
+	type MergeBuilder = OrderedBuilder<B, K, L::MergeBuilder>;
+	type TupleBuilder = OrderedBuilder<B, K, L::TupleBuilder>;
 
 	fn keys(&self) -> usize { self.keys.len() }
 	fn tuples(&self) -> usize { self.vals.tuples() }
-	fn cursor_from(&self, lower: usize, upper: usize) -> Self::Cursor {
+	fn cursor_from(&self, owned_self: OwningRef<Rc<B>, Self>, lower: usize, upper: usize) -> Self::Cursor {
 		// let child_lower = if lower == 0 { 0 } else { self.offs[lower-1] };
 		// let child_upper = self.offs[lower];
 
@@ -38,19 +39,19 @@ impl<K: Ord+Clone, L: Trie> Trie for OrderedLayer<K, L> {
 			let child_lower = self.offs[lower];
 			let child_upper = self.offs[lower + 1];
 			OrderedCursor {
-				keys: self.keys.clone(),
-				offs: self.offs.clone(),
+				keys: owned_self.clone().map(|x| &x.keys),
+				offs: owned_self.clone().map(|x| &x.offs),
 				bounds: (lower, upper),
-				child: self.vals.cursor_from(child_lower, child_upper),
+				child: self.vals.cursor_from(owned_self.map(|x| &x.vals), child_lower, child_upper),
 				pos: lower,
 			}		
 		}
 		else {
 			OrderedCursor {
-				keys: self.keys.clone(),
-				offs: self.offs.clone(),
+				keys: owned_self.clone().map(|x| &x.keys),
+				offs: owned_self.clone().map(|x| &x.offs),
 				bounds: (0, 0),
-				child: self.vals.cursor_from(0, 0),
+				child: self.vals.cursor_from(owned_self.map(|x| &x.vals), 0, 0),
 				pos: 0,
 			}	
 		}
@@ -58,16 +59,17 @@ impl<K: Ord+Clone, L: Trie> Trie for OrderedLayer<K, L> {
 }
 
 /// Assembles a layer of this 
-pub struct OrderedBuilder<K: Ord, L> {
+pub struct OrderedBuilder<B, K: Ord, L> {
 	/// Keys
 	pub keys: Vec<K>,
 	/// Offsets
 	pub offs: Vec<usize>,
 	/// The next layer down
 	pub vals: L,
+    _b: ::std::marker::PhantomData<B>,
 }
 
-impl<K: Ord+Clone, L: Builder> Builder for OrderedBuilder<K, L> {
+impl<B, K: Ord+Clone, L: Builder<B>> Builder<B> for OrderedBuilder<B, K, L> {
 	type Trie = OrderedLayer<K, L::Trie>; 
 	fn boundary(&mut self) -> usize { 
 		self.offs[self.keys.len()] = self.vals.boundary();
@@ -78,14 +80,14 @@ impl<K: Ord+Clone, L: Builder> Builder for OrderedBuilder<K, L> {
 			self.offs[self.keys.len()] = self.vals.boundary();
 		}
 		OrderedLayer {
-			keys: Rc::new(self.keys),
-			offs: Rc::new(self.offs),
+			keys: self.keys,
+			offs: self.offs,
 			vals: self.vals.done(),
 		}
 	}
 }
 
-impl<K: Ord+Clone, L: MergeBuilder> MergeBuilder for OrderedBuilder<K, L> {
+impl<B, K: Ord+Clone, L: MergeBuilder<B>> MergeBuilder<B> for OrderedBuilder<B, K, L> {
 	fn with_capacity(other1: &Self::Trie, other2: &Self::Trie) -> Self {
 		let mut offs = Vec::with_capacity(other1.keys() + other2.keys() + 1);
 		offs.push(0);
@@ -93,6 +95,7 @@ impl<K: Ord+Clone, L: MergeBuilder> MergeBuilder for OrderedBuilder<K, L> {
 			keys: Vec::with_capacity(other1.keys() + other2.keys()),
 			offs: offs,
 			vals: L::with_capacity(&other1.vals, &other2.vals),
+            _b: ::std::marker::PhantomData,
 		}
 	}
 	fn copy_range(&mut self, other: &Self::Trie, lower: usize, upper: usize) {
@@ -158,10 +161,10 @@ impl<K: Ord+Clone, L: MergeBuilder> MergeBuilder for OrderedBuilder<K, L> {
 	}
 }
 
-impl<K: Ord+Clone, L: TupleBuilder> TupleBuilder for OrderedBuilder<K, L> {
+impl<B, K: Ord+Clone, L: TupleBuilder<B>> TupleBuilder<B> for OrderedBuilder<B, K, L> {
 
 	type Item = (K, L::Item);
-	fn new() -> Self { OrderedBuilder { keys: Vec::new(), offs: vec![0], vals: L::new() } }
+	fn new() -> Self { OrderedBuilder { keys: Vec::new(), offs: vec![0], vals: L::new(), _b: ::std::marker::PhantomData } }
 	fn with_capacity(cap: usize) -> Self { 
 		let mut offs = Vec::with_capacity(cap + 1);
 		offs.push(0);
@@ -169,6 +172,7 @@ impl<K: Ord+Clone, L: TupleBuilder> TupleBuilder for OrderedBuilder<K, L> {
 			keys: Vec::with_capacity(cap), 
 			offs: offs, 
 			vals: L::with_capacity(cap),
+            _b: ::std::marker::PhantomData,
 		}
 	}
 	#[inline(always)]
@@ -188,16 +192,16 @@ impl<K: Ord+Clone, L: TupleBuilder> TupleBuilder for OrderedBuilder<K, L> {
 
 /// A cursor with a child cursor that is updated as we move.
 #[derive(Debug)]
-pub struct OrderedCursor<K: Ord, L: Cursor> {
-	keys: Rc<Vec<K>>,
-	offs: Rc<Vec<usize>>,
+pub struct OrderedCursor<B, K: Ord, L: Cursor> {
+	keys: OwningRef<Rc<B>, Vec<K>>,
+	offs: OwningRef<Rc<B>, Vec<usize>>,
 	pos: usize,
 	bounds: (usize, usize),
 	/// The cursor for the trie layer below this one.
 	pub child: L,
 }
 
-impl<K: Ord, L: Cursor> Cursor for OrderedCursor<K, L> {
+impl<B, K: Ord, L: Cursor> Cursor for OrderedCursor<B, K, L> {
 	type Key = K;
 	fn key(&self) -> &Self::Key { &self.keys[self.pos] }
 	fn step(&mut self) {

--- a/src/trace/layers/ordered_leaf.rs
+++ b/src/trace/layers/ordered_leaf.rs
@@ -21,7 +21,7 @@ impl<B, K: Ord+Clone, R: Diff+Clone> Trie<B> for OrderedLeaf<K, R> {
     type MergeBuilder = OrderedLeafBuilder<K, R>;
     type TupleBuilder = OrderedLeafBuilder<K, R>;
     fn keys(&self) -> usize { self.vals.len() }
-    fn tuples(&self) -> usize { self.vals.len() } //self.keys() } FIXME correct?
+    fn tuples(&self) -> usize { <OrderedLeaf<K, R> as Trie<B>>::keys(&self) }
     fn cursor_from(&self, owned_self: OwningRef<Rc<B>, Self>, lower: usize, upper: usize) -> Self::Cursor { 
         // println!("unordered: {} .. {}", lower, upper);
         OrderedLeafCursor {
@@ -47,7 +47,7 @@ impl<B, K: Ord+Clone, R: Diff+Clone> Builder<B> for OrderedLeafBuilder<K, R> {
 impl<B, K: Ord+Clone, R: Diff+Clone> MergeBuilder<B> for OrderedLeafBuilder<K, R> {
     fn with_capacity(other1: &Self::Trie, other2: &Self::Trie) -> Self {
         OrderedLeafBuilder {
-            vals: Vec::with_capacity(other1.vals.len() + other2.vals.len()), //other1.keys() + other2.keys()), FIXME correct?
+            vals: Vec::with_capacity(<OrderedLeaf<K, R> as Trie<B>>::keys(other1) + <OrderedLeaf<K, R> as Trie<B>>::keys(other2)),
         }
     }
     fn copy_range(&mut self, other: &Self::Trie, lower: usize, upper: usize) {

--- a/src/trace/layers/ordered_leaf.rs
+++ b/src/trace/layers/ordered_leaf.rs
@@ -2,6 +2,8 @@
 
 use std::rc::Rc;
 
+use owning_ref::OwningRef;
+
 use difference::Diff;
 
 use super::{Trie, Cursor, Builder, MergeBuilder, TupleBuilder};
@@ -10,20 +12,20 @@ use super::{Trie, Cursor, Builder, MergeBuilder, TupleBuilder};
 #[derive(Debug)]
 pub struct OrderedLeaf<K, R> {
     /// Unordered values.
-    pub vals: Rc<Vec<(K, R)>>,
+    pub vals: Vec<(K, R)>,
 }
 
-impl<K: Ord+Clone, R: Diff+Clone> Trie for OrderedLeaf<K, R> {
+impl<B, K: Ord+Clone, R: Diff+Clone> Trie<B> for OrderedLeaf<K, R> {
     type Item = (K, R);
-    type Cursor = OrderedLeafCursor<K, R>;
+    type Cursor = OrderedLeafCursor<B, K, R>;
     type MergeBuilder = OrderedLeafBuilder<K, R>;
     type TupleBuilder = OrderedLeafBuilder<K, R>;
     fn keys(&self) -> usize { self.vals.len() }
-    fn tuples(&self) -> usize { self.keys() }
-    fn cursor_from(&self, lower: usize, upper: usize) -> Self::Cursor { 
+    fn tuples(&self) -> usize { self.vals.len() } //self.keys() } FIXME correct?
+    fn cursor_from(&self, owned_self: OwningRef<Rc<B>, Self>, lower: usize, upper: usize) -> Self::Cursor { 
         // println!("unordered: {} .. {}", lower, upper);
         OrderedLeafCursor {
-            vals: self.vals.clone(),
+            vals: owned_self.map(|x| &x.vals),
             bounds: (lower, upper),
             pos: lower,
         }
@@ -36,16 +38,16 @@ pub struct OrderedLeafBuilder<K, R> {
     pub vals: Vec<(K, R)>,
 }
 
-impl<K: Ord+Clone, R: Diff+Clone> Builder for OrderedLeafBuilder<K, R> {
+impl<B, K: Ord+Clone, R: Diff+Clone> Builder<B> for OrderedLeafBuilder<K, R> {
     type Trie = OrderedLeaf<K, R>; 
     fn boundary(&mut self) -> usize { self.vals.len() } 
-    fn done(self) -> Self::Trie { OrderedLeaf { vals: Rc::new(self.vals) } }
+    fn done(self) -> Self::Trie { OrderedLeaf { vals: self.vals } }
 }
 
-impl<K: Ord+Clone, R: Diff+Clone> MergeBuilder for OrderedLeafBuilder<K, R> {
+impl<B, K: Ord+Clone, R: Diff+Clone> MergeBuilder<B> for OrderedLeafBuilder<K, R> {
     fn with_capacity(other1: &Self::Trie, other2: &Self::Trie) -> Self {
         OrderedLeafBuilder {
-            vals: Vec::with_capacity(other1.keys() + other2.keys()),
+            vals: Vec::with_capacity(other1.vals.len() + other2.vals.len()), //other1.keys() + other2.keys()), FIXME correct?
         }
     }
     fn copy_range(&mut self, other: &Self::Trie, lower: usize, upper: usize) {
@@ -68,7 +70,7 @@ impl<K: Ord+Clone, R: Diff+Clone> MergeBuilder for OrderedLeafBuilder<K, R> {
                 ::std::cmp::Ordering::Less => {
                     // determine how far we can advance lower1 until we reach/pass lower2
                     let step = 1 + advance(&trie1.vals[(1+lower1)..upper1], |x| x < &trie2.vals[lower2]);
-                    self.copy_range(trie1, lower1, lower1 + step);
+                    <OrderedLeafBuilder<K, R> as MergeBuilder<B>>::copy_range(self, trie1, lower1, lower1 + step);
                     lower1 += step;
                 }
                 ::std::cmp::Ordering::Equal => {
@@ -84,20 +86,20 @@ impl<K: Ord+Clone, R: Diff+Clone> MergeBuilder for OrderedLeafBuilder<K, R> {
                 ::std::cmp::Ordering::Greater => {
                     // determine how far we can advance lower2 until we reach/pass lower1
                     let step = 1 + advance(&trie2.vals[(1+lower2)..upper2], |x| x < &trie1.vals[lower1]);
-                    self.copy_range(trie2, lower2, lower2 + step);
+                    <OrderedLeafBuilder<K, R> as MergeBuilder<B>>::copy_range(self, trie2, lower2, lower2 + step);
                     lower2 += step;
                 }
             }
         }
 
-        if lower1 < upper1 { self.copy_range(trie1, lower1, upper1); }
-        if lower2 < upper2 { self.copy_range(trie2, lower2, upper2); }
+        if lower1 < upper1 { <OrderedLeafBuilder<K, R> as MergeBuilder<B>>::copy_range(self, trie1, lower1, upper1); }
+        if lower2 < upper2 { <OrderedLeafBuilder<K, R> as MergeBuilder<B>>::copy_range(self, trie2, lower2, upper2); }
 
         self.vals.len()
     }
 }
 
-impl<K: Ord+Clone, R: Diff+Clone> TupleBuilder for OrderedLeafBuilder<K, R> {
+impl<B, K: Ord+Clone, R: Diff+Clone> TupleBuilder<B> for OrderedLeafBuilder<K, R> {
     type Item = (K, R);
     fn new() -> Self { OrderedLeafBuilder { vals: Vec::new() } }
     fn with_capacity(cap: usize) -> Self { OrderedLeafBuilder { vals: Vec::with_capacity(cap) } }
@@ -108,13 +110,13 @@ impl<K: Ord+Clone, R: Diff+Clone> TupleBuilder for OrderedLeafBuilder<K, R> {
 ///
 /// This cursor does not support `seek`, though I'm not certain how to expose this.
 #[derive(Debug)]
-pub struct OrderedLeafCursor<K, R> {
-    vals: Rc<Vec<(K, R)>>,
+pub struct OrderedLeafCursor<B, K, R> {
+    vals: OwningRef<Rc<B>, Vec<(K, R)>>,
     pos: usize,
     bounds: (usize, usize),
 }
 
-impl<K: Clone, R: Clone> Cursor for OrderedLeafCursor<K, R> {
+impl<B, K: Clone, R: Clone> Cursor for OrderedLeafCursor<B, K, R> {
     type Key = (K, R);
     fn key(&self) -> &Self::Key { &self.vals[self.pos] }
     fn step(&mut self) {

--- a/src/trace/layers/unordered.rs
+++ b/src/trace/layers/unordered.rs
@@ -19,7 +19,7 @@ impl<B, K: Clone> Trie<B> for UnorderedLayer<K> {
 	type MergeBuilder = UnorderedBuilder<K>;
 	type TupleBuilder = UnorderedBuilder<K>;
 	fn keys(&self) -> usize { self.vals.len() }
-	fn tuples(&self) -> usize { self.vals.len() } // self.keys() } // FIXME correct?
+	fn tuples(&self) -> usize { <UnorderedLayer<K> as Trie<B>>::keys(&self) }
 	fn cursor_from(&self, owned_self: OwningRef<Rc<B>, Self>, lower: usize, upper: usize) -> Self::Cursor {	
 		// println!("unordered: {} .. {}", lower, upper);
 		UnorderedCursor {
@@ -45,7 +45,7 @@ impl<B, K: Clone> Builder<B> for UnorderedBuilder<K> {
 impl<B, K: Clone> MergeBuilder<B> for UnorderedBuilder<K> {
 	fn with_capacity(other1: &Self::Trie, other2: &Self::Trie) -> Self {
 		UnorderedBuilder {
-			vals: Vec::with_capacity(other1.vals.len() + other2.vals.len()), // FIXME correct?
+			vals: Vec::with_capacity(<UnorderedLayer<K> as Trie<B>>::keys(other1) + <UnorderedLayer<K> as Trie<B>>::keys(other2)),
 		}
 	}
 	fn copy_range(&mut self, other: &Self::Trie, lower: usize, upper: usize) {

--- a/src/trace/layers/unordered.rs
+++ b/src/trace/layers/unordered.rs
@@ -52,8 +52,8 @@ impl<B, K: Clone> MergeBuilder<B> for UnorderedBuilder<K> {
 		self.vals.extend_from_slice(&other.vals[lower .. upper]);
 	}
 	fn push_merge(&mut self, other1: (&Self::Trie, usize, usize), other2: (&Self::Trie, usize, usize)) -> usize {
-        <UnorderedBuilder<K> as MergeBuilder<B>>::copy_range(self, &other1.0, other1.1, other1.2);
-        <UnorderedBuilder<K> as MergeBuilder<B>>::copy_range(self, &other2.0, other2.1, other2.2);
+		<UnorderedBuilder<K> as MergeBuilder<B>>::copy_range(self, &other1.0, other1.1, other1.2);
+		<UnorderedBuilder<K> as MergeBuilder<B>>::copy_range(self, &other2.0, other2.1, other2.2);
 		self.vals.len()
 	}
 }

--- a/src/trace/layers/unordered.rs
+++ b/src/trace/layers/unordered.rs
@@ -1,26 +1,29 @@
 //! Implementation using ordered keys and exponential search.
 
 use std::rc::Rc;
+
+use owning_ref::OwningRef;
+
 use super::{Trie, Cursor, Builder, MergeBuilder, TupleBuilder};
 
 /// A layer of unordered values. 
 #[derive(Debug)]
 pub struct UnorderedLayer<K> {
 	/// Unordered values.
-	pub vals: Rc<Vec<K>>,
+	pub vals: Vec<K>,
 }
 
-impl<K: Clone> Trie for UnorderedLayer<K> {
+impl<B, K: Clone> Trie<B> for UnorderedLayer<K> {
 	type Item = K;
-	type Cursor = UnorderedCursor<K>;
+	type Cursor = UnorderedCursor<B, K>;
 	type MergeBuilder = UnorderedBuilder<K>;
 	type TupleBuilder = UnorderedBuilder<K>;
 	fn keys(&self) -> usize { self.vals.len() }
-	fn tuples(&self) -> usize { self.keys() }
-	fn cursor_from(&self, lower: usize, upper: usize) -> Self::Cursor {	
+	fn tuples(&self) -> usize { self.vals.len() } // self.keys() } // FIXME correct?
+	fn cursor_from(&self, owned_self: OwningRef<Rc<B>, Self>, lower: usize, upper: usize) -> Self::Cursor {	
 		// println!("unordered: {} .. {}", lower, upper);
 		UnorderedCursor {
-			vals: self.vals.clone(),
+			vals: owned_self.map(|x| &x.vals),
 			bounds: (lower, upper),
 			pos: lower,
 		}
@@ -33,29 +36,29 @@ pub struct UnorderedBuilder<K> {
 	pub vals: Vec<K>,
 }
 
-impl<K: Clone> Builder for UnorderedBuilder<K> {
+impl<B, K: Clone> Builder<B> for UnorderedBuilder<K> {
 	type Trie = UnorderedLayer<K>; 
 	fn boundary(&mut self) -> usize { self.vals.len() } 
-	fn done(self) -> Self::Trie { UnorderedLayer { vals: Rc::new(self.vals) } }
+	fn done(self) -> Self::Trie { UnorderedLayer { vals: self.vals } }
 }
 
-impl<K: Clone> MergeBuilder for UnorderedBuilder<K> {
+impl<B, K: Clone> MergeBuilder<B> for UnorderedBuilder<K> {
 	fn with_capacity(other1: &Self::Trie, other2: &Self::Trie) -> Self {
 		UnorderedBuilder {
-			vals: Vec::with_capacity(other1.keys() + other2.keys()),
+			vals: Vec::with_capacity(other1.vals.len() + other2.vals.len()), // FIXME correct?
 		}
 	}
 	fn copy_range(&mut self, other: &Self::Trie, lower: usize, upper: usize) {
 		self.vals.extend_from_slice(&other.vals[lower .. upper]);
 	}
 	fn push_merge(&mut self, other1: (&Self::Trie, usize, usize), other2: (&Self::Trie, usize, usize)) -> usize {
-		self.copy_range(&other1.0, other1.1, other1.2);
-		self.copy_range(&other2.0, other2.1, other2.2);
+        <UnorderedBuilder<K> as MergeBuilder<B>>::copy_range(self, &other1.0, other1.1, other1.2);
+        <UnorderedBuilder<K> as MergeBuilder<B>>::copy_range(self, &other2.0, other2.1, other2.2);
 		self.vals.len()
 	}
 }
 
-impl<K: Clone> TupleBuilder for UnorderedBuilder<K> {
+impl<B, K: Clone> TupleBuilder<B> for UnorderedBuilder<K> {
 	type Item = K;
 	fn new() -> Self { UnorderedBuilder { vals: Vec::new() } }
 	fn with_capacity(cap: usize) -> Self { UnorderedBuilder { vals: Vec::with_capacity(cap) } }
@@ -66,13 +69,13 @@ impl<K: Clone> TupleBuilder for UnorderedBuilder<K> {
 ///
 /// This cursor does not support `seek`, though I'm not certain how to expose this.
 #[derive(Debug)]
-pub struct UnorderedCursor<K> {
-	vals: Rc<Vec<K>>,
+pub struct UnorderedCursor<B, K> {
+	vals: OwningRef<Rc<B>, Vec<K>>,
 	pos: usize,
 	bounds: (usize, usize),
 }
 
-impl<K: Clone> Cursor for UnorderedCursor<K> {
+impl<B, K: Clone> Cursor for UnorderedCursor<B, K> {
 	type Key = K;
 	fn key(&self) -> &Self::Key { &self.vals[self.pos] }
 	fn step(&mut self) {

--- a/src/trace/layers/weighted.rs
+++ b/src/trace/layers/weighted.rs
@@ -77,7 +77,7 @@ impl<B, K: Ord+Clone> MergeBuilder<B> for WeightedBuilder<K> {
 				::std::cmp::Ordering::Less => {
 					// determine how far we can advance lower1 until we reach/pass lower2
 					let step = 1 + advance(&trie1.keys[(1+lower1)..upper1], |x| x < &trie2.keys[lower2]);
-                    <WeightedBuilder<K> as MergeBuilder<B>>::copy_range(self, trie1, lower1, lower1 + step);
+					<WeightedBuilder<K> as MergeBuilder<B>>::copy_range(self, trie1, lower1, lower1 + step);
 					lower1 += step;
 				}
 				::std::cmp::Ordering::Equal => {
@@ -93,7 +93,7 @@ impl<B, K: Ord+Clone> MergeBuilder<B> for WeightedBuilder<K> {
 				::std::cmp::Ordering::Greater => {
 					// determine how far we can advance lower2 until we reach/pass lower1
 					let step = 1 + advance(&trie2.keys[(1+lower2)..upper2], |x| x < &trie1.keys[lower1]);
-                    <WeightedBuilder<K> as MergeBuilder<B>>::copy_range(self, trie2, lower2, lower2 + step);
+					<WeightedBuilder<K> as MergeBuilder<B>>::copy_range(self, trie2, lower2, lower2 + step);
 					lower2 += step;
 				}
 			}

--- a/src/trace/layers/weighted.rs
+++ b/src/trace/layers/weighted.rs
@@ -19,7 +19,7 @@ impl<B, K: Ord+Clone> Trie<B> for WeightedLayer<K> {
 	type MergeBuilder = WeightedBuilder<K>;
 	type TupleBuilder = WeightedBuilder<K>;
 	fn keys(&self) -> usize { self.keys.len() }
-	fn tuples(&self) -> usize { self.keys.len() } //self.keys() } FIXME correct?
+	fn tuples(&self) -> usize { <WeightedLayer<K> as Trie<B>>::keys(&self) }
 	fn cursor_from(&self, owned_self: OwningRef<Rc<B>, Self>, lower: usize, upper: usize) -> Self::Cursor {	
 		WeightedCursor {
 			keys: owned_self.clone().map(|x| &x.keys),
@@ -57,8 +57,8 @@ impl<B, K: Ord+Clone> MergeBuilder<B> for WeightedBuilder<K> {
 	fn with_capacity(other1: &Self::Trie, other2: &Self::Trie) -> Self {
 		WeightedBuilder {
 			is_new: false,
-			keys: Vec::with_capacity(other1.keys.len() + other2.keys.len()), // FIXME correct?
-			wgts: Vec::with_capacity(other1.keys.len() + other2.keys.len()), // FIXME correct?
+			keys: Vec::with_capacity(<WeightedLayer<K> as Trie<B>>::keys(other1) + <WeightedLayer<K> as Trie<B>>::keys(other2)),
+			wgts: Vec::with_capacity(<WeightedLayer<K> as Trie<B>>::keys(other1) + <WeightedLayer<K> as Trie<B>>::keys(other2)),
 		}
 	}
 	fn copy_range(&mut self, other: &Self::Trie, lower: usize, upper: usize) {

--- a/tests/trace.rs
+++ b/tests/trace.rs
@@ -1,14 +1,19 @@
 extern crate timely;
 extern crate differential_dataflow;
+
+use std::rc::Rc;
+
 use differential_dataflow::trace::implementations::ord::OrdValSpine;
 use differential_dataflow::trace::{Trace, TraceReader, Batch, Batcher};
 use differential_dataflow::trace::cursor::CursorDebug;
-// use differential_dataflow::operators::ValueHistory2;
 use differential_dataflow::hashable::UnsignedWrapper;
+
+use differential_dataflow::trace::implementations::ord::OrdValBatch;
+use differential_dataflow::trace::implementations::spine::Spine;
 
 type IntegerTrace = OrdValSpine<UnsignedWrapper<u64>, u64, usize, i64>;
 
-fn get_trace() -> differential_dataflow::trace::implementations::spine::Spine<differential_dataflow::hashable::UnsignedWrapper<u64>, u64, usize, i64, differential_dataflow::trace::implementations::ord::OrdValBatch<differential_dataflow::hashable::UnsignedWrapper<u64>, u64, usize, i64>> {
+fn get_trace() -> Spine<UnsignedWrapper<u64>, u64, usize, i64, Rc<OrdValBatch<UnsignedWrapper<u64>, u64, usize, i64>>> {
     let mut trace = IntegerTrace::new();
     {
         let mut batcher = <<


### PR DESCRIPTION
Fixes #61.

This removes `Rc`s between Batch layers so that a Batch can be `exhume`d correctly (with Abomonation). Cursors for the layers hold an owning reference to the enclosing full Batch using `OwningRef<Rc<Batch>, _>`.