### PR TITLE
Address name clash introduced by nightly

### DIFF
--- a/src/lattice.rs
+++ b/src/lattice.rs
@@ -16,10 +16,10 @@ pub trait Lattice : PartialOrder {
     /// ```
     /// use differential_dataflow::lattice::Lattice;
     ///
-    /// let min = <usize as Lattice>::min();
+    /// let min = <usize as Lattice>::minimum();
     /// assert_eq!(min, usize::min_value());
     /// ```
-    fn min() -> Self;
+    fn minimum() -> Self;
 
     /// The largest element of the type.
     ///
@@ -28,10 +28,10 @@ pub trait Lattice : PartialOrder {
     /// ```
     /// use differential_dataflow::lattice::Lattice;
     ///
-    /// let max = <usize as Lattice>::max();
+    /// let max = <usize as Lattice>::maximum();
     /// assert_eq!(max, usize::max_value());
     /// ```
-    fn max() -> Self;
+    fn maximum() -> Self;
 
     /// The smallest element greater than or equal to both arguments.
     ///
@@ -83,7 +83,7 @@ pub trait Lattice : PartialOrder {
     /// the sense that any other element with the same property (compares identically to times
     /// greater or equal to `frontier`) must be less or equal to the result.
     ///
-    /// When provided an empty frontier, the result is `<Self as Lattice>::max()`. It should
+    /// When provided an empty frontier, the result is `<Self as Lattice>::maximum()`. It should
     /// perhaps be distinguished by an `Option<Self>` type, but the `None` case only happens
     /// when `frontier` is empty, which the caller can see for themselves if they want to be
     /// clever.
@@ -126,7 +126,7 @@ pub trait Lattice : PartialOrder {
             result
         }  
         else {
-            Self::max()
+            Self::maximum()
         }
     }
 }
@@ -167,9 +167,9 @@ use timely::progress::nested::product::Product;
 
 impl<T1: Lattice, T2: Lattice> Lattice for Product<T1, T2> {
     #[inline(always)]
-    fn min() -> Self { Product::new(T1::min(), T2::min()) }
+    fn minimum() -> Self { Product::new(T1::minimum(), T2::minimum()) }
     #[inline(always)]
-    fn max() -> Self { Product::new(T1::max(), T2::max()) }
+    fn maximum() -> Self { Product::new(T1::maximum(), T2::maximum()) }
     #[inline(always)]
     fn join(&self, other: &Product<T1, T2>) -> Product<T1, T2> {
         Product {
@@ -203,9 +203,9 @@ use timely::progress::timestamp::RootTimestamp;
 
 impl Lattice for RootTimestamp {
     #[inline(always)]
-    fn min() -> RootTimestamp { RootTimestamp }
+    fn minimum() -> RootTimestamp { RootTimestamp }
     #[inline(always)]
-    fn max() -> RootTimestamp { RootTimestamp }
+    fn maximum() -> RootTimestamp { RootTimestamp }
     #[inline(always)]
     fn join(&self, _: &RootTimestamp) -> RootTimestamp { RootTimestamp }
     #[inline(always)]
@@ -216,9 +216,9 @@ impl TotalOrder for RootTimestamp { }
 
 impl Lattice for usize {
     #[inline(always)]
-    fn min() -> usize { usize::min_value() }
+    fn minimum() -> usize { usize::min_value() }
     #[inline(always)]
-    fn max() -> usize { usize::max_value() }
+    fn maximum() -> usize { usize::max_value() }
     #[inline(always)]
     fn join(&self, other: &usize) -> usize { ::std::cmp::max(*self, *other) }
     #[inline(always)]
@@ -229,9 +229,9 @@ impl TotalOrder for usize { }
 
 impl Lattice for u64 {
     #[inline(always)]
-    fn min() -> u64 { u64::min_value() }
+    fn minimum() -> u64 { u64::min_value() }
     #[inline(always)]
-    fn max() -> u64 { u64::max_value() }
+    fn maximum() -> u64 { u64::max_value() }
     #[inline(always)]
     fn join(&self, other: &u64) -> u64 { ::std::cmp::max(*self, *other) }
     #[inline(always)]
@@ -242,9 +242,9 @@ impl TotalOrder for u64 { }
 
 impl Lattice for u32 {
     #[inline(always)]
-    fn min() -> u32 { u32::min_value() }
+    fn minimum() -> u32 { u32::min_value() }
     #[inline(always)]
-    fn max() -> u32 { u32::max_value() }
+    fn maximum() -> u32 { u32::max_value() }
     #[inline(always)]
     fn join(&self, other: &u32) -> u32 { ::std::cmp::max(*self, *other) }
     #[inline(always)]
@@ -255,9 +255,9 @@ impl TotalOrder for u32 { }
 
 impl Lattice for i32 {
     #[inline(always)]
-    fn min() -> i32 { i32::min_value() }
+    fn minimum() -> i32 { i32::min_value() }
     #[inline(always)]
-    fn max() -> i32 { i32::max_value() }
+    fn maximum() -> i32 { i32::max_value() }
     #[inline(always)]
     fn join(&self, other: &i32) -> i32 { ::std::cmp::max(*self, *other) }
     #[inline(always)]
@@ -268,9 +268,9 @@ impl TotalOrder for i32 { }
 
 impl Lattice for () {
     #[inline(always)]
-    fn min() -> () { () }
+    fn minimum() -> () { () }
     #[inline(always)]
-    fn max() -> () { () }
+    fn maximum() -> () { () }
     #[inline(always)]
     fn join(&self, _other: &()) -> () { () }
     #[inline(always)]

--- a/src/operators/group.rs
+++ b/src/operators/group.rs
@@ -325,10 +325,10 @@ where
         let mut upper_limit = Vec::<G::Timestamp>::new();
 
         // tracks frontiers received from batches, for sanity.
-        let mut upper_received = vec![<G::Timestamp as Lattice>::min()];
+        let mut upper_received = vec![<G::Timestamp as Lattice>::minimum()];
 
         // We separately track the frontiers for what we have sent, and what we have sealed. 
-        let mut lower_issued = vec![<G::Timestamp as Lattice>::min()];
+        let mut lower_issued = vec![<G::Timestamp as Lattice>::minimum()];
 
         let id = self.stream.scope().index();
 
@@ -801,7 +801,7 @@ mod history_replay {
             }
 
             // Determine the meet of times in `batch` and `times`.
-            let mut meet = T::max();
+            let mut meet = T::maximum();
             if self.meets.len() > 0 { meet = meet.meet(&self.meets[0]); }
             if let Some(time) = self.batch_history.meet() { meet = meet.meet(&time); }
 
@@ -842,13 +842,13 @@ mod history_replay {
                   !self.batch_history.is_done() || self.synth_times.len() > 0 || times_slice.len() > 0 {
 
                 // Determine the next time we will process from the available source of times.
-                let mut next_time = T::max();
+                let mut next_time = T::maximum();
                 if let Some(time) = self.input_history.time() { if time.cmp(&next_time) == Ordering::Less { next_time = time.clone(); } }
                 if let Some(time) = self.output_history.time() { if time.cmp(&next_time) == Ordering::Less { next_time = time.clone(); } }
                 if let Some(time) = self.batch_history.time() { if time.cmp(&next_time) == Ordering::Less { next_time = time.clone(); } }
                 if let Some(time) = self.synth_times.first() { if time.cmp(&next_time) == Ordering::Less { next_time = time.clone(); } }
                 if let Some(time) = times_slice.first() { if time.cmp(&next_time) == Ordering::Less { next_time = time.clone(); } }
-                assert!(next_time != T::max());
+                assert!(next_time != T::maximum());
 
                 // advance input and output histories.
                 self.input_history.step_while_time_is(&next_time);
@@ -1028,7 +1028,7 @@ mod history_replay {
                 }
 
                 // Update `meet` to track the meet of each source of times.
-                meet = T::max();
+                meet = T::maximum();
                 if let Some(time) = self.batch_history.meet() { meet = meet.meet(time); }
                 if let Some(time) = self.input_history.meet() { meet = meet.meet(time); }
                 if let Some(time) = self.output_history.meet() { meet = meet.meet(time); }
@@ -1133,7 +1133,7 @@ mod history_replay_prior {
         {
             // The first thing we need to know is which times and values we are worried about.
             // We use `T::min` as the lower bound with which we join everything to avoid changing the times.
-            self.batch_history.reload(key, batch_cursor, &T::min());
+            self.batch_history.reload(key, batch_cursor, &T::minimum());
 
             // Determine a lower frontier of interesting times.
             // I'm not sure what we do with this other than a `debug_assert` and re-scan it to produce `meet`.
@@ -1155,7 +1155,7 @@ mod history_replay_prior {
 
             // All times we encounter will be at least `meet`, and so long as we just join with and compare 
             // against interesting times, it is safe to advance all historical times by `meet`. 
-            let mut meet = self.lower.iter().fold(T::max(), |meet, time| meet.meet(time));
+            let mut meet = self.lower.iter().fold(T::maximum(), |meet, time| meet.meet(time));
 
             // We build "histories" of the input and output, with respect to the times we may encounter in this
             // invocation of `compute`. This means we advance times by joining them with `meet`, which can yield
@@ -1206,7 +1206,7 @@ mod history_replay_prior {
                 while times_slice.len() > 0 || batch_slice.len() > 0 || input_slice.len() > 0 || output_slice.len() > 0 {
 
                     // Determine the next time.
-                    let mut next = T::max();
+                    let mut next = T::maximum();
                     if times_slice.len() > 0 && times_slice[0].cmp(&next) == Ordering::Less { next = times_slice[0].clone(); }
                     if batch_slice.len() > 0 && batch_slice[0].0.cmp(&next) == Ordering::Less { next = batch_slice[0].0.clone(); }
                     if input_slice.len() > 0 && input_slice[0].0.cmp(&next) == Ordering::Less { next = input_slice[0].0.clone(); }
@@ -1253,7 +1253,7 @@ mod history_replay_prior {
             while known_slice.len() > 0 || self.synth_times.len() > 0 {
 
                 // Determine the next time to process.
-                let mut next_time = T::max();
+                let mut next_time = T::maximum();
                 if known_slice.len() > 0 && next_time.cmp(&known_slice[0]) == Ordering::Greater {
                     next_time = known_slice[0].clone();
                 }
@@ -1462,9 +1462,9 @@ mod history_replay_prior {
                 // Update `meet`, and advance and deduplicate times in `self.times_current`.
                 // NOTE: This does not advance input or output collections, which is done when the are accumulated.
                 if meets_slice.len() > 0 || self.synth_times.len() > 0 {
-                    // Start from `T::max()` and take the meet with each synthetic time. Also meet with the first 
+                    // Start from `T::maximum()` and take the meet with each synthetic time. Also meet with the first 
                     // element of `meets_slice` if it exists.
-                    meet = self.synth_times.iter().fold(T::max(), |meet, time| meet.meet(time));
+                    meet = self.synth_times.iter().fold(T::maximum(), |meet, time| meet.meet(time));
                     if meets_slice.len() > 0 { meet = meet.meet(&meets_slice[0]); }
 
                     // Advance the contents of `self.times_current`.

--- a/src/trace/implementations/batcher.rs
+++ b/src/trace/implementations/batcher.rs
@@ -22,7 +22,7 @@ pub struct RadixBatcher<K: HashOrdered, V, T: PartialOrd, R: Diff, B: Batch<K, V
 
 impl<K, V, T, R, B> RadixBatcher<K, V, T, R, B>
 where 
-    K: Ord+HashOrdered, 
+    K: Ord+HashOrdered,
     V: Ord,
     T: Lattice+Ord,
     R: Diff,
@@ -102,7 +102,7 @@ where
             sorted: 0,
             stash: Vec::new(),
             frontier: Antichain::new(),
-            lower: vec![T::min()],
+            lower: vec![T::minimum()],
         } 
     }
 

--- a/src/trace/implementations/batcher_merge.rs
+++ b/src/trace/implementations/batcher_merge.rs
@@ -77,7 +77,7 @@ where
             sorter: MSBRadixSorter::new(),
             sorted: None,
             frontier: Antichain::new(),
-            lower: vec![T::min()],
+            lower: vec![T::minimum()],
         } 
     }
 

--- a/src/trace/implementations/spine.rs
+++ b/src/trace/implementations/spine.rs
@@ -103,8 +103,8 @@ where
 	fn new() -> Self {
 		Spine { 
 			phantom: ::std::marker::PhantomData,
-			advance_frontier: vec![<T as Lattice>::min()],
-			through_frontier: vec![<T as Lattice>::min()],
+			advance_frontier: vec![<T as Lattice>::minimum()],
+			through_frontier: vec![<T as Lattice>::minimum()],
 			merging: Vec::new(),
 			pending: Vec::new(),
 		}


### PR DESCRIPTION
Rust nightly has introduced new methods `Ord::min()` and `Ord::max()`, which in the noble goal of removing papercuts just migrated them to other people. This PR changes `Lattice::min()` and `Lattice::max()` to be `Lattice::minimum()` and `Lattice::maximum()` instead. 

They may change again, if the Rust folks randomly change things again. This is all nightly Rust, but since you can't load/use shared libraries outside of nightly it is important to have a differential dataflow that builds with nightly.