### PR TITLE
arrange_mut implemented for ord

### DIFF
--- a/src/trace/layers/ordered.rs
+++ b/src/trace/layers/ordered.rs
@@ -7,7 +7,7 @@ use owning_ref::OwningRef;
 /// A level of the trie, with keys and offsets into a lower layer.
 ///
 /// In this representation, the values for `keys[i]` are found at `vals[offs[i] .. offs[i+1]]`.
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct OrderedLayer<K: Ord, L> {
 	/// The keys of the layer.
 	pub keys: Vec<K>,

--- a/src/trace/layers/ordered_leaf.rs
+++ b/src/trace/layers/ordered_leaf.rs
@@ -9,7 +9,7 @@ use difference::Diff;
 use super::{Trie, Cursor, Builder, MergeBuilder, TupleBuilder};
 
 /// A layer of unordered values. 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct OrderedLeaf<K, R> {
     /// Unordered values.
     pub vals: Vec<(K, R)>,


### PR DESCRIPTION
This implements `arrange_mut` for the `Ord` batch implementation. This allows the batch the opportunity to update in place if it has exclusive ownership (through the `Rc`), which can avoid a substantial amount of allocation. For example, in Eintopf where the value types are `String`, this resulted in a ~20% performance improvement for write-only workloads.

The implementation is for both `OrdValBatch` and `OrdKeyBatch`, that is the with- and without-value variants. There is not currently an implementation for the `Hash` batch variants as they have a more complicated representation, and while collapsing in place is probably possible, it requires a bit of thinking about how to re-layout the hash tables, and whether they should be collapsed down.

This fixes #30.