### PR TITLE
OwningRef::Erased

### DIFF
--- a/src/trace/implementations/ord.rs
+++ b/src/trace/implementations/ord.rs
@@ -43,19 +43,19 @@ pub struct OrdValBatch<K: Ord+HashOrdered, V: Ord, T: Lattice, R> {
 }
 
 impl<K, V, T, R> BatchReader<K, V, T, R> for Rc<OrdValBatch<K, V, T, R>>
-where K: Ord+Clone+HashOrdered, V: Ord+Clone, T: Lattice+Ord+Clone, R: Diff {
+where K: Ord+Clone+HashOrdered+'static, V: Ord+Clone+'static, T: Lattice+Ord+Clone+'static, R: Diff {
 	type Cursor = OrdValCursor<K, V, T, R>;
 	fn cursor(&self) -> Self::Cursor { 
 		OrdValCursor {
-			cursor: self.layer.cursor(OwningRef::new(self.clone()).map(|x| &x.layer))
+			cursor: self.layer.cursor(OwningRef::new(self.clone()).map(|x| &x.layer).erase_owner())
 		}
 	}
-	fn len(&self) -> usize { <OrderedLayer<K, OrderedLayer<V, OrderedLeaf<T, R>>> as Trie<OrdValBatch<K, V, T, R>>>::tuples(&self.layer) }
+	fn len(&self) -> usize { <OrderedLayer<K, OrderedLayer<V, OrderedLeaf<T, R>>> as Trie>::tuples(&self.layer) }
 	fn description(&self) -> &Description<T> { &self.desc }
 }
 
 impl<K, V, T, R> Batch<K, V, T, R> for Rc<OrdValBatch<K, V, T, R>>
-where K: Ord+Clone+HashOrdered, V: Ord+Clone, T: Lattice+Ord+Clone+::std::fmt::Debug, R: Diff {
+where K: Ord+Clone+HashOrdered+'static, V: Ord+Clone+'static, T: Lattice+Ord+Clone+::std::fmt::Debug+'static, R: Diff {
 	type Batcher = RadixBatcher<K, V, T, R, Self>;
 	type Builder = OrdValBuilder<K, V, T, R>;
 	fn merge(&self, other: &Self) -> Self {
@@ -72,7 +72,7 @@ where K: Ord+Clone+HashOrdered, V: Ord+Clone, T: Lattice+Ord+Clone+::std::fmt::D
 		};
 		
 		Rc::new(OrdValBatch {
-			layer: <OrderedLayer<K, OrderedLayer<V, OrderedLeaf<T, R>>> as Trie<OrdValBatch<K, V, T, R>>>::merge(&self.layer, &other.layer),  //self.layer.merge(&other.layer),
+			layer: <OrderedLayer<K, OrderedLayer<V, OrderedLeaf<T, R>>> as Trie>::merge(&self.layer, &other.layer),  //self.layer.merge(&other.layer),
 			desc: Description::new(self.desc.lower(), other.desc.upper(), since),
 		})
 	}
@@ -199,7 +199,7 @@ where K: Ord+Clone+HashOrdered, V: Ord+Clone, T: Lattice+Ord+Clone+::std::fmt::D
 /// A cursor for navigating a single layer.
 #[derive(Debug)]
 pub struct OrdValCursor<K: Ord+Clone+HashOrdered, V: Ord+Clone, T: Lattice+Ord+Clone, R: Copy> {
-	cursor: OrderedCursor<OrdValBatch<K, V, T, R>, K, OrderedCursor<OrdValBatch<K, V, T, R>, V, OrderedLeafCursor<OrdValBatch<K, V, T, R>, T, R>>>,
+	cursor: OrderedCursor<K, OrderedCursor<V, OrderedLeafCursor<T, R>>>,
 }
 
 impl<K, V, T, R> Cursor<K, V, T, R> for OrdValCursor<K, V, T, R> 
@@ -226,20 +226,20 @@ where K: Ord+Clone+HashOrdered, V: Ord+Clone, T: Lattice+Ord+Clone, R: Copy {
 
 /// A builder for creating layers from unsorted update tuples.
 pub struct OrdValBuilder<K: Ord+HashOrdered, V: Ord, T: Ord+Lattice, R: Diff> {
-	builder: OrderedBuilder<OrdValBatch<K, V, T, R>, K, OrderedBuilder<OrdValBatch<K, V, T, R>, V, OrderedLeafBuilder<T, R>>>,
+	builder: OrderedBuilder<K, OrderedBuilder<V, OrderedLeafBuilder<T, R>>>,
 }
 
 impl<K, V, T, R> Builder<K, V, T, R, Rc<OrdValBatch<K, V, T, R>>> for OrdValBuilder<K, V, T, R> 
-where K: Ord+Clone+HashOrdered, V: Ord+Clone, T: Lattice+Ord+Clone+::std::fmt::Debug, R: Diff {
+where K: Ord+Clone+HashOrdered+'static, V: Ord+Clone+'static, T: Lattice+Ord+Clone+::std::fmt::Debug+'static, R: Diff {
 
 	fn new() -> Self { 
 		OrdValBuilder { 
-			builder: OrderedBuilder::<OrdValBatch<K, V, T, R>, K, OrderedBuilder<OrdValBatch<K, V, T, R>, V, OrderedLeafBuilder<T, R>>>::new() 
+			builder: OrderedBuilder::<K, OrderedBuilder<V, OrderedLeafBuilder<T, R>>>::new() 
 		} 
 	}
 	fn with_capacity(cap: usize) -> Self { 
 		OrdValBuilder { 
-			builder: OrderedBuilder::<OrdValBatch<K, V, T, R>, K, OrderedBuilder<OrdValBatch<K, V, T, R>, V, OrderedLeafBuilder<T, R>>>::with_capacity(cap) 
+			builder: OrderedBuilder::<K, OrderedBuilder<V, OrderedLeafBuilder<T, R>>>::with_capacity(cap) 
 		} 
 	}
 
@@ -270,21 +270,21 @@ pub struct OrdKeyBatch<K: Ord+HashOrdered, T: Lattice, R> {
 }
 
 impl<K, T, R> BatchReader<K, (), T, R> for Rc<OrdKeyBatch<K, T, R>>
-where K: Ord+Clone+HashOrdered, T: Lattice+Ord+Clone, R: Diff {
+where K: Ord+Clone+HashOrdered+'static, T: Lattice+Ord+Clone+'static, R: Diff {
 	type Cursor = OrdKeyCursor<K, T, R>;
 	fn cursor(&self) -> Self::Cursor { 
 		OrdKeyCursor {
 			empty: (),
 			valid: true,
-			cursor: self.layer.cursor(OwningRef::new(self.clone()).map(|x| &x.layer)),
+			cursor: self.layer.cursor(OwningRef::new(self.clone()).map(|x| &x.layer).erase_owner()),
 		} 
 	}
-	fn len(&self) -> usize { <OrderedLayer<K, OrderedLeaf<T, R>> as Trie<OrdKeyBatch<K, T, R>>>::tuples(&self.layer) }
+	fn len(&self) -> usize { <OrderedLayer<K, OrderedLeaf<T, R>> as Trie>::tuples(&self.layer) }
 	fn description(&self) -> &Description<T> { &self.desc }
 }
 
 impl<K, T, R> Batch<K, (), T, R> for Rc<OrdKeyBatch<K, T, R>>
-where K: Ord+Clone+HashOrdered, T: Lattice+Ord+Clone, R: Diff {
+where K: Ord+Clone+HashOrdered+'static, T: Lattice+Ord+Clone+'static, R: Diff {
 	type Batcher = RadixBatcher<K, (), T, R, Self>;
 	type Builder = OrdKeyBuilder<K, T, R>;
 	fn merge(&self, other: &Self) -> Self {
@@ -301,7 +301,7 @@ where K: Ord+Clone+HashOrdered, T: Lattice+Ord+Clone, R: Diff {
 		};
 		
 		Rc::new(OrdKeyBatch {
-			layer: <OrderedLayer<K, OrderedLeaf<T, R>> as Trie<OrdKeyBatch<K, T, R>>>::merge(&self.layer, &other.layer),
+			layer: <OrderedLayer<K, OrderedLeaf<T, R>> as Trie>::merge(&self.layer, &other.layer),
 			desc: Description::new(self.desc.lower(), other.desc.upper(), since),
 		})
 	}
@@ -404,7 +404,7 @@ where K: Ord+Clone+HashOrdered, T: Lattice+Ord+Clone, R: Diff {
 pub struct OrdKeyCursor<K: Ord+Clone+HashOrdered, T: Lattice+Ord+Clone, R: Copy> {
 	valid: bool,
 	empty: (),
-	cursor: OrderedCursor<OrdKeyBatch<K, T, R>, K, OrderedLeafCursor<OrdKeyBatch<K, T, R>, T, R>>,
+	cursor: OrderedCursor<K, OrderedLeafCursor<T, R>>,
 }
 
 impl<K: Ord+Clone+HashOrdered, T: Lattice+Ord+Clone, R: Copy> Cursor<K, (), T, R> for OrdKeyCursor<K, T, R> {
@@ -430,21 +430,21 @@ impl<K: Ord+Clone+HashOrdered, T: Lattice+Ord+Clone, R: Copy> Cursor<K, (), T, R
 
 /// A builder for creating layers from unsorted update tuples.
 pub struct OrdKeyBuilder<K: Ord+HashOrdered, T: Ord+Lattice, R: Diff> {
-	builder: OrderedBuilder<OrdKeyBatch<K, T, R>, K, OrderedLeafBuilder<T, R>>,
+	builder: OrderedBuilder<K, OrderedLeafBuilder<T, R>>,
 }
 
 impl<K, T, R> Builder<K, (), T, R, Rc<OrdKeyBatch<K, T, R>>> for OrdKeyBuilder<K, T, R> 
-where K: Ord+Clone+HashOrdered, T: Lattice+Ord+Clone, R: Diff {
+where K: Ord+Clone+HashOrdered+'static, T: Lattice+Ord+Clone+'static, R: Diff {
 
 	fn new() -> Self { 
 		OrdKeyBuilder { 
-			builder: OrderedBuilder::<OrdKeyBatch<K, T, R>, K, OrderedLeafBuilder<T, R>>::new() 
+			builder: OrderedBuilder::<K, OrderedLeafBuilder<T, R>>::new() 
 		} 
 	}
 
 	fn with_capacity(cap: usize) -> Self {
 		OrdKeyBuilder { 
-			builder: OrderedBuilder::<OrdKeyBatch<K, T, R>, K, OrderedLeafBuilder<T, R>>::with_capacity(cap) 
+			builder: OrderedBuilder::<K, OrderedLeafBuilder<T, R>>::with_capacity(cap) 
 		} 
 	}
 

--- a/src/trace/layers/hashed.rs
+++ b/src/trace/layers/hashed.rs
@@ -80,7 +80,7 @@ impl<K: Clone+HashOrdered+Default, L: Trie> Trie for HashedLayer<K, L> {
 				shift: shift,
 				bounds: (lower, upper),
 				pos: pos,
-				keys: owned_self.clone().map(|x| &x.keys),
+				keys: owned_self.clone().map(|x| &x.keys[..]),
 				child: self.vals.cursor_from(owned_self.map(|x| &x.vals), self.keys[pos].get_lower(), self.keys[pos].get_upper())
 			}
 		}
@@ -89,7 +89,7 @@ impl<K: Clone+HashOrdered+Default, L: Trie> Trie for HashedLayer<K, L> {
 				shift: 0,
 				bounds: (0, 0),
 				pos: 0,
-				keys: owned_self.clone().map(|x| &x.keys), // &self.keys,
+				keys: owned_self.clone().map(|x| &x.keys[..]), // &self.keys,
 				child: self.vals.cursor_from(owned_self.map(|x| &x.vals), 0, 0),
 			}
 		}
@@ -405,7 +405,7 @@ pub struct HashedCursor<K: HashOrdered, L: Cursor> {
 	bounds: (usize, usize),	// bounds of slice of self.keys.
 	pos: usize,				// <-- current cursor position.
 
-	keys: OwningRef<Rc<Erased>, Vec<Entry<K>>>,
+	keys: OwningRef<Rc<Erased>, [Entry<K>]>,
 	/// A cursor for the layer below this one.
 	pub child: L,
 }

--- a/src/trace/layers/mod.rs
+++ b/src/trace/layers/mod.rs
@@ -11,32 +11,32 @@ pub mod weighted;
 pub mod unordered;
 
 use std::rc::Rc;
-use owning_ref::OwningRef;
+use owning_ref::{OwningRef, Erased};
 
 /// A collection of tuples, and types for building and enumerating them.
 ///
 /// There are some implicit assumptions about the elements in trie-structured data, mostly that
 /// the items have some `(key, val)` structure. Perhaps we will nail these down better in the
 /// future and get a better name for the trait.
-pub trait Trie<B>  : ::std::marker::Sized {
+pub trait Trie  : ::std::marker::Sized {
 	/// The type of item from which the type is constructed.
 	type Item;
 	/// The type of cursor used to navigate the type.
 	type Cursor: Cursor;
 	/// The type used to merge instances of the type together.
-	type MergeBuilder: MergeBuilder<B, Trie=Self>;
+	type MergeBuilder: MergeBuilder<Trie=Self>;
 	/// The type used to assemble instances of the type from its `Item`s.
-	type TupleBuilder: TupleBuilder<B, Trie=Self, Item=Self::Item>;
+	type TupleBuilder: TupleBuilder<Trie=Self, Item=Self::Item>;
 
 	/// The number of distinct keys, as distinct from the total number of tuples.
 	fn keys(&self) -> usize;
 	/// The total number of tuples in the collection.
 	fn tuples(&self) -> usize;
 	/// Returns a cursor capable of navigating the collection.
-	fn cursor(&self, owned_self: OwningRef<Rc<B>, Self>) -> Self::Cursor { self.cursor_from(owned_self, 0, self.keys()) }
+	fn cursor(&self, owned_self: OwningRef<Rc<Erased>, Self>) -> Self::Cursor { self.cursor_from(owned_self, 0, self.keys()) }
 	/// Returns a cursor over a range of data, commonly used by others to restrict navigation to 
 	/// sub-collections.
-	fn cursor_from(&self, owned_self: OwningRef<Rc<B>, Self>, lower: usize, upper: usize) -> Self::Cursor;
+	fn cursor_from(&self, owned_self: OwningRef<Rc<Erased>, Self>, lower: usize, upper: usize) -> Self::Cursor;
 
 	/// Merges two collections into a third.
 	///
@@ -52,9 +52,9 @@ pub trait Trie<B>  : ::std::marker::Sized {
 }
 
 /// A type used to assemble collections.
-pub trait Builder<B> {
+pub trait Builder {
 	/// The type of collection produced.
-	type Trie: Trie<B>;
+	type Trie: Trie;
 	/// Requests a commitment to the offset of the current-most sub-collection.
 	///
 	/// This is most often used by parent collections to indicate that some set of values are now
@@ -66,7 +66,7 @@ pub trait Builder<B> {
 }
 
 /// A type used to assemble collections by merging other instances.
-pub trait MergeBuilder<B> : Builder<B> {
+pub trait MergeBuilder : Builder {
 	/// Allocates an instance of the builder with sufficient capacity to contain the merged data.
 	fn with_capacity(other1: &Self::Trie, other2: &Self::Trie) -> Self;
 	/// Copies sub-collections of `other` into this collection.
@@ -76,7 +76,7 @@ pub trait MergeBuilder<B> : Builder<B> {
 }
 
 /// A type used to assemble collections from ordered sequences of tuples.
-pub trait TupleBuilder<B> : Builder<B> {
+pub trait TupleBuilder : Builder {
 	/// The type of item accepted for construction.
 	type Item;
 	/// Allocates a new builder.

--- a/src/trace/layers/ordered.rs
+++ b/src/trace/layers/ordered.rs
@@ -39,8 +39,8 @@ impl<K: Ord+Clone, L: Trie> Trie for OrderedLayer<K, L> {
 			let child_lower = self.offs[lower];
 			let child_upper = self.offs[lower + 1];
 			OrderedCursor {
-				keys: owned_self.clone().map(|x| &x.keys),
-				offs: owned_self.clone().map(|x| &x.offs),
+				keys: owned_self.clone().map(|x| &x.keys[..]),
+				offs: owned_self.clone().map(|x| &x.offs[..]),
 				bounds: (lower, upper),
 				child: self.vals.cursor_from(owned_self.map(|x| &x.vals), child_lower, child_upper),
 				pos: lower,
@@ -48,8 +48,8 @@ impl<K: Ord+Clone, L: Trie> Trie for OrderedLayer<K, L> {
 		}
 		else {
 			OrderedCursor {
-				keys: owned_self.clone().map(|x| &x.keys),
-				offs: owned_self.clone().map(|x| &x.offs),
+				keys: owned_self.clone().map(|x| &x.keys[..]),
+				offs: owned_self.clone().map(|x| &x.offs[..]),
 				bounds: (0, 0),
 				child: self.vals.cursor_from(owned_self.map(|x| &x.vals), 0, 0),
 				pos: 0,
@@ -190,8 +190,8 @@ impl<K: Ord+Clone, L: TupleBuilder> TupleBuilder for OrderedBuilder<K, L> {
 /// A cursor with a child cursor that is updated as we move.
 #[derive(Debug)]
 pub struct OrderedCursor<K: Ord, L: Cursor> {
-	keys: OwningRef<Rc<Erased>, Vec<K>>,
-	offs: OwningRef<Rc<Erased>, Vec<usize>>,
+	keys: OwningRef<Rc<Erased>, [K]>,
+	offs: OwningRef<Rc<Erased>, [usize]>,
 	pos: usize,
 	bounds: (usize, usize),
 	/// The cursor for the trie layer below this one.

--- a/src/trace/layers/unordered.rs
+++ b/src/trace/layers/unordered.rs
@@ -2,7 +2,7 @@
 
 use std::rc::Rc;
 
-use owning_ref::OwningRef;
+use owning_ref::{OwningRef, Erased};
 
 use super::{Trie, Cursor, Builder, MergeBuilder, TupleBuilder};
 
@@ -13,14 +13,14 @@ pub struct UnorderedLayer<K> {
 	pub vals: Vec<K>,
 }
 
-impl<B, K: Clone> Trie<B> for UnorderedLayer<K> {
+impl<K: Clone> Trie for UnorderedLayer<K> {
 	type Item = K;
-	type Cursor = UnorderedCursor<B, K>;
+	type Cursor = UnorderedCursor<K>;
 	type MergeBuilder = UnorderedBuilder<K>;
 	type TupleBuilder = UnorderedBuilder<K>;
 	fn keys(&self) -> usize { self.vals.len() }
-	fn tuples(&self) -> usize { <UnorderedLayer<K> as Trie<B>>::keys(&self) }
-	fn cursor_from(&self, owned_self: OwningRef<Rc<B>, Self>, lower: usize, upper: usize) -> Self::Cursor {	
+	fn tuples(&self) -> usize { <UnorderedLayer<K> as Trie>::keys(&self) }
+	fn cursor_from(&self, owned_self: OwningRef<Rc<Erased>, Self>, lower: usize, upper: usize) -> Self::Cursor {	
 		// println!("unordered: {} .. {}", lower, upper);
 		UnorderedCursor {
 			vals: owned_self.map(|x| &x.vals),
@@ -36,29 +36,29 @@ pub struct UnorderedBuilder<K> {
 	pub vals: Vec<K>,
 }
 
-impl<B, K: Clone> Builder<B> for UnorderedBuilder<K> {
+impl<K: Clone> Builder for UnorderedBuilder<K> {
 	type Trie = UnorderedLayer<K>; 
 	fn boundary(&mut self) -> usize { self.vals.len() } 
 	fn done(self) -> Self::Trie { UnorderedLayer { vals: self.vals } }
 }
 
-impl<B, K: Clone> MergeBuilder<B> for UnorderedBuilder<K> {
+impl<K: Clone> MergeBuilder for UnorderedBuilder<K> {
 	fn with_capacity(other1: &Self::Trie, other2: &Self::Trie) -> Self {
 		UnorderedBuilder {
-			vals: Vec::with_capacity(<UnorderedLayer<K> as Trie<B>>::keys(other1) + <UnorderedLayer<K> as Trie<B>>::keys(other2)),
+			vals: Vec::with_capacity(<UnorderedLayer<K> as Trie>::keys(other1) + <UnorderedLayer<K> as Trie>::keys(other2)),
 		}
 	}
 	fn copy_range(&mut self, other: &Self::Trie, lower: usize, upper: usize) {
 		self.vals.extend_from_slice(&other.vals[lower .. upper]);
 	}
 	fn push_merge(&mut self, other1: (&Self::Trie, usize, usize), other2: (&Self::Trie, usize, usize)) -> usize {
-		<UnorderedBuilder<K> as MergeBuilder<B>>::copy_range(self, &other1.0, other1.1, other1.2);
-		<UnorderedBuilder<K> as MergeBuilder<B>>::copy_range(self, &other2.0, other2.1, other2.2);
+		<UnorderedBuilder<K> as MergeBuilder>::copy_range(self, &other1.0, other1.1, other1.2);
+		<UnorderedBuilder<K> as MergeBuilder>::copy_range(self, &other2.0, other2.1, other2.2);
 		self.vals.len()
 	}
 }
 
-impl<B, K: Clone> TupleBuilder<B> for UnorderedBuilder<K> {
+impl<K: Clone> TupleBuilder for UnorderedBuilder<K> {
 	type Item = K;
 	fn new() -> Self { UnorderedBuilder { vals: Vec::new() } }
 	fn with_capacity(cap: usize) -> Self { UnorderedBuilder { vals: Vec::with_capacity(cap) } }
@@ -69,13 +69,13 @@ impl<B, K: Clone> TupleBuilder<B> for UnorderedBuilder<K> {
 ///
 /// This cursor does not support `seek`, though I'm not certain how to expose this.
 #[derive(Debug)]
-pub struct UnorderedCursor<B, K> {
-	vals: OwningRef<Rc<B>, Vec<K>>,
+pub struct UnorderedCursor<K> {
+	vals: OwningRef<Rc<Erased>, Vec<K>>,
 	pos: usize,
 	bounds: (usize, usize),
 }
 
-impl<B, K: Clone> Cursor for UnorderedCursor<B, K> {
+impl<K: Clone> Cursor for UnorderedCursor<K> {
 	type Key = K;
 	fn key(&self) -> &Self::Key { &self.vals[self.pos] }
 	fn step(&mut self) {

--- a/src/trace/layers/unordered.rs
+++ b/src/trace/layers/unordered.rs
@@ -23,7 +23,7 @@ impl<K: Clone> Trie for UnorderedLayer<K> {
 	fn cursor_from(&self, owned_self: OwningRef<Rc<Erased>, Self>, lower: usize, upper: usize) -> Self::Cursor {	
 		// println!("unordered: {} .. {}", lower, upper);
 		UnorderedCursor {
-			vals: owned_self.map(|x| &x.vals),
+			vals: owned_self.map(|x| &x.vals[..]),
 			bounds: (lower, upper),
 			pos: lower,
 		}
@@ -70,7 +70,7 @@ impl<K: Clone> TupleBuilder for UnorderedBuilder<K> {
 /// This cursor does not support `seek`, though I'm not certain how to expose this.
 #[derive(Debug)]
 pub struct UnorderedCursor<K> {
-	vals: OwningRef<Rc<Erased>, Vec<K>>,
+	vals: OwningRef<Rc<Erased>, [K]>,
 	pos: usize,
 	bounds: (usize, usize),
 }

--- a/src/trace/layers/weighted.rs
+++ b/src/trace/layers/weighted.rs
@@ -22,8 +22,8 @@ impl<K: Ord+Clone> Trie for WeightedLayer<K> {
 	fn tuples(&self) -> usize { <WeightedLayer<K> as Trie>::keys(&self) }
 	fn cursor_from(&self, owned_self: OwningRef<Rc<Erased>, Self>, lower: usize, upper: usize) -> Self::Cursor {	
 		WeightedCursor {
-			keys: owned_self.clone().map(|x| &x.keys),
-			wgts: owned_self.clone().map(|x| &x.wgts),
+			keys: owned_self.clone().map(|x| &x.keys[..]),
+			wgts: owned_self.clone().map(|x| &x.wgts[..]),
 			bounds: (lower, upper),
 			pos: lower,
 		}
@@ -141,8 +141,8 @@ impl<K: Ord+Clone> TupleBuilder for WeightedBuilder<K> {
 
 /// A cursor with a child cursor that is updated as we move.
 pub struct WeightedCursor<K: Ord> {
-	keys: OwningRef<Rc<Erased>, Vec<K>>,
-	wgts: OwningRef<Rc<Erased>, Vec<isize>>,
+	keys: OwningRef<Rc<Erased>, [K]>,
+	wgts: OwningRef<Rc<Erased>, [isize]>,
 	pos: usize,
 	bounds: (usize, usize),
 }

--- a/src/trace/layers/weighted.rs
+++ b/src/trace/layers/weighted.rs
@@ -1,7 +1,7 @@
 //! Implementation using ordered keys and exponential search.
 
 use std::rc::Rc;
-use owning_ref::OwningRef;
+use owning_ref::{OwningRef, Erased};
 use super::{Trie, Cursor, Builder, MergeBuilder, TupleBuilder};
 
 /// A layer with sorted keys and integer weights.
@@ -13,14 +13,14 @@ pub struct WeightedLayer<K: Ord> {
 	pub wgts: Vec<isize>,
 }
 
-impl<B, K: Ord+Clone> Trie<B> for WeightedLayer<K> {
+impl<K: Ord+Clone> Trie for WeightedLayer<K> {
 	type Item = (K, isize);
-	type Cursor = WeightedCursor<B, K>;
+	type Cursor = WeightedCursor<K>;
 	type MergeBuilder = WeightedBuilder<K>;
 	type TupleBuilder = WeightedBuilder<K>;
 	fn keys(&self) -> usize { self.keys.len() }
-	fn tuples(&self) -> usize { <WeightedLayer<K> as Trie<B>>::keys(&self) }
-	fn cursor_from(&self, owned_self: OwningRef<Rc<B>, Self>, lower: usize, upper: usize) -> Self::Cursor {	
+	fn tuples(&self) -> usize { <WeightedLayer<K> as Trie>::keys(&self) }
+	fn cursor_from(&self, owned_self: OwningRef<Rc<Erased>, Self>, lower: usize, upper: usize) -> Self::Cursor {	
 		WeightedCursor {
 			keys: owned_self.clone().map(|x| &x.keys),
 			wgts: owned_self.clone().map(|x| &x.wgts),
@@ -39,7 +39,7 @@ pub struct WeightedBuilder<K: Ord> {
 	pub wgts: Vec<isize>,
 }
 
-impl<B, K: Ord+Clone> Builder<B> for WeightedBuilder<K> {
+impl<K: Ord+Clone> Builder for WeightedBuilder<K> {
 	type Trie = WeightedLayer<K>; 
 	fn boundary(&mut self) -> usize { 
 		self.is_new = true; 
@@ -53,12 +53,12 @@ impl<B, K: Ord+Clone> Builder<B> for WeightedBuilder<K> {
 	}
 }
 
-impl<B, K: Ord+Clone> MergeBuilder<B> for WeightedBuilder<K> {
+impl<K: Ord+Clone> MergeBuilder for WeightedBuilder<K> {
 	fn with_capacity(other1: &Self::Trie, other2: &Self::Trie) -> Self {
 		WeightedBuilder {
 			is_new: false,
-			keys: Vec::with_capacity(<WeightedLayer<K> as Trie<B>>::keys(other1) + <WeightedLayer<K> as Trie<B>>::keys(other2)),
-			wgts: Vec::with_capacity(<WeightedLayer<K> as Trie<B>>::keys(other1) + <WeightedLayer<K> as Trie<B>>::keys(other2)),
+			keys: Vec::with_capacity(<WeightedLayer<K> as Trie>::keys(other1) + <WeightedLayer<K> as Trie>::keys(other2)),
+			wgts: Vec::with_capacity(<WeightedLayer<K> as Trie>::keys(other1) + <WeightedLayer<K> as Trie>::keys(other2)),
 		}
 	}
 	fn copy_range(&mut self, other: &Self::Trie, lower: usize, upper: usize) {
@@ -77,7 +77,7 @@ impl<B, K: Ord+Clone> MergeBuilder<B> for WeightedBuilder<K> {
 				::std::cmp::Ordering::Less => {
 					// determine how far we can advance lower1 until we reach/pass lower2
 					let step = 1 + advance(&trie1.keys[(1+lower1)..upper1], |x| x < &trie2.keys[lower2]);
-					<WeightedBuilder<K> as MergeBuilder<B>>::copy_range(self, trie1, lower1, lower1 + step);
+					<WeightedBuilder<K> as MergeBuilder>::copy_range(self, trie1, lower1, lower1 + step);
 					lower1 += step;
 				}
 				::std::cmp::Ordering::Equal => {
@@ -93,20 +93,20 @@ impl<B, K: Ord+Clone> MergeBuilder<B> for WeightedBuilder<K> {
 				::std::cmp::Ordering::Greater => {
 					// determine how far we can advance lower2 until we reach/pass lower1
 					let step = 1 + advance(&trie2.keys[(1+lower2)..upper2], |x| x < &trie1.keys[lower1]);
-					<WeightedBuilder<K> as MergeBuilder<B>>::copy_range(self, trie2, lower2, lower2 + step);
+					<WeightedBuilder<K> as MergeBuilder>::copy_range(self, trie2, lower2, lower2 + step);
 					lower2 += step;
 				}
 			}
 		}
 
-		if lower1 < upper1 { <WeightedBuilder<K> as MergeBuilder<B>>::copy_range(self, trie1, lower1, upper1); }
-		if lower2 < upper2 { <WeightedBuilder<K> as MergeBuilder<B>>::copy_range(self, trie2, lower2, upper2); }
+		if lower1 < upper1 { <WeightedBuilder<K> as MergeBuilder>::copy_range(self, trie1, lower1, upper1); }
+		if lower2 < upper2 { <WeightedBuilder<K> as MergeBuilder>::copy_range(self, trie2, lower2, upper2); }
 
 		self.keys.len()
 	}
 }
 
-impl<B, K: Ord+Clone> TupleBuilder<B> for WeightedBuilder<K> {
+impl<K: Ord+Clone> TupleBuilder for WeightedBuilder<K> {
 
 	type Item = (K, isize);
 	fn new() -> Self { 
@@ -140,19 +140,19 @@ impl<B, K: Ord+Clone> TupleBuilder<B> for WeightedBuilder<K> {
 }
 
 /// A cursor with a child cursor that is updated as we move.
-pub struct WeightedCursor<B, K: Ord> {
-	keys: OwningRef<Rc<B>, Vec<K>>,
-	wgts: OwningRef<Rc<B>, Vec<isize>>,
+pub struct WeightedCursor<K: Ord> {
+	keys: OwningRef<Rc<Erased>, Vec<K>>,
+	wgts: OwningRef<Rc<Erased>, Vec<isize>>,
 	pos: usize,
 	bounds: (usize, usize),
 }
 
-impl<B, K: Ord> WeightedCursor<B, K> {
+impl<K: Ord> WeightedCursor<K> {
 	/// Recovers the weight of the item.
 	pub fn weight(&self) -> isize { self.wgts[self.bounds.0] }
 }
 
-impl<B, K: Ord> Cursor for WeightedCursor<B, K> {
+impl<K: Ord> Cursor for WeightedCursor<K> {
 	type Key = K;
 	fn key(&self) -> &Self::Key { &self.keys[self.pos] }
 	fn step(&mut self) {


### PR DESCRIPTION
This PR removes the dependence of the various uses of `OwningRef` on a concrete owned type. This removes a generic parameter (`B`) from many of the types and trait, which I claim simplifies things somehow. :)

The main change is the use of `OwningRef::erase_owner()`, which replaces the owning type with something related to the original owning type. In this case, it ends up being `Rc<OwningRef::Erased>`, I think because the owning reference still needs to know what type of ownership it is, I guess?

The only constraints introduced are that we need `'static` bounds on the keys, values, and times, so that the erasure can happen. I think these constraints end up being imposed eventually for data we want to shuffle around anyhow, although it could have bene nicer to avoid them (perhaps it is possible, if `Erased` had a lifetime; not complaining, though).

Another minor change, the type dereferenced to was changed from various `Vec<T>` types to `[T]`, meaning that we don't actually have to have a `Vec<T>` on hand but can dereference directly to slices if that is helpful. I'm not sure that it is yet, but it seemed like a nice thing to do as we don't use `.capacity()`.