### PR TITLE
Timely ops

### DIFF
--- a/examples/arrange.rs
+++ b/examples/arrange.rs
@@ -45,7 +45,7 @@ fn main() {
     	let mut graph = worker.dataflow(|scope| {
 
             // create a source operator which will produce random edges and delete them.
-            timely::dataflow::operators::operator::source(scope, "RandomGraph", |mut capability| {
+            timely::dataflow::operators::generic::source(scope, "RandomGraph", |mut capability| {
 
                 let seed: &[_] = &[1, 2, 3, index];
                 let mut rng1: StdRng = SeedableRng::from_seed(seed);    // rng for edge additions

--- a/server/src/bin/server.rs
+++ b/server/src/bin/server.rs
@@ -62,7 +62,7 @@ fn main() {
             let mut recvd = Vec::new();
 
             // a source that attempts to pull from `recv` and produce commands for everyone
-            timely::dataflow::operators::operator::source(dataflow, "InputCommands", move |mut capability| {
+            timely::dataflow::operators::generic::source(dataflow, "InputCommands", move |mut capability| {
 
                 // closure broadcasts any commands it grabs.
                 move |output| {

--- a/src/operators/arrange.rs
+++ b/src/operators/arrange.rs
@@ -25,11 +25,9 @@ use std::collections::VecDeque;
 
 use timely::dataflow::operators::{Enter, Map};
 use timely::order::PartialOrder;
-use timely::dataflow::*;
-use timely::dataflow::operators::Unary;
+use timely::dataflow::{Scope, Stream};
+use timely::dataflow::operators::generic::{Unary, source};
 use timely::dataflow::channels::pact::{Pipeline, Exchange};
-// use timely::progress::nested::product::Product;
-// use timely::progress::frontier::MutableAntichain;
 use timely::progress::Timestamp;
 use timely::dataflow::operators::Capability;
 use timely::dataflow::scopes::Child;
@@ -276,7 +274,7 @@ where T: Lattice+Clone+'static, Tr: TraceReader<K,V,T,R> {
 
         let queue = self.new_listener();
 
-        let collection = ::timely::dataflow::operators::operator::source(scope, "ArrangedSource", move |capability| {
+        let collection = source(scope, "ArrangedSource", move |capability| {
             
             // capabilities the source maintains.
             let mut capabilities = vec![capability];

--- a/src/operators/join.rs
+++ b/src/operators/join.rs
@@ -9,14 +9,12 @@ use std::cmp::Ordering;
 
 use timely::progress::Timestamp;
 use timely::dataflow::Scope;
-use timely::dataflow::operators::Binary;
+use timely::dataflow::operators::generic::{Binary, OutputHandle};
 use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::Capability;
-use timely_sort::Unsigned;
-
-use timely::dataflow::operators::OutputHandle;
 use timely::dataflow::channels::pushers::tee::Tee;
 
+use timely_sort::Unsigned;
 
 use hashable::{Hashable, UnsignedWrapper, OrdWrapper};
 use ::{Data, Diff, Collection, AsCollection};


### PR DESCRIPTION
This PR fixes up a few paths that were changed in timely dataflow to generic operators. They will probably break again if they change again, but it is pretty easy to do. The hard part is just making sure that things stay in sync. Current-most git repos should work with each other, and non-current repos.. well let me know if you have something like this and are experiencing breakage!