### PR TITLE
Merge batcher (work in progress)

### DIFF
--- a/examples/arrange.rs
+++ b/examples/arrange.rs
@@ -97,7 +97,7 @@ fn main() {
             })
             .probe_with(&mut probe)
             .as_collection()
-            .arrange_by_key_u()
+            .arrange_by_key()
             .trace
         });
 
@@ -121,10 +121,10 @@ fn main() {
                 let edges = edges.enter(&dists.scope());
                 let roots = roots.enter(&dists.scope());
 
-                dists.arrange_by_key_u()
+                dists.arrange_by_key()
                      .join_core(&edges, |_k,l,d| Some((*d, l+1)))
                      .concat(&roots)
-                     .group_u(|_, s, t| t.push((*s[0].0, 1)))
+                     .group(|_, s, t| t.push((*s[0].0, 1)))
             })
             .map(|(_node, dist)| dist)
             .consolidate()
@@ -140,11 +140,11 @@ fn main() {
             let (input, query) = scope.new_collection();
 
             query.map(|x| (x, x))
-                 .arrange_by_key_u()
+                 .arrange_by_key()
                  .join_core(&edges, |_n, &q, &d| Some((d, q)))
-                 .arrange_by_key_u()
+                 .arrange_by_key()
                  .join_core(&edges, |_n, &q, &d| Some((d, q)))
-                 .arrange_by_key_u()
+                 .arrange_by_key()
                  .join_core(&edges, |_n, &q, &d| Some((d, q)))
                  .filter(move |_| inspect)
                  .map(|x| x.1)

--- a/examples/bfs.rs
+++ b/examples/bfs.rs
@@ -113,8 +113,8 @@ where G::Timestamp: Lattice+Ord {
         let edges = edges.enter(&inner.scope());
         let nodes = nodes.enter(&inner.scope());
 
-        inner.join_map_u(&edges, |_k,l,d| (*d, l+1))
+        inner.join_map(&edges, |_k,l,d| (*d, l+1))
              .concat(&nodes)
-             .group_u(|_, s, t| t.push((*s[0].0, 1)))
+             .group(|_, s, t| t.push((*s[0].0, 1)))
      })
 }

--- a/examples/degrees.rs
+++ b/examples/degrees.rs
@@ -30,11 +30,11 @@ fn main() {
             let (input, edges) = scope.new_collection();
 
             let degrs = edges.map(|(src, _dst)| src)
-                             .count_total_u();
+                             .count_total();
 
             // pull of count, and count.
             let distr = degrs.map(|(_src, cnt)| cnt as usize)
-                             .count_total_u();
+                             .count_total();
 
             // show us something about the collection, notice when done.
             let probe = if inspect { 

--- a/examples/degrees.rs
+++ b/examples/degrees.rs
@@ -85,13 +85,12 @@ fn main() {
 
             let requests_per_sec = batch;
             let ns_per_request = 1000000000 / requests_per_sec;
-            // let ns_per_request = batch;//1000000;  // corresponds to 1K requests / second.
             let mut request_counter = 1;
             let mut measurements = Vec::with_capacity(20 * requests_per_sec);
 
             let timer = ::std::time::Instant::now();
 
-            while timer.elapsed().as_secs() < 10 {
+            while measurements.len() < requests_per_sec * 20 {
 
                 // Open-loop latency-throughput test, parameterized by offered rate `ns_per_request`.
                 let elapsed = timer.elapsed();
@@ -106,13 +105,7 @@ fn main() {
                     request_counter += 1;
                 }
 
-                // Advance `input` as far as we can promise. 
-                // This *could* have been `index + ns_per_request * request_counter`, but that would have
-                // exploited our foreknowledge that inputs arrive at known rate; this is "more fair".
-                // input.advance_to(nanoseconds);
                 input.flush();
-
-                // Do one quantum of work
                 worker.step();
 
                 // Determine completed ns 
@@ -127,27 +120,9 @@ fn main() {
                     measurements.push(elapsed_ns - requested_at);
                 }
             }
-            
-            // input.close();
-            // while worker.step() {
 
-            //     // determine completed ns 
-            //     let acknowledged_ns: u64 = probe.with_frontier(|frontier| frontier[0].inner);
-
-            //     let elapsed = timer.elapsed();
-            //     let elapsed_ns = elapsed.as_secs() * 1_000_000_000 + (elapsed.subsec_nanos() as u64);
-
-            //     // any un-recorded measurements that are complete should be recorded.
-            //     while ((index + measurements.len() * ns_per_request) as u64) < acknowledged_ns {
-            //         let requested_at = (index + measurements.len() * ns_per_request) as u64;
-            //         measurements.push(elapsed_ns - requested_at);
-            //     }
-            // }
-
-            // for measurement in measurements {
-            //     println!("{}", measurement);
-            // }
-
+            measurements.truncate(requests_per_sec * 20);
+            measurements.drain(0 .. (requests_per_sec * 10));
             measurements.sort();
 
             let med = measurements[measurements.len() / 2];

--- a/examples/difference.rs
+++ b/examples/difference.rs
@@ -24,7 +24,7 @@ fn main() {
 
             // move `val` into the ring component.
             data.explode(|(x,y)| Some((x, DiffPair::new(y, 1))))
-                .consolidate_u();
+                .consolidate();
 
             input
         });

--- a/examples/reachability.rs
+++ b/examples/reachability.rs
@@ -102,9 +102,9 @@ where G::Timestamp: Lattice+Ord {
         let roots = roots.enter(&inner.scope());
 
         edges
-            .semijoin_u(&roots)
+            .semijoin(&roots)
             .map(|(_s,d)| d)
             .concat(&roots)
-            .distinct_u()
+            .distinct()
      })
 }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -3,9 +3,6 @@ name = "dd_server"
 version = "0.1.0"
 authors = ["Frank McSherry <fmcsherry@me.com>"]
 
-[dependencies.timely]
-git="https://github.com/frankmcsherry/timely-dataflow/"
-
 [dependencies.differential-dataflow]
 path="../"
 
@@ -13,3 +10,4 @@ path="../"
 rand="0.3.13"
 libloading="*"
 timely_communication="0.1.8"
+timely="0.3.0"

--- a/server/dataflows/degr_dist/src/lib.rs
+++ b/server/dataflows/degr_dist/src/lib.rs
@@ -15,8 +15,8 @@ pub fn build((dataflow, handles, probe, args): Environment) -> Result<(), String
         .get_mut::<TraceHandle>(&args[0])?
         .import(dataflow)
         .as_collection(|k,v| (k.item.clone(), v.clone()))
-        .map(|(src, _dst)| src as usize).count_total_u()
-        .map(|(_src, cnt)| cnt as usize).count_total_u()
+        .map(|(src, _dst)| src as usize).count_total()
+        .map(|(_src, cnt)| cnt as usize).count_total()
         .inspect(|x| println!("count: {:?}", x))
         .probe_with(probe);
 

--- a/server/dataflows/neighborhood/src/lib.rs
+++ b/server/dataflows/neighborhood/src/lib.rs
@@ -24,9 +24,9 @@ pub fn build((dataflow, handles, probe, args): Environment) -> Result<(), String
 
     query
         .map(|x| (x, x))
-        .arrange_by_key_u().join_core(&edges, |_n, &q, &d| Some((d, q)))
-        .arrange_by_key_u().join_core(&edges, |_n, &q, &d| Some((d, q)))
-        .arrange_by_key_u().join_core(&edges, |_n, &q, &d| Some((d, q)))
+        .arrange_by_key().join_core(&edges, |_n, &q, &d| Some((d, q)))
+        .arrange_by_key().join_core(&edges, |_n, &q, &d| Some((d, q)))
+        .arrange_by_key().join_core(&edges, |_n, &q, &d| Some((d, q)))
         .map(|x| x.1)
         .consolidate()
         .inspect(move |x| println!("{:?}:\t{:?}", timer.elapsed(), x))

--- a/server/dataflows/random_graph/Cargo.toml
+++ b/server/dataflows/random_graph/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Frank McSherry <fmcsherry@me.com>"]
 
 [dependencies]
-timely = { git = "https://github.com/frankmcsherry/timely-dataflow/" }
+timely = "0.3.0"
 differential-dataflow = { path = "../../../" }
 dd_server = { path = "../../" }
 rand="0.3.13"

--- a/server/dataflows/random_graph/src/lib.rs
+++ b/server/dataflows/random_graph/src/lib.rs
@@ -138,7 +138,7 @@ pub fn build((dataflow, handles, probe, args): Environment) -> Result<(), String
         })
         .probe_with(probe)
         .as_collection()
-        .arrange_by_key_u()
+        .arrange_by_key()
         .trace;
 
     handles.set::<TraceHandle>(name.to_owned(), trace);

--- a/server/dataflows/reachability/src/lib.rs
+++ b/server/dataflows/reachability/src/lib.rs
@@ -21,10 +21,10 @@ pub fn build((dataflow, handles, probe, args): Environment) -> Result<(), String
     roots.iterate(|dists| {
         let edges = edges.enter(&dists.scope());
         let roots = roots.enter(&dists.scope());
-        dists.arrange_by_self_u()
+        dists.arrange_by_self()
              .join_core(&edges, |_src, _, &dst| Some(dst))
              .concat(&roots)
-             .distinct_u()
+             .distinct()
     })
     .probe_with(probe);
 

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -11,16 +11,15 @@ use timely::dataflow::scopes::{Child, Root};
 use timely::dataflow::operators::probe::Handle as ProbeHandle;
 
 // stuff for talking about shared trace types ...
-use differential_dataflow::hashable::UnsignedWrapper;
 use differential_dataflow::operators::arrange::TraceAgent;
 use differential_dataflow::trace::implementations::spine::Spine;
 use differential_dataflow::trace::implementations::ord::OrdValBatch;
 
 // These are all defined here so that users can be assured a common layout.
 pub type RootTime = timely::progress::nested::product::Product<timely::progress::timestamp::RootTimestamp, usize>;
-type TraceBatch = OrdValBatch<UnsignedWrapper<usize>, usize, RootTime, isize>;
-type TraceSpine = Spine<UnsignedWrapper<usize>, usize, RootTime, isize, Rc<TraceBatch>>;
-pub type TraceHandle = TraceAgent<UnsignedWrapper<usize>, usize, RootTime, isize, TraceSpine>;
+type TraceBatch = OrdValBatch<usize, usize, RootTime, isize>;
+type TraceSpine = Spine<usize, usize, RootTime, isize, Rc<TraceBatch>>;
+pub type TraceHandle = TraceAgent<usize, usize, RootTime, isize, TraceSpine>;
 
 /// Arguments provided to each shared library to help build their dataflows and register their results.
 pub type Environment<'a, 'b> = (

--- a/src/operators/consolidate.rs
+++ b/src/operators/consolidate.rs
@@ -6,8 +6,7 @@
 //! underlying system can more clearly see that no work must be done in the later case, and we can
 //! drop out of, e.g. iterative computations.
 
-use timely::dataflow::*;
-use timely_sort::Unsigned;
+use timely::dataflow::Scope;
 
 use ::{Collection, Data, Diff, Hashable};
 use operators::arrange::ArrangeBySelf;
@@ -41,33 +40,6 @@ pub trait Consolidate<D: Data+Hashable> {
     /// }
     /// ```
     fn consolidate(&self) -> Self;
-    /// Aggregates the weights of equal records into at most one record.
-    ///
-    /// This method uses the type `D` itself to partition the data. The data are 
-    /// accumulated in place, each held back until their timestamp has completed.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// extern crate timely;
-    /// extern crate differential_dataflow;
-    ///
-    /// use differential_dataflow::input::Input;
-    /// use differential_dataflow::operators::Consolidate;
-    ///
-    /// fn main() {
-    ///     ::timely::example(|scope| {
-    ///
-    ///         let x = scope.new_collection_from(1 .. 10u32).1;
-    ///
-    ///         x.negate()
-    ///          .concat(&x)
-    ///          .consolidate_u() // <-- ensures cancellation occurs
-    ///          .assert_empty();
-    ///     });
-    /// }
-    /// ```    
-    fn consolidate_u(&self) -> Self where D: Unsigned+Copy;
 }
 
 impl<G: Scope, D, R> Consolidate<D> for Collection<G, D, R>
@@ -77,9 +49,6 @@ where
     G::Timestamp: ::lattice::Lattice+Ord,
  {
     fn consolidate(&self) -> Self {
-       self.arrange_by_self().as_collection(|d,_| d.item.clone())
-    }
-    fn consolidate_u(&self) -> Self where D: Unsigned+Copy {
-       self.arrange_by_self_u().as_collection(|d,_| d.item.clone())
+       self.arrange_by_self().as_collection(|d,_| d.clone())
     }
 }

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -7,7 +7,7 @@
 pub use self::group::{Group, Distinct, Count, consolidate_from};
 pub use self::consolidate::Consolidate;
 pub use self::iterate::Iterate;
-pub use self::join::{Join, JoinUnsigned, JoinCore};
+pub use self::join::{Join, JoinCore};
 pub use self::count::CountTotal;
 pub use self::distinct::DistinctTotal;
 

--- a/src/trace/implementations/hash.rs
+++ b/src/trace/implementations/hash.rs
@@ -51,9 +51,6 @@ where K: Clone+Default+HashOrdered+'static, V: Clone+Ord+'static, T: Lattice+Ord
 		};
 
 		(cursor, self.clone())
-		// HashValCursor {
-		// 	cursor: self.layer.cursor(OwningRef::new(self.clone()).map(|x| &x.layer).erase_owner()),
-		// }
 	}
 	fn len(&self) -> usize { <HashedLayer<K, OrderedLayer<V, OrderedLeaf<T, R>>> as Trie>::tuples(&self.layer) }
 	fn description(&self) -> &Description<T> { &self.desc }
@@ -88,26 +85,6 @@ where K: Clone+Default+HashOrdered+'static, V: Clone+Ord+'static, T: Lattice+Ord
 pub struct HashValCursor<V: Ord+Clone, T: Lattice+Ord+Clone, R: Diff> {
 	cursor: HashedCursor<OrderedLayer<V, OrderedLeaf<T, R>>>,
 }
-
-// impl<K: Clone+HashOrdered, V: Ord+Clone, T: Lattice+Ord+Clone, R: Copy> Cursor<K, V, T, R> for HashValCursor<K, V, T, R> {
-// 	fn key(&self) -> &K { &self.cursor.key() }
-// 	fn val(&self) -> &V { &self.cursor.child.key() }
-// 	fn map_times<L: FnMut(&T, R)>(&mut self, mut logic: L) {
-// 		self.cursor.child.child.rewind();
-// 		while self.cursor.child.child.valid() {
-// 			logic(&self.cursor.child.child.key().0, self.cursor.child.child.key().1);
-// 			self.cursor.child.child.step();
-// 		}
-// 	}
-// 	fn key_valid(&self) -> bool { self.cursor.valid() }
-// 	fn val_valid(&self) -> bool { self.cursor.child.valid() }
-// 	fn step_key(&mut self){ self.cursor.step(); }
-// 	fn seek_key(&mut self, key: &K) { self.cursor.seek(key); }
-// 	fn step_val(&mut self) { self.cursor.child.step(); }
-// 	fn seek_val(&mut self, val: &V) { self.cursor.child.seek(val); }
-// 	fn rewind_keys(&mut self) { self.cursor.rewind(); }
-// 	fn rewind_vals(&mut self) { self.cursor.child.rewind(); }
-// }
 
 impl<K, V, T, R> Cursor<K, V, T, R> for HashValCursor<V, T, R> 
 where K: Clone+HashOrdered, V: Ord+Clone, T: Lattice+Ord+Clone, R: Diff {
@@ -232,26 +209,6 @@ pub struct HashKeyCursor<T: Lattice+Ord+Clone, R: Diff> {
 	empty: (),
 	cursor: HashedCursor<OrderedLeaf<T, R>>,
 }
-
-// impl<K: Clone+HashOrdered, T: Lattice+Ord+Clone, R: Copy> Cursor<K, (), T, R> for HashKeyCursor<K, T, R> {
-// 	fn key(&self) -> &K { &self.cursor.key() }
-// 	fn val(&self) -> &() { &self.empty }
-// 	fn map_times<L: FnMut(&T, R)>(&mut self, mut logic: L) {
-// 		self.cursor.child.rewind();
-// 		while self.cursor.child.valid() {
-// 			logic(&self.cursor.child.key().0, self.cursor.child.key().1);
-// 			self.cursor.child.step();
-// 		}
-// 	}
-// 	fn key_valid(&self) -> bool { self.cursor.valid() }
-// 	fn val_valid(&self) -> bool { self.valid }
-// 	fn step_key(&mut self){ self.cursor.step(); self.valid = true; }
-// 	fn seek_key(&mut self, key: &K) { self.cursor.seek(key); self.valid = true; }
-// 	fn step_val(&mut self) { self.valid = false; }
-// 	fn seek_val(&mut self, _val: &()) { }
-// 	fn rewind_keys(&mut self) { self.cursor.rewind(); self.valid = true; }
-// 	fn rewind_vals(&mut self) { self.valid = true; }
-// }
 
 impl<K: Clone+HashOrdered, T: Lattice+Ord+Clone, R: Diff> Cursor<K, (), T, R> for HashKeyCursor<T, R> {
 

--- a/src/trace/implementations/merge_batcher.rs
+++ b/src/trace/implementations/merge_batcher.rs
@@ -86,7 +86,7 @@ where
         let mut builder_seal = B::Builder::new();
 
         // TODO: make this `clear()` when that lands.
-        self.frontier = Antichain::new();
+        self.frontier.clear();
 
         while self.sorted.len() > 1 {
             let batch1 = self.sorted.pop().unwrap();

--- a/src/trace/implementations/mod.rs
+++ b/src/trace/implementations/mod.rs
@@ -43,8 +43,8 @@ pub mod spine;
 mod radix_batcher;
 mod merge_batcher;
 
-pub use self::radix_batcher::RadixBatcher as Batcher;
-// pub use self::merge_batcher::MergeBatcher as Batcher;
+// pub use self::radix_batcher::RadixBatcher as Batcher;
+pub use self::merge_batcher::MergeBatcher as Batcher;
 
 pub mod ord;
 pub mod hash;

--- a/src/trace/implementations/ord.rs
+++ b/src/trace/implementations/ord.rs
@@ -22,7 +22,7 @@ use trace::{Batch, BatchReader, Builder, Cursor};
 use trace::description::Description;
 
 use super::spine::Spine;
-use super::Batcher;
+use super::merge_batcher::MergeBatcher;
 
 /// A trace implementation using a spine of hash-map batches.
 pub type OrdValSpine<K, V, T, R> = Spine<K, V, T, R, Rc<OrdValBatch<K, V, T, R>>>;
@@ -55,7 +55,7 @@ where K: Ord+Clone+'static, V: Ord+Clone+'static, T: Lattice+Ord+Clone+'static, 
 
 impl<K, V, T, R> Batch<K, V, T, R> for Rc<OrdValBatch<K, V, T, R>>
 where K: Ord+Clone+'static, V: Ord+Clone+'static, T: Lattice+Ord+Clone+::std::fmt::Debug+'static, R: Diff {
-	type Batcher = Batcher<K, V, T, R, Self>;
+	type Batcher = MergeBatcher<K, V, T, R, Self>;
 	type Builder = OrdValBuilder<K, V, T, R>;
 	fn merge(&self, other: &Self) -> Self {
 
@@ -289,7 +289,7 @@ where K: Ord+Clone+'static, T: Lattice+Ord+Clone+'static, R: Diff {
 
 impl<K, T, R> Batch<K, (), T, R> for Rc<OrdKeyBatch<K, T, R>>
 where K: Ord+Clone+'static, T: Lattice+Ord+Clone+'static, R: Diff {
-	type Batcher = Batcher<K, (), T, R, Self>;
+	type Batcher = MergeBatcher<K, (), T, R, Self>;
 	type Builder = OrdKeyBuilder<K, T, R>;
 	fn merge(&self, other: &Self) -> Self {
 

--- a/src/trace/layers/ordered.rs
+++ b/src/trace/layers/ordered.rs
@@ -92,21 +92,17 @@ impl<K: Ord+Clone, L: MergeBuilder> MergeBuilder for OrderedBuilder<K, L> {
 			vals: L::with_capacity(&other1.vals, &other2.vals),
 		}
 	}
+	#[inline(always)]
 	fn copy_range(&mut self, other: &Self::Trie, lower: usize, upper: usize) {
+		debug_assert!(lower < upper);
+		let other_basis = other.offs[lower];
+		let self_basis = self.offs.last().map(|&x| x).unwrap_or(0);
 
-		if lower < upper {
-			let other_basis = other.offs[lower];
-			let self_basis = self.offs.last().map(|&x| x).unwrap_or(0);
-
-			self.keys.extend_from_slice(&other.keys[lower .. upper]);
-			for index in lower .. upper {
-				self.offs.push((other.offs[index + 1] + self_basis) - other_basis);
-			}
-			self.vals.copy_range(&other.vals, other_basis, other.offs[upper]);
+		self.keys.extend_from_slice(&other.keys[lower .. upper]);
+		for index in lower .. upper {
+			self.offs.push((other.offs[index + 1] + self_basis) - other_basis);
 		}
-		else {
-			panic!("{}: lower !< upper: {}", lower, upper);
-		}
+		self.vals.copy_range(&other.vals, other_basis, other.offs[upper]);
 	}
 	fn push_merge(&mut self, other1: (&Self::Trie, usize, usize), other2: (&Self::Trie, usize, usize)) -> usize {
 		let (trie1, mut lower1, upper1) = other1;

--- a/src/trace/layers/ordered_leaf.rs
+++ b/src/trace/layers/ordered_leaf.rs
@@ -46,6 +46,7 @@ impl<K: Ord+Clone, R: Diff+Clone> MergeBuilder for OrderedLeafBuilder<K, R> {
             vals: Vec::with_capacity(<OrderedLeaf<K, R> as Trie>::keys(other1) + <OrderedLeaf<K, R> as Trie>::keys(other2)),
         }
     }
+    #[inline(always)]
     fn copy_range(&mut self, other: &Self::Trie, lower: usize, upper: usize) {
         self.vals.extend_from_slice(&other.vals[lower .. upper]);
     }

--- a/tpchlike/src/queries/query01.rs
+++ b/tpchlike/src/queries/query01.rs
@@ -54,6 +54,6 @@ pub fn query<G: Scope>(collections: &mut Collections<G>) -> ProbeHandle<G::Times
                 None
             }
         )
-        .count_total_u()
+        .count_total()
         .probe()
 }

--- a/tpchlike/src/queries/query02.rs
+++ b/tpchlike/src/queries/query02.rs
@@ -80,14 +80,14 @@ where G::Timestamp: Lattice+TotalOrder+Ord {
     collections
         .nations()
         .map(|x| (x.region_key, (x.nation_key, x.name)))
-        .semijoin_u(&regions)
+        .semijoin(&regions)
         .map(|(_region_key, (nation_key, name))| (nation_key, name));
 
     let suppliers = 
     collections
         .suppliers()
         .map(|x| (x.nation_key, (x.acctbal, x.name, x.address.to_string(), x.phone, x.comment.to_string(), x.supp_key)))
-        .semijoin_u(&nations.map(|x| x.0))
+        .semijoin(&nations.map(|x| x.0))
         .map(|(nat, (acc, nam, add, phn, com, key))| (key, (nat, acc, nam, add, phn, com)));
 
     let parts = 
@@ -99,19 +99,19 @@ where G::Timestamp: Lattice+TotalOrder+Ord {
     collections
         .partsupps()
         .map(|x| (x.supp_key, (x.part_key, x.supplycost)))
-        .semijoin_u(&suppliers.map(|x| x.0))
+        .semijoin(&suppliers.map(|x| x.0))
         .map(|(supp, (part, supply_cost))| (part, (supply_cost, supp)))
-        .semijoin_u(&parts.map(|x| x.0))
-        .group_u(|_x, s, t| {
+        .semijoin(&parts.map(|x| x.0))
+        .group(|_x, s, t| {
             let minimum = (s[0].0).0;
             t.extend(s.iter().take_while(|x| (x.0).0 == minimum).map(|&(&x,w)| (x,w)));
         });
 
     partsupps
-        .join_u(&parts)
+        .join(&parts)
         .map(|(part_key, (cost, supp), mfgr)| (supp, (cost, part_key, mfgr)))
-        .join_u(&suppliers)
+        .join(&suppliers)
         .map(|(_supp, (cost, part, mfgr), (nat, acc, nam, add, phn, com))| (nat, (cost, part, mfgr, acc, nam, add, phn, com)))
-        .join_u(&nations)
+        .join(&nations)
         .probe()
 }

--- a/tpchlike/src/queries/query03.rs
+++ b/tpchlike/src/queries/query03.rs
@@ -49,7 +49,7 @@ where G::Timestamp: Lattice+TotalOrder+Ord {
     let customers =
     collections
         .customers()
-        .flat_map(|c| if starts_with(&c.mktsegment[..], b"BUILDING") { Some(c.cust_key).into_iter() } else { None.into_iter() });
+        .flat_map(|c| if starts_with(&c.mktsegment[..], b"BUILDING") { Some(c.cust_key) } else { None });
 
     let lineitems = 
     collections
@@ -68,9 +68,9 @@ where G::Timestamp: Lattice+TotalOrder+Ord {
         .map(|o| (o.cust_key, (o.order_key, o.order_date, o.ship_priority)));
 
     orders
-        .semijoin_u(&customers)
+        .semijoin(&customers)
         .map(|(_, (order_key, order_date, ship_priority))| (order_key, (order_date, ship_priority)))
-        .semijoin_u(&lineitems)
+        .semijoin(&lineitems)
         .count_total()
         .probe()
 }

--- a/tpchlike/src/queries/query04.rs
+++ b/tpchlike/src/queries/query04.rs
@@ -45,12 +45,10 @@ use ::Collections;
 pub fn query<G: Scope>(collections: &mut Collections<G>) -> ProbeHandle<G::Timestamp> 
 where G::Timestamp: Lattice+TotalOrder+Ord {
 
-    println!("TODO: Q04 could use count_u for [u8;15] 'priority'");
-
     let lineitems = 
     collections
         .lineitems()
-        .flat_map(|l| if l.commit_date < l.receipt_date { Some((UnsignedWrapper::from(l.order_key), ())).into_iter() } else { None.into_iter() })
+        .flat_map(|l| if l.commit_date < l.receipt_date { Some((UnsignedWrapper::from(l.order_key), ())) } else { None })
         .arrange(DefaultKeyTrace::new())
         .group_arranged(|_k,_s,t| t.push(((), 1)), DefaultKeyTrace::new());
 

--- a/tpchlike/src/queries/query06.rs
+++ b/tpchlike/src/queries/query06.rs
@@ -28,16 +28,14 @@ use ::types::create_date;
 pub fn query<G: Scope>(collections: &mut Collections<G>) -> ProbeHandle<G::Timestamp> 
 where G::Timestamp: Lattice+TotalOrder+Ord {
 
-    println!("TODO: Q06 does a global aggregation with 0u8 as a key rather than ().");
-
     collections
         .lineitems()
         .explode(|x|
             if create_date(1994, 1, 1) <= x.ship_date && x.ship_date < create_date(1995, 1, 1) && 5 <= x.discount && x.discount < 7 && x.quantity < 24 {
-                Some((0u8, (x.extended_price * x.discount / 100) as isize))
+                Some(((), (x.extended_price * x.discount / 100) as isize))
             }
             else { None }
         )
-        .count_total_u()
+        .count_total()
         .probe()
 }

--- a/tpchlike/src/queries/query07.rs
+++ b/tpchlike/src/queries/query07.rs
@@ -74,21 +74,21 @@ where G::Timestamp: Lattice+TotalOrder+Ord {
     collections
         .customers()
         .map(|c| (c.nation_key, c.cust_key))
-        .join_u(&nations)
+        .join(&nations)
         .map(|(_nation_key, cust_key, name)| (cust_key, name));
 
     let orders = 
     collections
         .orders()
         .map(|o| (o.cust_key, o.order_key))
-        .join_u(&customers)
+        .join(&customers)
         .map(|(_cust_key, order_key, name)| (order_key, name));
 
     let suppliers = 
     collections
         .suppliers()
         .map(|s| (s.nation_key, s.supp_key))
-        .join_u(&nations)
+        .join(&nations)
         .map(|(_nation_key, supp_key, name)| (supp_key, name));
 
     collections
@@ -99,9 +99,9 @@ where G::Timestamp: Lattice+TotalOrder+Ord {
             }
             else { None }
         )
-        .join_u(&suppliers)
+        .join(&suppliers)
         .map(|(_supp_key, (order_key, ship_date), name_s)| (order_key, (ship_date, name_s)))
-        .join_u(&orders)
+        .join(&orders)
         .map(|(_order_key, (ship_date, name_s), name_c)| (name_s, name_c, ship_date >> 16))
         .filter(|x| x.0 != x.1)
         .count_total()

--- a/tpchlike/src/queries/query09.rs
+++ b/tpchlike/src/queries/query09.rs
@@ -66,17 +66,17 @@ where G::Timestamp: Lattice+TotalOrder+Ord {
     collections
         .lineitems()
         .map(|l| (l.part_key, (l.supp_key, l.order_key, l.extended_price * (100 - l.discount) / 100, l.quantity)))
-        .semijoin_u(&parts)
+        .semijoin(&parts)
         .map(|(part_key, (supp_key, order_key, revenue, quantity))| ((part_key, supp_key), (order_key, revenue, quantity)))
         .join(&collections.partsupps().map(|ps| ((ps.part_key, ps.supp_key), ps.supplycost)))
         .explode(|((_part_key, supp_key), (order_key, revenue, quantity), supplycost)|
             Some(((order_key, supp_key), ((revenue - supplycost * quantity) as isize)))
         )
-        .join_u(&collections.orders().map(|o| (o.order_key, o.order_date >> 16)))
+        .join(&collections.orders().map(|o| (o.order_key, o.order_date >> 16)))
         .map(|(_, supp_key, order_year)| (supp_key, order_year))
-        .join_u(&collections.suppliers().map(|s| (s.supp_key, s.nation_key)))
+        .join(&collections.suppliers().map(|s| (s.supp_key, s.nation_key)))
         .map(|(_, order_year, nation_key)| (nation_key, order_year))
-        .join_u(&collections.nations().map(|n| (n.nation_key, n.name)))
+        .join(&collections.nations().map(|n| (n.nation_key, n.name)))
         .count_total()
         .probe()
 }

--- a/tpchlike/src/queries/query10.rs
+++ b/tpchlike/src/queries/query10.rs
@@ -73,15 +73,15 @@ where G::Timestamp: Lattice+TotalOrder+Ord {
             }
             else { None }
         )
-        .semijoin_u(&lineitems)
+        .semijoin(&lineitems)
         .map(|(_, cust_key)| cust_key);
 
     collections
         .customers()
         .map(|c| (c.cust_key, (c.name.to_string(), c.phone, c.address.to_string(), c.comment.to_string(), c.nation_key)))
-        .semijoin_u(&orders)
+        .semijoin(&orders)
         .map(|(cust_key, (name, phn, addr, comm, nation_key))| (nation_key, (cust_key, name, phn, addr, comm)))
-        .join_u(&collections.nations().map(|n| (n.nation_key, n.name)))
+        .join(&collections.nations().map(|n| (n.nation_key, n.name)))
         .count_total()
         .probe()
 }

--- a/tpchlike/src/queries/query11.rs
+++ b/tpchlike/src/queries/query11.rs
@@ -49,8 +49,6 @@ fn starts_with(source: &[u8], query: &[u8]) -> bool {
 pub fn query<G: Scope>(collections: &mut Collections<G>) -> ProbeHandle<G::Timestamp> 
 where G::Timestamp: Lattice+TotalOrder+Ord {
 
-    println!("TODO: Q11 does a global aggregation with 0u8 as a key rather than ().");
-
     let nations =
     collections
         .nations()
@@ -61,19 +59,19 @@ where G::Timestamp: Lattice+TotalOrder+Ord {
     collections
         .suppliers()
         .map(|s| (s.nation_key, s.supp_key))
-        .semijoin_u(&nations)
+        .semijoin(&nations)
         .map(|s| s.1);
 
     collections
         .partsupps()
         .explode(|x| Some(((x.supp_key, x.part_key), (x.supplycost as isize) * (x.availqty as isize))))
-        .semijoin_u(&suppliers)
-        .map(|(_, part_key)| (0u8, part_key))
-        .group_u(|_part_key, s, t| {
+        .semijoin(&suppliers)
+        .map(|(_, part_key)| ((), part_key))
+        .group(|_part_key, s, t| {
             let threshold: isize = s.iter().map(|x| x.1 as isize).sum::<isize>() / 10000;
             t.extend(s.iter().filter(|x| x.1 > threshold).map(|&(&a,b)| (a, b)));
         })
         .map(|(_, part_key)| part_key)
-        .count_total_u()
+        .count_total()
         .probe()
 }

--- a/tpchlike/src/queries/query12.rs
+++ b/tpchlike/src/queries/query12.rs
@@ -79,7 +79,7 @@ where G::Timestamp: Lattice+TotalOrder+Ord {
         );
 
     orders
-        .join_u(&lineitems)
+        .join(&lineitems)
         .map(|(_order, _, ship_mode)| ship_mode)
         .count_total()
         .probe()

--- a/tpchlike/src/queries/query13.rs
+++ b/tpchlike/src/queries/query13.rs
@@ -54,8 +54,8 @@ where G::Timestamp: Lattice+TotalOrder+Ord {
         .customers()
         .map(|c| c.cust_key)
         .concat(&orders)
-        .count_total_u()
+        .count_total()
         .map(|(_cust_key, count)| (count-1) as usize)
-        .count_total_u()
+        .count_total()
         .probe()
 }

--- a/tpchlike/src/queries/query14.rs
+++ b/tpchlike/src/queries/query14.rs
@@ -52,8 +52,8 @@ where G::Timestamp: Lattice+TotalOrder+Ord {
     collections
         .parts()
         .explode(|p| Some(((p.part_key, ()), DiffPair::new(1, if starts_with(&p.typ.as_bytes(), b"PROMO") { 1 } else { 0 }))))
-        .semijoin_u(&lineitems)
+        .semijoin(&lineitems)
         .map(|(part_key, _)| part_key)
-        .count_total_u()
+        .count_total()
         .probe()
 }

--- a/tpchlike/src/queries/query16.rs
+++ b/tpchlike/src/queries/query16.rs
@@ -59,7 +59,7 @@ fn substring2(source: &[u8], query1: &[u8], query2: &[u8]) -> bool {
 pub fn query<G: Scope>(collections: &mut Collections<G>) -> ProbeHandle<G::Timestamp> 
 where G::Timestamp: Lattice+TotalOrder+Ord {
 
-    println!("TODO: query 16 could use a count_u if it joins after to re-collect its attributes");
+    println!("TODO: query 16 could use a count if it joins after to re-collect its attributes");
 
     let suppliers =
     collections
@@ -75,7 +75,7 @@ where G::Timestamp: Lattice+TotalOrder+Ord {
     let parts = collections
         .partsupps()
         .map(|ps| (ps.supp_key, ps.part_key))
-        .antijoin_u(&suppliers)
+        .antijoin(&suppliers)
         .map(|(_supp_key, part_key)| part_key);
 
     collections
@@ -86,7 +86,7 @@ where G::Timestamp: Lattice+TotalOrder+Ord {
             }
             else { None }
         )
-        .semijoin_u(&parts)
+        .semijoin(&parts)
         .count_total()
         .probe()
 }

--- a/tpchlike/src/queries/query17.rs
+++ b/tpchlike/src/queries/query17.rs
@@ -35,8 +35,6 @@ use ::Collections;
 pub fn query<G: Scope>(collections: &mut Collections<G>) -> ProbeHandle<G::Timestamp> 
 where G::Timestamp: Lattice+TotalOrder+Ord {
 
-    println!("TODO: Q17 gets a global count with key 0u8, rather than ().");
-
     let parts = 
     collections
         .parts()   // We fluff out search strings to have the right lengths. \\
@@ -50,8 +48,8 @@ where G::Timestamp: Lattice+TotalOrder+Ord {
     collections
         .lineitems()
         .map(|x| (x.part_key, (x.quantity, x.extended_price)))
-        .semijoin_u(&parts)
-        .group_u(|_k, s, t| {
+        .semijoin(&parts)
+        .group(|_k, s, t| {
 
             // determine the total and count of quantity.
             let total: i64 = s.iter().map(|x| (x.0).0).sum();
@@ -64,7 +62,7 @@ where G::Timestamp: Lattice+TotalOrder+Ord {
             t.extend(s.iter().filter(|&&(&(quantity,_),_)| quantity < threshold)
                              .map(|&(&(_,price),count)| (price, count)));
         })
-        .explode(|(_part, price)| Some((0u8, price as isize)))
-        .count_total_u()
+        .explode(|(_part, price)| Some(((), price as isize)))
+        .count_total()
         .probe()
 }

--- a/tpchlike/src/queries/query18.rs
+++ b/tpchlike/src/queries/query18.rs
@@ -76,6 +76,6 @@ where G::Timestamp: Lattice+TotalOrder+Ord {
             }
             else { None }
         )
-        .join_u(&collections.customers().map(|c| (c.cust_key, c.name.to_string())))
+        .join(&collections.customers().map(|c| (c.cust_key, c.name.to_string())))
         .probe()
 }

--- a/tpchlike/src/queries/query19.rs
+++ b/tpchlike/src/queries/query19.rs
@@ -80,14 +80,14 @@ where G::Timestamp: Lattice+TotalOrder+Ord {
     let parts2 = parts.filter(|&(_key, (brand, container, size))| starts_with(&brand, b"Brand#23") && 1 <= size && size <= 10 && (starts_with(&container, b"MED BAG") || starts_with(&container, b"MED BOX") || starts_with(&container, b"MED PKG") || starts_with(&container, b"MED PACK"))).map(|x| x.0);
     let parts3 = parts.filter(|&(_key, (brand, container, size))| starts_with(&brand, b"Brand#34") && 1 <= size && size <= 15 && (starts_with(&container, b"LG CASE") || starts_with(&container, b"LG BOX") || starts_with(&container, b"LG PACK") || starts_with(&container, b"LG PCG"))).map(|x| x.0);
 
-    let result1 = lines1.semijoin_u(&parts1);
-    let result2 = lines2.semijoin_u(&parts2);
-    let result3 = lines3.semijoin_u(&parts3);
+    let result1 = lines1.semijoin(&parts1);
+    let result2 = lines2.semijoin(&parts2);
+    let result3 = lines3.semijoin(&parts3);
 
     result1
         .concat(&result2)
         .concat(&result3)
         .map(|(x,_)| x)
-        .count_total_u()
+        .count_total()
         .probe()
 }

--- a/tpchlike/src/queries/query20.rs
+++ b/tpchlike/src/queries/query20.rs
@@ -77,7 +77,7 @@ where G::Timestamp: Lattice+TotalOrder+Ord {
             if l.ship_date >= create_date(1994, 1, 1) && l.ship_date < create_date(1995, 1, 1) { Some((l.part_key, (l.supp_key, l.quantity))) }
             else { None }
         )
-        .semijoin_u(&partkeys)
+        .semijoin(&partkeys)
         .explode(|l| Some(((UnsignedWrapper::from(((l.0 as u64) << 32) + (l.1).0 as u64), ()), (l.1).1 as isize)))
         .arrange(DefaultKeyTrace::new())
         .group_arranged(|_k,s,t| t.push((s[0].1, 1)), DefaultValTrace::new());
@@ -86,7 +86,7 @@ where G::Timestamp: Lattice+TotalOrder+Ord {
     collections
         .partsupps()
         .map(|ps| (ps.part_key, (ps.supp_key, ps.availqty)))
-        .semijoin_u(&partkeys)
+        .semijoin(&partkeys)
         .map(|(part_key, (supp_key, avail))| (UnsignedWrapper::from(((part_key as u64) << 32) + (supp_key as u64)), avail))
         .arrange(DefaultValTrace::new())
         .join_core(&available, |&key, &avail1, &avail2| 
@@ -101,8 +101,8 @@ where G::Timestamp: Lattice+TotalOrder+Ord {
     collections
         .suppliers()
         .map(|s| (s.supp_key, (s.name, s.address.to_string(), s.nation_key)))
-        .semijoin_u(&suppliers)
+        .semijoin(&suppliers)
         .map(|(_, (name, addr, nation))| (nation, (name, addr)))
-        .join_u(&nations)
+        .join(&nations)
         .probe()
 }


### PR DESCRIPTION
This PR is a work in progress, studying the possibility of replacing the `RadixBatcher` with a mergesort based `MergeBatcher`.

The `Batcher` types are ones that accept lumps of `Vec<(D, T, R)>` data, and are asked to "seal" batches up through some `upper: &[T]`. This is where the data are sorted and canonicalized and generally work is done to organize the representation of previously unordered data.

The `RadixBatcher` implementation uses radix sort, which (i) has a pretty decent throughput and (ii) leaves data in their `Vec<(D, T, R)>` form (rather than reallocating). On the downside, it (i) requires `D` elements provide a hash method and their `Ord` implementation respect it, (ii) it does most of its work in a large batch in `seal` making "spiky" work, and consequently (iii) it cannot collapse cancellations in place without additional mechanisms. Also, (iv) we need to post-process the radix sorted data with a sort over records with the same hash value, in case of key collision and also to order by value and time; for whatever reason `sort_unstable` is not great at this.

The `MergeBatcher` by comparison simplifies a bunch of these problems, at the cost of not being as awesome as radix sort. I'm going to enumerate some of the benefits, to think out whether it might be a good idea to switch over generally.

1. Merge sorting is generally simpler than radix sorting. We don't need to have hash values that haven't been tainted by partitioning, the hashing doesn't need to be repeatedly invoked (or cached) to ensure that we maintain the same order, and we don't need to do any finishing sorting to make sure we account for hash collision or multiple values and times with a key.

2. Merge sorting does its work as we receive data, which means that we have the opportunity to compact in place, maintaining a bounded footprint with respect to the compacted representation. This also means we are less likely to have big spikes of work, as the bulk of the `n log n` work happens on insertion, with `n` work at the moment of `seal`. It is also pretty easy to amortize the work of merging, if we would like a very smooth profile.

3. It feels like there is a quantum reduction in complexity, with for example the ability to remove the `_u` variants of operators (which were problematic in a few ways), and the removal of `HashOrdered` wrappers that frustrated the type system (e.g. that `Vec<(OrdWrapper<K>, ..>` is different from `Vec<(K, ..)>` and so required a copy).

The main downside that I foresee is that we could experience performance regressions in cases where the high throughput radix merging really helped. At the moment, on the problems I'm looking at, this is not currently a problem. It *was* a problem, but then some commits repaired that, and times now seem (marginally) better than their `RadixBatcher` equivalents. I'm going to try and report a bit on what I see performance-wise comparing the two, and I'll drop them in as comments here.