### PR TITLE
generalize distinct to threshold (WIP)

### DIFF
--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -4,12 +4,12 @@
 //! operators have specialized implementations to make them work efficiently, and are in addition 
 //! to several operations defined directly on the `Collection` type (e.g. `map` and `filter`).
 
-pub use self::group::{Group, Distinct, Count, consolidate_from};
+pub use self::group::{Group, Threshold, Count, consolidate_from};
 pub use self::consolidate::Consolidate;
 pub use self::iterate::Iterate;
 pub use self::join::{Join, JoinCore};
 pub use self::count::CountTotal;
-pub use self::distinct::DistinctTotal;
+pub use self::threshold::ThresholdTotal;
 
 pub mod arrange;
 pub mod group;
@@ -17,7 +17,7 @@ pub mod consolidate;
 pub mod iterate;
 pub mod join;
 pub mod count;
-pub mod distinct;
+pub mod threshold;
 // pub mod min;
 
 use ::Diff;

--- a/src/operators/threshold.rs
+++ b/src/operators/threshold.rs
@@ -16,7 +16,7 @@ use operators::arrange::{Arranged, ArrangeBySelf};
 use trace::{BatchReader, Cursor, TraceReader};
 
 /// Extension trait for the `distinct` differential dataflow method.
-pub trait DistinctTotal<G: Scope, K: Data, R: Diff> where G::Timestamp: TotalOrder+Lattice+Ord {
+pub trait ThresholdTotal<G: Scope, K: Data, R: Diff> where G::Timestamp: TotalOrder+Lattice+Ord {
     /// Reduces the collection to one occurrence of each distinct element.
     ///
     /// # Examples
@@ -26,7 +26,32 @@ pub trait DistinctTotal<G: Scope, K: Data, R: Diff> where G::Timestamp: TotalOrd
     /// extern crate differential_dataflow;
     ///
     /// use differential_dataflow::input::Input;
-    /// use differential_dataflow::operators::DistinctTotal;
+    /// use differential_dataflow::operators::ThresholdTotal;
+    ///
+    /// fn main() {
+    ///     ::timely::example(|scope| {
+    ///         // report the number of occurrences of each key
+    ///         scope.new_collection_from(1 .. 10).1
+    ///              .map(|x| x / 3)
+    ///              .threshold_total(|c| c % 2);
+    ///     });
+    /// }
+    /// ```
+    fn threshold_total<R2: Diff, F: Fn(R)->R2+'static>(&self, thresh: F) -> Collection<G, K, R2>;
+    /// Reduces the collection to one occurrence of each distinct element.
+    ///
+    /// This reduction only tests whether the weight associated with a record is non-zero, and otherwise
+    /// ignores its specific value. To take more general actions based on the accumulated weight, consider
+    /// the `threshold` method.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// extern crate timely;
+    /// extern crate differential_dataflow;
+    ///
+    /// use differential_dataflow::input::Input;
+    /// use differential_dataflow::operators::ThresholdTotal;
     ///
     /// fn main() {
     ///     ::timely::example(|scope| {
@@ -37,61 +62,33 @@ pub trait DistinctTotal<G: Scope, K: Data, R: Diff> where G::Timestamp: TotalOrd
     ///     });
     /// }
     /// ```
-    fn distinct_total(&self) -> Collection<G, K, isize>;
-}
-
-impl<G: Scope, K: Data+Hashable, R: Diff> DistinctTotal<G, K, R> for Collection<G, K, R>
-where G::Timestamp: TotalOrder+Lattice+Ord {
     fn distinct_total(&self) -> Collection<G, K, isize> {
-        self.arrange_by_self()
-            .distinct_total_core()
+        self.threshold_total(|c| if c.is_zero() { 0 } else { 1 })        
     }
 }
 
-
-/// Extension trait for the `distinct_total_core` differential dataflow method.
-pub trait DistinctTotalCore<G: Scope, K: Data, R: Diff> where G::Timestamp: TotalOrder+Lattice+Ord {
-    /// Applies `distinct` to arranged data, and returns a collection of output data.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// extern crate timely;
-    /// extern crate differential_dataflow;
-    ///
-    /// use differential_dataflow::input::Input;
-    /// use differential_dataflow::operators::arrange::Arrange;
-    /// use differential_dataflow::operators::distinct::DistinctTotalCore;
-    /// use differential_dataflow::trace::Trace;
-    /// use differential_dataflow::trace::implementations::ord::OrdKeySpine;
-    /// use differential_dataflow::hashable::OrdWrapper;
-    ///
-    /// fn main() {
-    ///     ::timely::example(|scope| {
-    ///
-    ///         // wrap and order input, then group manually.
-    ///         scope.new_collection_from(1 .. 10u32).1
-    ///              .map(|x| (OrdWrapper { item: x / 3 }, ()))
-    ///              .arrange(OrdKeySpine::new())
-    ///              .distinct_total_core();
-    ///     });
-    /// }    
-    /// ```
-    fn distinct_total_core(&self) -> Collection<G, K, isize>;
+impl<G: Scope, K: Data+Hashable, R: Diff> ThresholdTotal<G, K, R> for Collection<G, K, R>
+where G::Timestamp: TotalOrder+Lattice+Ord {
+    fn threshold_total<R2: Diff, F: Fn(R)->R2+'static>(&self, thresh: F) -> Collection<G, K, R2> {
+        self.arrange_by_self()
+            .threshold_total(thresh)
+    }
 }
 
-impl<G: Scope, K: Data, R: Diff, T1> DistinctTotalCore<G, K, R> for Arranged<G, K, (), R, T1>
+impl<G: Scope, K: Data, R: Diff, T1> ThresholdTotal<G, K, R> for Arranged<G, K, (), R, T1>
 where 
     G::Timestamp: TotalOrder+Lattice+Ord,
     T1: TraceReader<K, (), G::Timestamp, R>+Clone+'static,
     T1::Batch: BatchReader<K, (), G::Timestamp, R> {
 
-    fn distinct_total_core(&self) -> Collection<G, K, isize> {
+    fn threshold_total<R2: Diff, F:Fn(R)->R2+'static>(&self, thresh: F) -> Collection<G, K, R2> {
 
         let mut trace = self.trace.clone();
 
-        self.stream.unary_stream(Pipeline, "DistinctTotal", move |input, output| {
+        self.stream.unary_stream(Pipeline, "ThresholdTotal", move |input, output| {
 
+            let thresh = &thresh;
+    
             input.for_each(|capability, batches| {
 
                 let mut session = output.session(&capability);
@@ -110,18 +107,15 @@ where
                             trace_cursor.map_times(&trace_storage, |_, diff| count = count + diff);
                         }
 
-                        // Take into account the current batch. At each time, check whether the
-                        // "presence" of the key changes. If it was previously present (i.e. had
-                        // nonzero multiplicity) but now is no more, emit -1. Conversely, if it is
-                        // newly present, emit +1. In both remaining cases, the result remains
-                        // unchanged (note that this is better than the naive approach which would
-                        // eliminate the "previous" record and immediately re-add it).
+                        // Apply `thresh` both before and after `diff` is applied to `count`.
+                        // If the result is non-zero, send it along.
                         batch_cursor.map_times(&batch_storage, |time, diff| {
-                            let old_distinct = !count.is_zero();
+                            let old_weight = thresh(count);
                             count = count + diff;
-                            let new_distinct = !count.is_zero();
-                            if old_distinct != new_distinct {
-                                session.give((key.clone(), time.clone(), if old_distinct { -1 } else { 1 }));
+                            let new_weight = thresh(count);
+                            let difference = new_weight - old_weight;
+                            if !difference.is_zero() {
+                                session.give((key.clone(), time.clone(), difference));
                             }
                         });
 

--- a/tpchlike/src/queries/query21.rs
+++ b/tpchlike/src/queries/query21.rs
@@ -3,7 +3,7 @@ use timely::dataflow::*;
 use timely::dataflow::operators::probe::Handle as ProbeHandle;
 
 use differential_dataflow::operators::*;
-use differential_dataflow::operators::distinct::DistinctTotal;
+use differential_dataflow::operators::ThresholdTotal;
 use differential_dataflow::lattice::Lattice;
 
 use ::Collections;

--- a/tpchlike/src/queries/query22.rs
+++ b/tpchlike/src/queries/query22.rs
@@ -5,7 +5,7 @@ use timely::dataflow::operators::probe::Handle as ProbeHandle;
 use differential_dataflow::operators::*;
 use differential_dataflow::difference::DiffPair;
 use differential_dataflow::operators::group::GroupArranged;
-use differential_dataflow::operators::distinct::DistinctTotal;
+use differential_dataflow::operators::ThresholdTotal;
 use differential_dataflow::lattice::Lattice;
 
 use differential_dataflow::trace::Trace;


### PR DESCRIPTION
This PR generalizes the `distinct` operator to `threshold`, which allows one to specify an arbitrary function from the input difference type `R1` to a possibly different output difference type `R2`. 

```rust
fn threshold<R2: Diff, F: Fn(R1)->R2+'static>(&self, thresh: F) -> Collection<G, K, R2>;
```

In the case of distinct, there is a fairly simple default implementation in terms of threshold

```rust
fn distinct(&self) -> Collection<G, K, isize> {
    self.threshold(|c| if c.is_zero() { 0 } else { 1 })
}
```

However, threshold is more general, and allows one to write various operators that are useful in e.g. k-core computation (with a threshold of `k`) and at least TPCH query 18, where one wants to retain customers with at least 300 ordered items.

This PR also simplifies the `ThresholdTotal` trait (previously `DistinctTotal`), implementing it for both collections and arrangements, meaning we can avoid a `ThresholdTotalCore` trait.