### PR TITLE
remove Clone requirement for BatchReader

### DIFF
--- a/src/trace/implementations/ord.rs
+++ b/src/trace/implementations/ord.rs
@@ -42,12 +42,6 @@ pub struct OrdValBatch<K: Ord, V: Ord, T: Lattice, R> {
 	pub desc: Description<T>,
 }
 
-impl<K: Ord, V: Ord, T: Lattice, R> Clone for OrdValBatch<K, V, T, R> {
-	fn clone(&self) -> Self {
-		panic!("Error: In OrdValBatch::clone()");
-	}
-}
-
 impl<K, V, T, R> BatchReader<K, V, T, R> for OrdValBatch<K, V, T, R>
 where K: Ord+Clone+'static, V: Ord+Clone+'static, T: Lattice+Ord+Clone+'static, R: Diff {
 	type Cursor = OrdValCursor<V, T, R>;
@@ -338,12 +332,6 @@ pub struct OrdKeyBatch<K: Ord, T: Lattice, R> {
 	pub layer: OrderedLayer<K, OrderedLeaf<T, R>>,
 	/// Description of the update times this layer represents.
 	pub desc: Description<T>,
-}
-
-impl<K: Ord, T: Lattice, R> Clone for OrdKeyBatch<K, T, R> {
-	fn clone(&self) -> Self {
-		panic!("Error: In OrdKeyBatch::clone()");
-	}
 }
 
 impl<K, T, R> BatchReader<K, (), T, R> for OrdKeyBatch<K, T, R>

--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -136,7 +136,7 @@ pub trait Trace<Key, Val, Time, R> : TraceReader<Key, Val, Time, R> where <Self 
 /// but do not expose ways to construct the batches. This trait is appropriate for views of the batch, and is
 /// especially useful for views derived from other sources in ways that prevent the construction of batches
 /// from the type of data in the view (for example, filtered views, or views with extended time coordinates).
-pub trait BatchReader<K, V, T, R> where Self: Clone+::std::marker::Sized 
+pub trait BatchReader<K, V, T, R> where Self: ::std::marker::Sized 
 {
 	/// The type used to enumerate the batch's contents.
 	type Cursor: Cursor<K, V, T, R, Storage=Self>;


### PR DESCRIPTION
This is no longer necessary, right?