### PR TITLE
Progressive merging check in

### DIFF
--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -247,7 +247,7 @@ pub trait Merger<K, V, T, R, Output: Batch<K, V, T, R>> {
 	///
 	/// If `fuel` is non-zero after the call, the merging is complete and
 	/// one should call `done` to extract the merged results.
-	fn work(&mut self, source1: &Output, source2: &Output, fuel: &mut usize);
+	fn work(&mut self, source1: &Output, source2: &Output, frontier: &Option<Vec<T>>, fuel: &mut usize);
 	/// Extracts merged results.
 	///
 	/// This method should only be called after `work` has been called and
@@ -374,7 +374,7 @@ pub mod rc_blanket_impls {
 
 	/// Represents a merge in progress.
 	impl<K,V,T,R,B:Batch<K,V,T,R>> Merger<K, V, T, R, Rc<B>> for RcMerger<K,V,T,R,B> {
-		fn work(&mut self, source1: &Rc<B>, source2: &Rc<B>, fuel: &mut usize) { self.merger.work(source1, source2, fuel) }
+		fn work(&mut self, source1: &Rc<B>, source2: &Rc<B>, frontier: &Option<Vec<T>>, fuel: &mut usize) { self.merger.work(source1, source2, frontier, fuel) }
 		fn done(self) -> Rc<B> { Rc::new(self.merger.done()) }
 	}
 }


### PR DESCRIPTION
This PR adds support for progressive `advance_by` as part of merging. This changes the signature of

```rust
Merger::work
```

to include a `frontier: &Option<Vec<T>>`, which allows for the optional specification of a frontier to use for advancing as part of the merge.

This also results in a fair bit of code duplication, because the current mergers need the same logic as exists for `advance_mut`. I suspect that in the fullness of time, `advance_mut` will be retired in preference for using progressive mergers (even if with a large amount of fuel).

The default is still the non-progressive merging, until various performance kinks get sorted out.