### PR TITLE
Abomonation support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ itertools="^0.6"
 
 [dependencies]
 abomonation = { git = "https://github.com/frankmcsherry/abomonation" }
+abomonation_derive = { git = "https://github.com/mystor/abomonation_derive" }
 timely_sort="0.1.6"
 timely_communication = { git = "https://github.com/frankmcsherry/timely-dataflow" }
 timely = { git = "https://github.com/frankmcsherry/timely-dataflow" }

--- a/examples/arrange.rs
+++ b/examples/arrange.rs
@@ -8,12 +8,14 @@ use rand::{Rng, SeedableRng, StdRng};
 
 use differential_dataflow::input::Input;
 use differential_dataflow::AsCollection;
-use differential_dataflow::operators::arrange::ArrangeByKey;
+use differential_dataflow::operators::arrange::{Arrange, ArrangeByKey};
 use differential_dataflow::operators::group::Group;
 use differential_dataflow::operators::join::JoinCore;
 use differential_dataflow::operators::Iterate;
 use differential_dataflow::operators::Consolidate;
 
+use differential_dataflow::trace::Trace;
+use differential_dataflow::trace::implementations::ord::OrdValSpineAbom;
 
 // use differential_dataflow::trace::implementations::ord::OrdValSpine;
 // use differential_dataflow::trace::{Cursor, Trace};
@@ -97,7 +99,8 @@ fn main() {
             })
             .probe_with(&mut probe)
             .as_collection()
-            .arrange_by_key()
+            // .arrange_by_key()
+            .arrange(OrdValSpineAbom::new())
             .trace
         });
 
@@ -140,11 +143,8 @@ fn main() {
             let (input, query) = scope.new_collection();
 
             query.map(|x| (x, x))
-                 .arrange_by_key()
                  .join_core(&edges, |_n, &q, &d| Some((d, q)))
-                 .arrange_by_key()
                  .join_core(&edges, |_n, &q, &d| Some((d, q)))
-                 .arrange_by_key()
                  .join_core(&edges, |_n, &q, &d| Some((d, q)))
                  .filter(move |_| inspect)
                  .map(|x| x.1)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,9 @@ extern crate fnv;
 extern crate timely;
 extern crate timely_sort;
 extern crate timely_communication;
+
+#[macro_use]
+extern crate abomonation_derive;
 extern crate abomonation;
 
 pub mod hashable;

--- a/src/trace/description.rs
+++ b/src/trace/description.rs
@@ -62,7 +62,7 @@
 /// frontier indicates a moment at which the times were observed. If `since` is strictly in 
 /// advance of `lower`, the contained times may be "advanced" to times which appear equivalent to
 /// any time after `since`.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Abomonation)]
 pub struct Description<Time> {
 	/// lower frontier of contained updates.
 	lower: Vec<Time>,

--- a/src/trace/implementations/ord.rs
+++ b/src/trace/implementations/ord.rs
@@ -27,19 +27,23 @@ use super::spine::Spine;
 // use super::spine_fueled::Spine;
 use super::merge_batcher::MergeBatcher;
 
-// use abomonation::abomonated::Abomonated;
+use abomonation::abomonated::Abomonated;
 
-/// A trace implementation using a spine of hash-map batches.
+/// A trace implementation using a spine of ordered lists.
 pub type OrdValSpine<K, V, T, R> = Spine<K, V, T, R, Rc<OrdValBatch<K, V, T, R>>>;
-// pub type OrdValSpine<K, V, T, R> = Spine<K, V, T, R, Rc<Abomonated<OrdValBatch<K, V, T, R>, Vec<u8>>>>;
 
-/// A trace implementation for empty values using a spine of hash-map batches.
+/// A trace implementation using a spine of abomonated ordered lists.
+pub type OrdValSpineAbom<K, V, T, R> = Spine<K, V, T, R, Rc<Abomonated<OrdValBatch<K, V, T, R>, Vec<u8>>>>;
+
+/// A trace implementation for empty values using a spine of ordered lists.
 pub type OrdKeySpine<K, T, R> = Spine<K, (), T, R, Rc<OrdKeyBatch<K, T, R>>>;
-// pub type OrdKeySpine<K, T, R> = Spine<K, (), T, R, Rc<Abomonated<OrdKeyBatch<K, T, R>, Vec<u8>>>>;
+
+/// A trace implementation for empty values using a spine of abomonated ordered lists.
+pub type OrdKeySpineAbom<K, T, R> = Spine<K, (), T, R, Rc<Abomonated<OrdKeyBatch<K, T, R>, Vec<u8>>>>;
 
 
 /// An immutable collection of update tuples, from a contiguous interval of logical times.
-#[derive(Debug)]
+#[derive(Debug, Abomonation)]
 pub struct OrdValBatch<K: Ord, V: Ord, T: Lattice, R> {
 	/// Where all the dataz is.
 	pub layer: OrderedLayer<K, OrderedLayer<V, OrderedLeaf<T, R>>>,
@@ -448,7 +452,7 @@ where K: Ord+Clone+'static, V: Ord+Clone+'static, T: Lattice+Ord+Clone+::std::fm
 
 
 /// An immutable collection of update tuples, from a contiguous interval of logical times.
-#[derive(Debug)]
+#[derive(Debug, Abomonation)]
 pub struct OrdKeyBatch<K: Ord, T: Lattice, R> {
 	/// Where all the dataz is.
 	pub layer: OrderedLayer<K, OrderedLeaf<T, R>>,

--- a/src/trace/layers/ordered.rs
+++ b/src/trace/layers/ordered.rs
@@ -5,7 +5,7 @@ use super::{Trie, Cursor, Builder, MergeBuilder, TupleBuilder};
 /// A level of the trie, with keys and offsets into a lower layer.
 ///
 /// In this representation, the values for `keys[i]` are found at `vals[offs[i] .. offs[i+1]]`.
-#[derive(Debug, Eq, PartialEq, Clone)]
+#[derive(Debug, Eq, PartialEq, Clone, Abomonation)]
 pub struct OrderedLayer<K: Ord, L> {
 	/// The keys of the layer.
 	pub keys: Vec<K>,

--- a/src/trace/layers/ordered_leaf.rs
+++ b/src/trace/layers/ordered_leaf.rs
@@ -5,7 +5,7 @@ use difference::Diff;
 use super::{Trie, Cursor, Builder, MergeBuilder, TupleBuilder};
 
 /// A layer of unordered values. 
-#[derive(Debug, Eq, PartialEq, Clone)]
+#[derive(Debug, Eq, PartialEq, Clone, Abomonation)]
 pub struct OrderedLeaf<K, R> {
     /// Unordered values.
     pub vals: Vec<(K, R)>,


### PR DESCRIPTION
This PR introduces derived `Abomonation` implementations for batch layers and batches, which should enable the use of `Abomonated<B, _>` as a batch implementor. This is mostly just adding the `abomonation_derive` crate, adding `Abomonation` to the list of derived traits, and tweaking the `examples/arrange.rs` example to test it out.

@utaal 