### PR TITLE
new cursor_list

### DIFF
--- a/src/operators/group.rs
+++ b/src/operators/group.rs
@@ -28,7 +28,7 @@ use timely::dataflow::operators::Capability;
 use operators::arrange::{Arranged, ArrangeByKey, ArrangeBySelf, BatchWrapper, TraceAgent};
 use lattice::Lattice;
 use trace::{Batch, BatchReader, Cursor, Trace, Builder};
-use trace::cursor::cursor_list::CursorList;
+use trace::cursor::CursorList;
 // use trace::implementations::hash::HashValSpine as DefaultValTrace;
 // use trace::implementations::hash::HashKeySpine as DefaultKeyTrace;
 use trace::implementations::ord::OrdValSpine as DefaultValTrace;

--- a/src/trace/cursor/cursor_list_neu.rs
+++ b/src/trace/cursor/cursor_list_neu.rs
@@ -8,160 +8,160 @@ use super::Cursor;
 /// the minimum key and minimum value. It performs no clever management of these sets otherwise.
 #[derive(Debug)]
 pub struct CursorList<K, V, T, R, C: Cursor<K, V, T, R>> {
-	_phantom: ::std::marker::PhantomData<(K, V, T, R)>,
-	cursors: Vec<C>,
-	min_key: Vec<usize>,
-	min_val: Vec<usize>,
+    _phantom: ::std::marker::PhantomData<(K, V, T, R)>,
+    cursors: Vec<C>,
+    min_key: Vec<usize>,
+    min_val: Vec<usize>,
 }
 
 impl<K, V, T, R, C: Cursor<K, V, T, R>> CursorList<K, V, T, R, C> where K: Ord, V: Ord {
-	/// Creates a new cursor list from pre-existing cursors.
-	pub fn new(cursors: Vec<C>, storage: &Vec<C::Storage>) -> Self {
+    /// Creates a new cursor list from pre-existing cursors.
+    pub fn new(cursors: Vec<C>, storage: &Vec<C::Storage>) -> Self {
 
-		let mut result = CursorList {
-			_phantom: ::std::marker::PhantomData,
-			cursors: cursors.into_iter().collect(),
-			min_key: Vec::new(),
-			min_val: Vec::new(),
-		};
+        let mut result = CursorList {
+            _phantom: ::std::marker::PhantomData,
+            cursors: cursors.into_iter().collect(),
+            min_key: Vec::new(),
+            min_val: Vec::new(),
+        };
 
-		result.minimize_keys(storage);
-		result
-	}
+        result.minimize_keys(storage);
+        result
+    }
 
-	// Initialize min_key with the indices of cursors with the minimum key.
-	fn minimize_keys(&mut self, storage: &Vec<C::Storage>) {
+    // Initialize min_key with the indices of cursors with the minimum key.
+    fn minimize_keys(&mut self, storage: &Vec<C::Storage>) {
 
-		self.min_key.clear();
+        self.min_key.clear();
 
-		// Determine the index of the cursor with minimum key.
-		let mut min_key_index: Option<usize> = None;
-		for (index, cursor) in self.cursors.iter().enumerate() {
-			if cursor.key_valid(&storage[index]) {
-				if let Some(min_index) = min_key_index {
-					if cursor.key(&storage[index]).lt(self.cursors[min_index].key(&storage[min_index])) {
-						min_key_index = Some(index);
-					}
-				}
-				else {
-					min_key_index = Some(index);
-				}
-			}
-		}
-		// Install each index with equal key.
-		if let Some(min_index) = min_key_index {
-			for (index, cursor) in self.cursors.iter().enumerate() {
-				if cursor.key_valid(&storage[index]) {
-					if cursor.key(&storage[index]).eq(self.cursors[min_index].key(&storage[min_index])) {
-						self.min_key.push(index);
-					}
-				}
-			}
-		}
+        // Determine the index of the cursor with minimum key.
+        let mut min_key_index: Option<usize> = None;
+        for (index, cursor) in self.cursors.iter().enumerate() {
+            if cursor.key_valid(&storage[index]) {
+                if let Some(min_index) = min_key_index {
+                    if cursor.key(&storage[index]).lt(self.cursors[min_index].key(&storage[min_index])) {
+                        min_key_index = Some(index);
+                    }
+                }
+                else {
+                    min_key_index = Some(index);
+                }
+            }
+        }
+        // Install each index with equal key.
+        if let Some(min_index) = min_key_index {
+            for (index, cursor) in self.cursors.iter().enumerate() {
+                if cursor.key_valid(&storage[index]) {
+                    if cursor.key(&storage[index]).eq(self.cursors[min_index].key(&storage[min_index])) {
+                        self.min_key.push(index);
+                    }
+                }
+            }
+        }
 
-		self.minimize_vals(storage);
-	}
+        self.minimize_vals(storage);
+    }
 
-	// Initialize min_val with the indices of minimum key cursors with the minimum value.
-	fn minimize_vals(&mut self, storage: &Vec<C::Storage>) {
+    // Initialize min_val with the indices of minimum key cursors with the minimum value.
+    fn minimize_vals(&mut self, storage: &Vec<C::Storage>) {
 
-		self.min_val.clear();
+        self.min_val.clear();
 
-		// Determine the index of the cursor with minimum value.
-		let mut min_val_index: Option<usize> = None;
-		for &index in self.min_key.iter() {
-			if self.cursors[index].val_valid(&storage[index]) {
-				if let Some(min_index) = min_val_index {
-					if self.cursors[index].val(&storage[index]).lt(self.cursors[min_index].val(&storage[min_index])) {
-						min_val_index = Some(index);
-					}
-				}
-				else {
-					min_val_index = Some(index);
-				}
-			}
-		}
-		// Install each index with equal value.
-		if let Some(min_index) = min_val_index {
-			for &index in self.min_key.iter() {
-				if self.cursors[index].val_valid(&storage[index]) {
-					if self.cursors[index].val(&storage[index]).eq(self.cursors[min_index].val(&storage[min_index])) {
-						self.min_val.push(index);
-					}
-				}
-			}
-		}
-	}
+        // Determine the index of the cursor with minimum value.
+        let mut min_val_index: Option<usize> = None;
+        for &index in self.min_key.iter() {
+            if self.cursors[index].val_valid(&storage[index]) {
+                if let Some(min_index) = min_val_index {
+                    if self.cursors[index].val(&storage[index]).lt(self.cursors[min_index].val(&storage[min_index])) {
+                        min_val_index = Some(index);
+                    }
+                }
+                else {
+                    min_val_index = Some(index);
+                }
+            }
+        }
+        // Install each index with equal value.
+        if let Some(min_index) = min_val_index {
+            for &index in self.min_key.iter() {
+                if self.cursors[index].val_valid(&storage[index]) {
+                    if self.cursors[index].val(&storage[index]).eq(self.cursors[min_index].val(&storage[min_index])) {
+                        self.min_val.push(index);
+                    }
+                }
+            }
+        }
+    }
 }
 
 impl<K, V, T, R, C: Cursor<K, V, T, R>> Cursor<K, V, T, R> for CursorList<K, V, T, R, C>
 where
-	K: Ord,
-	V: Ord {
+    K: Ord,
+    V: Ord {
 
-	type Storage = Vec<C::Storage>;
+    type Storage = Vec<C::Storage>;
 
-	// validation methods
-	fn key_valid(&self, _storage: &Self::Storage) -> bool { !self.min_key.is_empty() }
-	fn val_valid(&self, _storage: &Self::Storage) -> bool { !self.min_val.is_empty() }
+    // validation methods
+    fn key_valid(&self, _storage: &Self::Storage) -> bool { !self.min_key.is_empty() }
+    fn val_valid(&self, _storage: &Self::Storage) -> bool { !self.min_val.is_empty() }
 
-	// accessors
-	fn key<'a>(&self, storage: &'a Self::Storage) -> &'a K {
-		debug_assert!(self.key_valid(storage));
-		assert!(self.cursors[self.min_key[0]].key_valid(&storage[self.min_key[0]]));
-		self.cursors[self.min_key[0]].key(&storage[self.min_key[0]])
-	}
-	fn val<'a>(&self, storage: &'a Self::Storage) -> &'a V {
-		debug_assert!(self.key_valid(storage));
-		debug_assert!(self.val_valid(storage));
-		assert!(self.cursors[self.min_val[0]].val_valid(&storage[self.min_val[0]]));
-		self.cursors[self.min_val[0]].val(&storage[self.min_val[0]])
-	}
-	fn map_times<L: FnMut(&T, R)>(&mut self, storage: &Self::Storage, mut logic: L) {
-		for &index in self.min_val.iter() {
-			self.cursors[index].map_times(&storage[index], |t,d| logic(t,d));
-		}
-	}
+    // accessors
+    fn key<'a>(&self, storage: &'a Self::Storage) -> &'a K {
+        debug_assert!(self.key_valid(storage));
+        assert!(self.cursors[self.min_key[0]].key_valid(&storage[self.min_key[0]]));
+        self.cursors[self.min_key[0]].key(&storage[self.min_key[0]])
+    }
+    fn val<'a>(&self, storage: &'a Self::Storage) -> &'a V {
+        debug_assert!(self.key_valid(storage));
+        debug_assert!(self.val_valid(storage));
+        assert!(self.cursors[self.min_val[0]].val_valid(&storage[self.min_val[0]]));
+        self.cursors[self.min_val[0]].val(&storage[self.min_val[0]])
+    }
+    fn map_times<L: FnMut(&T, R)>(&mut self, storage: &Self::Storage, mut logic: L) {
+        for &index in self.min_val.iter() {
+            self.cursors[index].map_times(&storage[index], |t,d| logic(t,d));
+        }
+    }
 
-	// key methods
-	fn step_key(&mut self, storage: &Self::Storage) {
-		for &index in self.min_key.iter() {
-			self.cursors[index].step_key(&storage[index]);
-		}
-		self.minimize_keys(storage);
-	}
-	fn seek_key(&mut self, storage: &Self::Storage, key: &K) {
-		for index in 0 .. self.cursors.len() {
-			self.cursors[index].seek_key(&storage[index], key);
-		}
-		self.minimize_keys(storage);
-	}
+    // key methods
+    fn step_key(&mut self, storage: &Self::Storage) {
+        for &index in self.min_key.iter() {
+            self.cursors[index].step_key(&storage[index]);
+        }
+        self.minimize_keys(storage);
+    }
+    fn seek_key(&mut self, storage: &Self::Storage, key: &K) {
+        for index in 0 .. self.cursors.len() {
+            self.cursors[index].seek_key(&storage[index], key);
+        }
+        self.minimize_keys(storage);
+    }
 
-	// value methods
-	fn step_val(&mut self, storage: &Self::Storage) {
-		for &index in self.min_val.iter() {
-			self.cursors[index].step_val(&storage[index]);
-		}
-		self.minimize_vals(storage);
-	}
-	fn seek_val(&mut self, storage: &Self::Storage, val: &V) {
-		for &index in self.min_key.iter() {
-			self.cursors[index].seek_val(&storage[index], val);
-		}
-		self.minimize_vals(storage);
-	}
+    // value methods
+    fn step_val(&mut self, storage: &Self::Storage) {
+        for &index in self.min_val.iter() {
+            self.cursors[index].step_val(&storage[index]);
+        }
+        self.minimize_vals(storage);
+    }
+    fn seek_val(&mut self, storage: &Self::Storage, val: &V) {
+        for &index in self.min_key.iter() {
+            self.cursors[index].seek_val(&storage[index], val);
+        }
+        self.minimize_vals(storage);
+    }
 
-	// rewinding methods
-	fn rewind_keys(&mut self, storage: &Self::Storage) {
-		for index in 0 .. self.cursors.len() {
-			self.cursors[index].rewind_keys(&storage[index]);
-		}
-		self.minimize_keys(storage);
-	}
-	fn rewind_vals(&mut self, storage: &Self::Storage) {
-		for &index in self.min_key.iter() {
-			self.cursors[index].rewind_vals(&storage[index]);
-		}
-		self.minimize_vals(storage);
-	}
+    // rewinding methods
+    fn rewind_keys(&mut self, storage: &Self::Storage) {
+        for index in 0 .. self.cursors.len() {
+            self.cursors[index].rewind_keys(&storage[index]);
+        }
+        self.minimize_keys(storage);
+    }
+    fn rewind_vals(&mut self, storage: &Self::Storage) {
+        for &index in self.min_key.iter() {
+            self.cursors[index].rewind_vals(&storage[index]);
+        }
+        self.minimize_vals(storage);
+    }
 }

--- a/src/trace/cursor/cursor_list_neu.rs
+++ b/src/trace/cursor/cursor_list_neu.rs
@@ -1,0 +1,167 @@
+//! A generic cursor implementation merging multiple cursors.
+
+use super::Cursor;
+
+/// Provides a cursor interface over a list of cursors.
+///
+/// The `CursorList` tracks the indices of cursors with the minimum key, and the the indices of cursors with
+/// the minimum key and minimum value. It performs no clever management of these sets otherwise.
+#[derive(Debug)]
+pub struct CursorList<K, V, T, R, C: Cursor<K, V, T, R>> {
+	_phantom: ::std::marker::PhantomData<(K, V, T, R)>,
+	cursors: Vec<C>,
+	min_key: Vec<usize>,
+	min_val: Vec<usize>,
+}
+
+impl<K, V, T, R, C: Cursor<K, V, T, R>> CursorList<K, V, T, R, C> where K: Ord, V: Ord {
+	/// Creates a new cursor list from pre-existing cursors.
+	pub fn new(cursors: Vec<C>, storage: &Vec<C::Storage>) -> Self {
+
+		let mut result = CursorList {
+			_phantom: ::std::marker::PhantomData,
+			cursors: cursors.into_iter().collect(),
+			min_key: Vec::new(),
+			min_val: Vec::new(),
+		};
+
+		result.minimize_keys(storage);
+		result
+	}
+
+	// Initialize min_key with the indices of cursors with the minimum key.
+	fn minimize_keys(&mut self, storage: &Vec<C::Storage>) {
+
+		self.min_key.clear();
+
+		// Determine the index of the cursor with minimum key.
+		let mut min_key_index: Option<usize> = None;
+		for (index, cursor) in self.cursors.iter().enumerate() {
+			if cursor.key_valid(&storage[index]) {
+				if let Some(min_index) = min_key_index {
+					if cursor.key(&storage[index]).lt(self.cursors[min_index].key(&storage[min_index])) {
+						min_key_index = Some(index);
+					}
+				}
+				else {
+					min_key_index = Some(index);
+				}
+			}
+		}
+		// Install each index with equal key.
+		if let Some(min_index) = min_key_index {
+			for (index, cursor) in self.cursors.iter().enumerate() {
+				if cursor.key_valid(&storage[index]) {
+					if cursor.key(&storage[index]).eq(self.cursors[min_index].key(&storage[min_index])) {
+						self.min_key.push(index);
+					}
+				}
+			}
+		}
+
+		self.minimize_vals(storage);
+	}
+
+	// Initialize min_val with the indices of minimum key cursors with the minimum value.
+	fn minimize_vals(&mut self, storage: &Vec<C::Storage>) {
+
+		self.min_val.clear();
+
+		// Determine the index of the cursor with minimum value.
+		let mut min_val_index: Option<usize> = None;
+		for &index in self.min_key.iter() {
+			if self.cursors[index].val_valid(&storage[index]) {
+				if let Some(min_index) = min_val_index {
+					if self.cursors[index].val(&storage[index]).lt(self.cursors[min_index].val(&storage[min_index])) {
+						min_val_index = Some(index);
+					}
+				}
+				else {
+					min_val_index = Some(index);
+				}
+			}
+		}
+		// Install each index with equal value.
+		if let Some(min_index) = min_val_index {
+			for &index in self.min_key.iter() {
+				if self.cursors[index].val_valid(&storage[index]) {
+					if self.cursors[index].val(&storage[index]).eq(self.cursors[min_index].val(&storage[min_index])) {
+						self.min_val.push(index);
+					}
+				}
+			}
+		}
+	}
+}
+
+impl<K, V, T, R, C: Cursor<K, V, T, R>> Cursor<K, V, T, R> for CursorList<K, V, T, R, C>
+where
+	K: Ord,
+	V: Ord {
+
+	type Storage = Vec<C::Storage>;
+
+	// validation methods
+	fn key_valid(&self, _storage: &Self::Storage) -> bool { !self.min_key.is_empty() }
+	fn val_valid(&self, _storage: &Self::Storage) -> bool { !self.min_val.is_empty() }
+
+	// accessors
+	fn key<'a>(&self, storage: &'a Self::Storage) -> &'a K {
+		debug_assert!(self.key_valid(storage));
+		assert!(self.cursors[self.min_key[0]].key_valid(&storage[self.min_key[0]]));
+		self.cursors[self.min_key[0]].key(&storage[self.min_key[0]])
+	}
+	fn val<'a>(&self, storage: &'a Self::Storage) -> &'a V {
+		debug_assert!(self.key_valid(storage));
+		debug_assert!(self.val_valid(storage));
+		assert!(self.cursors[self.min_val[0]].val_valid(&storage[self.min_val[0]]));
+		self.cursors[self.min_val[0]].val(&storage[self.min_val[0]])
+	}
+	fn map_times<L: FnMut(&T, R)>(&mut self, storage: &Self::Storage, mut logic: L) {
+		for &index in self.min_val.iter() {
+			self.cursors[index].map_times(&storage[index], |t,d| logic(t,d));
+		}
+	}
+
+	// key methods
+	fn step_key(&mut self, storage: &Self::Storage) {
+		for &index in self.min_key.iter() {
+			self.cursors[index].step_key(&storage[index]);
+		}
+		self.minimize_keys(storage);
+	}
+	fn seek_key(&mut self, storage: &Self::Storage, key: &K) {
+		for index in 0 .. self.cursors.len() {
+			self.cursors[index].seek_key(&storage[index], key);
+		}
+		self.minimize_keys(storage);
+	}
+
+	// value methods
+	fn step_val(&mut self, storage: &Self::Storage) {
+		for &index in self.min_val.iter() {
+			self.cursors[index].step_val(&storage[index]);
+		}
+		self.minimize_vals(storage);
+	}
+	fn seek_val(&mut self, storage: &Self::Storage, val: &V) {
+		for &index in self.min_key.iter() {
+			self.cursors[index].seek_val(&storage[index], val);
+		}
+		self.minimize_vals(storage);
+	}
+
+	// rewinding methods
+	fn rewind_keys(&mut self, storage: &Self::Storage) {
+		for index in 0 .. self.cursors.len() {
+			self.cursors[index].rewind_keys(&storage[index]);
+		}
+		self.minimize_keys(storage);
+	}
+	fn rewind_vals(&mut self, storage: &Self::Storage) {
+		for &index in self.min_key.iter() {
+			self.cursors[index].rewind_vals(&storage[index]);
+		}
+		self.minimize_vals(storage);
+	}
+}

--- a/src/trace/cursor/mod.rs
+++ b/src/trace/cursor/mod.rs
@@ -1,18 +1,20 @@
 //! Traits and types for navigating order sequences of update tuples.
 //!
 //! The `Cursor` trait contains several methods for efficiently navigating ordered collections
-//! of tuples of the form `(key, val, time, diff)`. The cursor is different from an iterator 
-//! both because it allows navigation on multiple levels (key and val), but also because it 
+//! of tuples of the form `(key, val, time, diff)`. The cursor is different from an iterator
+//! both because it allows navigation on multiple levels (key and val), but also because it
 //! supports efficient seeking (via the `seek_key` and `seek_val` methods).
 
-// pub mod viewers;
 pub mod cursor_list;
 pub mod cursor_pair;
-// pub mod cache;
+pub mod cursor_list_neu;
+
+pub use self::cursor_list_neu::CursorList;
+// pub use self::cursor_list::CursorList;
 
 /// A cursor for navigating ordered `(key, val, time, diff)` updates.
 pub trait Cursor<K, V, T, R> {
-	
+
 	/// Type the cursor addresses data in.
 	type Storage;
 
@@ -47,13 +49,13 @@ pub trait Cursor<K, V, T, R> {
 	fn step_key(&mut self, storage: &Self::Storage);
 	/// Advances the cursor to the specified key. Indicates if the key is valid.
 	fn seek_key(&mut self, storage: &Self::Storage, key: &K);
-	
+
 	/// Advances the cursor to the next value. Indicates if the value is valid.
 	fn step_val(&mut self, storage: &Self::Storage);
 	/// Advances the cursor to the specified value. Indicates if the value is valid.
 	fn seek_val(&mut self, storage: &Self::Storage, val: &V);
 
-	/// Rewinds the cursor to the first key.	
+	/// Rewinds the cursor to the first key.
 	fn rewind_keys(&mut self, storage: &Self::Storage);
 	/// Rewinds the cursor to the first value for current key.
 	fn rewind_vals(&mut self, storage: &Self::Storage);

--- a/src/trace/implementations/spine.rs
+++ b/src/trace/implementations/spine.rs
@@ -7,8 +7,8 @@
 use ::Diff;
 use lattice::Lattice;
 use trace::{Batch, BatchReader, Trace, TraceReader};
-use trace::cursor::cursor_list::CursorList;
-use trace::cursor::Cursor;
+// use trace::cursor::cursor_list::CursorList;
+use trace::cursor::{Cursor, CursorList};
 use trace::Merger;
 
 /// An append-only collection of update tuples.

--- a/src/trace/implementations/spine_fueled.rs
+++ b/src/trace/implementations/spine_fueled.rs
@@ -7,8 +7,8 @@
 use ::Diff;
 use lattice::Lattice;
 use trace::{Batch, BatchReader, Trace, TraceReader};
-use trace::cursor::cursor_list::CursorList;
-use trace::cursor::Cursor;
+// use trace::cursor::cursor_list::CursorList;
+use trace::cursor::{Cursor, CursorList};
 use trace::Merger;
 
 enum MergeState<K, V, T, R, B: Batch<K, V, T, R>> {


### PR DESCRIPTION
This PR introduces a simpler implementation of `CursorList`, the type responsible for live-merging Cursors. The previous implementation was *very clever*, and would do a good job with unboundedly many cursors by maintaining things in *very clever* sorted order. It was all a bit complicated, especially given that there should typically be at most a logarithmic number of batches being merged.

Anyhow, this version is simpler, and just tracks for a list of cursors:

1. The list of indices of cursors with the smallest valid key, and of those
2. The list of indices of cursors with the smallest valid value.

Each time you step or seek a key, it steps minimum keys or seeks in all cursors, respectively. When you step or seek a value, it does this but restricted to the minimum values or minimum keys, respectively.

The upside of this is a 20% throughput increase in a simple `Count` benchmark. That is a pretty solid improvement, from my point of view. All other tests pass; no benchmarking done for other applications, but they should be generally improved by the simplification of the cursor navigation logic.