### PR TITLE
Generalize feedback

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ abomonation = "0.7"
 abomonation_derive = "0.3"
 timely_sort="0.1.6"
 #timely = "0.7"
-timely = { git = "https://github.com/frankmcsherry/timely-dataflow" }
+timely = { git = "https://github.com/frankmcsherry/timely-dataflow", branch = "generalize_feedback" }
 fnv="1.0.2"
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ abomonation = "0.7"
 abomonation_derive = "0.3"
 timely_sort="0.1.6"
 #timely = "0.7"
-timely = { git = "https://github.com/frankmcsherry/timely-dataflow", branch = "generalize_feedback" }
+timely = { git = "https://github.com/frankmcsherry/timely-dataflow" }
 fnv="1.0.2"
 
 [profile.release]

--- a/examples/bijkstra.rs
+++ b/examples/bijkstra.rs
@@ -4,6 +4,7 @@ extern crate differential_dataflow;
 
 use rand::{Rng, SeedableRng, StdRng};
 
+use timely::progress::nested::product::Product;
 use timely::dataflow::*;
 use timely::dataflow::operators::probe::Handle;
 
@@ -107,8 +108,8 @@ where G::Timestamp: Lattice+Ord {
         // is a corresponding destination or source that has not yet been reached.
 
         // forward and reverse (node, (root, dist))
-        let forward = Variable::new_from(goals.map(|(x,_)| (x,(x,0))).enter(inner), u64::max_value(), 1);
-        let reverse = Variable::new_from(goals.map(|(_,y)| (y,(y,0))).enter(inner), u64::max_value(), 1);
+        let forward = Variable::new_from(goals.map(|(x,_)| (x,(x,0))).enter(inner), Product::new(Default::default(), 1));
+        let reverse = Variable::new_from(goals.map(|(_,y)| (y,(y,0))).enter(inner), Product::new(Default::default(), 1));
 
         let goals = goals.enter(inner);
         let edges = edges.enter(inner);

--- a/examples/dataflog.rs
+++ b/examples/dataflog.rs
@@ -19,7 +19,7 @@ use differential_dataflow::lattice::Lattice;
 /// addition of collections, and a final `distinct` operator applied before connecting the definition.
 pub struct Variable<'a, G: Scope, D: Default+Data+Hashable>
 where G::Timestamp: Lattice+Ord {
-    feedback: Option<Handle<G::Timestamp, u64,(D, Product<G::Timestamp, u64>, isize)>>,
+    feedback: Option<Handle<Product<G::Timestamp, u64>, (D, Product<G::Timestamp, u64>, isize)>>,
     current: Collection<Child<'a, G, u64>, D>,
     cycle: Collection<Child<'a, G, u64>, D>,
 }
@@ -27,7 +27,7 @@ where G::Timestamp: Lattice+Ord {
 impl<'a, G: Scope, D: Default+Data+Hashable> Variable<'a, G, D> where G::Timestamp: Lattice+Ord {
     /// Creates a new `Variable` from a supplied `source` stream.
     pub fn from(source: &Collection<Child<'a, G, u64>, D>) -> Variable<'a, G, D> {
-        let (feedback, cycle) = source.inner.scope().loop_variable(u64::max_value(), 1);
+        let (feedback, cycle) = source.inner.scope().loop_variable(Product::new(Default::default(), 1));
         let cycle = Collection::new(cycle);
         let mut result = Variable { feedback: Some(feedback), current: cycle.clone(), cycle: cycle };
         result.add(source);

--- a/examples/dataflog.rs
+++ b/examples/dataflog.rs
@@ -27,7 +27,7 @@ where G::Timestamp: Lattice+Ord {
 impl<'a, G: Scope, D: Default+Data+Hashable> Variable<'a, G, D> where G::Timestamp: Lattice+Ord {
     /// Creates a new `Variable` from a supplied `source` stream.
     pub fn from(source: &Collection<Child<'a, G, u64>, D>) -> Variable<'a, G, D> {
-        let (feedback, cycle) = source.inner.scope().loop_variable(Product::new(Default::default(), 1));
+        let (feedback, cycle) = source.inner.scope().loop_variable(1);
         let cycle = Collection::new(cycle);
         let mut result = Variable { feedback: Some(feedback), current: cycle.clone(), cycle: cycle };
         result.add(source);

--- a/examples/doop.rs
+++ b/examples/doop.rs
@@ -59,22 +59,19 @@ type MethodInvocation = Instruction;
 
 /// Set-valued collection.
 pub struct Relation<'a, G: Scope, D: Data+Hashable> where G::Timestamp : Lattice {
-    variable: Variable<'a, G, D, Iter, Diff>,
+    variable: Variable<Child<'a, G, Iter>, D, Diff>,
     current: Collection<Child<'a, G, Iter>, D, Diff>,
 }
 
 impl<'a, G: Scope, D: Data+Hashable> Relation<'a, G, D> where G::Timestamp : Lattice {
     /// Creates a new variable initialized with `source`.
     pub fn new(scope: &mut Child<'a, G, Iter>) -> Self {
-        let variable = Variable::new(scope, Iter::max_value(), 1);
-        Relation {
-            variable: variable,
-            current: ::timely::dataflow::operators::generic::operator::empty(scope).as_collection(),
-        }
+        Self::new_from(&::timely::dataflow::operators::generic::operator::empty(scope).as_collection())
     }
     /// Creates a new variable initialized with `source`.
     pub fn new_from(source: &Collection<Child<'a, G, Iter>, D>) -> Self {
-        let variable = Variable::new_from(source.clone(), Iter::max_value(), 1);
+        use ::timely::progress::nested::product::Product;
+        let variable = Variable::new_from(source.clone(), Product::new(Default::default(), 1));
         Relation {
             variable: variable,
             current: source.clone(),

--- a/experiments/Cargo.toml
+++ b/experiments/Cargo.toml
@@ -9,6 +9,6 @@ rand="0.3.13"
 abomonation = "0.7"
 abomonation_derive = "0.3"
 #timely = "0.7"
-timely = { git = "https://github.com/frankmcsherry/timely-dataflow", branch = "subscope_rework" }
+timely = { git = "https://github.com/frankmcsherry/timely-dataflow", branch = "generalize_feedback" }
 differential-dataflow = { path = "../" }
 graph_map = { git = "https://github.com/frankmcsherry/graph-map" }

--- a/experiments/Cargo.toml
+++ b/experiments/Cargo.toml
@@ -9,6 +9,6 @@ rand="0.3.13"
 abomonation = "0.7"
 abomonation_derive = "0.3"
 #timely = "0.7"
-timely = { git = "https://github.com/frankmcsherry/timely-dataflow", branch = "generalize_feedback" }
+timely = { git = "https://github.com/frankmcsherry/timely-dataflow" }
 differential-dataflow = { path = "../" }
 graph_map = { git = "https://github.com/frankmcsherry/graph-map" }

--- a/experiments/src/bin/arrange.rs
+++ b/experiments/src/bin/arrange.rs
@@ -160,7 +160,7 @@ fn main() {
                         let elapsed_ns = elapsed.as_secs() * 1_000_000_000 + (elapsed.subsec_nanos() as u64);
 
                         // Determine completed ns.
-                        let acknowledged_ns: u64 = probe.with_frontier(|frontier| frontier[0].inner);
+                        let acknowledged_ns: u64 = probe.with_frontier(|frontier| frontier[0]);
 
                         // any un-recorded measurements that are complete should be recorded.
                         while ((ack_counter * ns_per_request) as u64) < acknowledged_ns && ack_counter < ack_target {

--- a/experiments/src/bin/attend.rs
+++ b/experiments/src/bin/attend.rs
@@ -25,14 +25,14 @@ fn main() {
             let (input, graph) = scope.new_collection();
 
             let organizers = graph.explode(|(x,y)| Some((x, DiffPair::new(1,0))).into_iter().chain(Some((y, DiffPair::new(0,1))).into_iter()))
-                                  .threshold_total(|w| if w.element2 == 0 { 1 } else { 0 });
+                                  .threshold_total(|_,w| if w.element2 == 0 { 1 } else { 0 });
 
             organizers
                 .iterate(|attend| {
                     graph.enter(&attend.scope())
                          .semijoin(attend)
                          .map(|(_,y)| y)
-                         .threshold_total(|w| if w >= 3 { 1 } else { 0 })
+                         .threshold_total(|_,w| if w >= 3 { 1 } else { 0 })
                          .concat(&organizers.enter(&attend.scope()))
                          .consolidate()
                 })

--- a/experiments/src/bin/graphs-interactive-alt.rs
+++ b/experiments/src/bin/graphs-interactive-alt.rs
@@ -7,6 +7,7 @@ use rand::{Rng, SeedableRng, StdRng};
 
 use timely::dataflow::*;
 use timely::dataflow::operators::probe::Handle;
+use timely::progress::nested::product::Product;
 
 use differential_dataflow::input::Input;
 use differential_dataflow::Collection;
@@ -17,6 +18,7 @@ use differential_dataflow::operators::arrange::ArrangeByKey;
 use differential_dataflow::operators::arrange::ArrangeBySelf;
 
 type Node = usize;
+type Iter = usize;
 
 fn main() {
 
@@ -185,7 +187,7 @@ fn main() {
             let elapsed_ns: usize = (elapsed.as_secs() * 1_000_000_000 + (elapsed.subsec_nanos() as u64)) as usize;
 
             // Determine completed ns.
-            let acknowledged_ns: usize = probe.with_frontier(|frontier| frontier[0].inner);
+            let acknowledged_ns: usize = probe.with_frontier(|frontier| frontier[0]);
 
             // any un-recorded measurements that are complete should be recorded.
             while (ack_counter * ns_per_request) < acknowledged_ns && ack_counter < ack_target {
@@ -294,19 +296,18 @@ where G::Timestamp: Lattice+Ord {
 fn _bidijkstra<G: Scope>(
     forward_graph: &Arrange<G, Node, Node, isize>,
     reverse_graph: &Arrange<G, Node, Node, isize>,
-    goals: &Collection<G, (Node, Node)>,
-    bound: u64) -> Collection<G, ((Node, Node), u32)>
+    goals: &Collection<G, (Node, Node)>) -> Collection<G, ((Node, Node), u32)>
 where G::Timestamp: Lattice+Ord {
 
-    goals.scope().scoped(|inner| {
+    goals.scope().iterative::<Iter,_,_>(|inner| {
 
         // Our plan is to start evolving distances from both sources and destinations.
         // The evolution from a source or destination should continue as long as there
         // is a corresponding destination or source that has not yet been reached.
 
         // forward and reverse (node, (root, dist))
-        let forward = Variable::new_from(goals.map(|(x,_)| (x,(x,0))).enter(inner), bound, 1);
-        let reverse = Variable::new_from(goals.map(|(_,y)| (y,(y,0))).enter(inner), bound, 1);
+        let forward = Variable::new_from(goals.map(|(x,_)| (x,(x,0))).enter(inner), Product::new(Default::default(), 1));
+        let reverse = Variable::new_from(goals.map(|(_,y)| (y,(y,0))).enter(inner), Product::new(Default::default(), 1));
 
         let goals = goals.enter(inner);
         let forward_graph = forward_graph.enter(inner);

--- a/experiments/src/bin/graphs-interactive-neu-zwei.rs
+++ b/experiments/src/bin/graphs-interactive-neu-zwei.rs
@@ -150,7 +150,7 @@ fn main() {
             let elapsed_ns: usize = (elapsed.as_secs() * 1_000_000_000 + (elapsed.subsec_nanos() as u64)) as usize;
 
             // Determine completed ns.
-            let acknowledged_ns: usize = probe.with_frontier(|frontier| frontier[0].inner);
+            let acknowledged_ns: usize = probe.with_frontier(|frontier| frontier[0]);
 
             // any un-recorded measurements that are complete should be recorded.
             while (ack_counter * ns_per_request) < acknowledged_ns && ack_counter < ack_target {

--- a/experiments/src/bin/graphs-interactive-neu.rs
+++ b/experiments/src/bin/graphs-interactive-neu.rs
@@ -7,6 +7,7 @@ use rand::{Rng, SeedableRng, StdRng};
 
 use timely::dataflow::*;
 use timely::dataflow::operators::probe::Handle;
+use timely::progress::nested::product::Product;
 
 use differential_dataflow::input::Input;
 use differential_dataflow::Collection;
@@ -17,6 +18,7 @@ use differential_dataflow::operators::arrange::ArrangeByKey;
 use differential_dataflow::operators::arrange::ArrangeBySelf;
 
 type Node = usize;
+type Iter = usize;
 
 fn main() {
 
@@ -187,7 +189,7 @@ fn main() {
             let elapsed_ns: usize = (elapsed.as_secs() * 1_000_000_000 + (elapsed.subsec_nanos() as u64)) as usize;
 
             // Determine completed ns.
-            let acknowledged_ns: usize = probe.with_frontier(|frontier| frontier[0].inner);
+            let acknowledged_ns: usize = probe.with_frontier(|frontier| frontier[0]);
 
             // any un-recorded measurements that are complete should be recorded.
             while (ack_counter * ns_per_request) < acknowledged_ns && ack_counter < ack_target {
@@ -328,19 +330,18 @@ where G::Timestamp: Lattice+Ord {
 fn _bidijkstra<G: Scope>(
     forward_graph: &Arrange<G, Node, Node, isize>,
     reverse_graph: &Arrange<G, Node, Node, isize>,
-    goals: &Collection<G, (Node, Node)>,
-    bound: u64) -> Collection<G, ((Node, Node), u32)>
+    goals: &Collection<G, (Node, Node)>) -> Collection<G, ((Node, Node), u32)>
 where G::Timestamp: Lattice+Ord {
 
-    goals.scope().scoped(|inner| {
+    goals.scope().iterative::<Iter,_,_>(|inner| {
 
         // Our plan is to start evolving distances from both sources and destinations.
         // The evolution from a source or destination should continue as long as there
         // is a corresponding destination or source that has not yet been reached.
 
         // forward and reverse (node, (root, dist))
-        let forward = Variable::new_from(goals.map(|(x,_)| (x,(x,0))).enter(inner), bound, 1);
-        let reverse = Variable::new_from(goals.map(|(_,y)| (y,(y,0))).enter(inner), bound, 1);
+        let forward = Variable::new_from(goals.map(|(x,_)| (x,(x,0))).enter(inner), Product::new(Default::default(), 1));
+        let reverse = Variable::new_from(goals.map(|(_,y)| (y,(y,0))).enter(inner), Product::new(Default::default(), 1));
 
         let goals = goals.enter(inner);
         let forward_graph = forward_graph.enter(inner);

--- a/experiments/src/bin/graphs-interactive.rs
+++ b/experiments/src/bin/graphs-interactive.rs
@@ -7,6 +7,7 @@ use rand::{Rng, SeedableRng, StdRng};
 
 use timely::dataflow::*;
 use timely::dataflow::operators::probe::Handle;
+use timely::progress::nested::product::Product;
 
 use differential_dataflow::input::Input;
 use differential_dataflow::Collection;
@@ -17,6 +18,7 @@ use differential_dataflow::operators::arrange::ArrangeByKey;
 use differential_dataflow::operators::arrange::ArrangeBySelf;
 
 type Node = usize;
+type Iter = usize;
 
 fn main() {
 
@@ -235,19 +237,18 @@ where G::Timestamp: Lattice+Ord {
 fn _bidijkstra<G: Scope>(
     forward_graph: &Arrange<G, Node, Node, isize>,
     reverse_graph: &Arrange<G, Node, Node, isize>,
-    goals: &Collection<G, (Node, Node)>,
-    bound: u64) -> Collection<G, ((Node, Node), u32)>
+    goals: &Collection<G, (Node, Node)>) -> Collection<G, ((Node, Node), u32)>
 where G::Timestamp: Lattice+Ord {
 
-    goals.scope().scoped(|inner| {
+    goals.scope().iterative::<Iter,_,_>(|inner| {
 
         // Our plan is to start evolving distances from both sources and destinations.
         // The evolution from a source or destination should continue as long as there
         // is a corresponding destination or source that has not yet been reached.
 
         // forward and reverse (node, (root, dist))
-        let forward = Variable::new_from(goals.map(|(x,_)| (x,(x,0))).enter(inner), bound, 1);
-        let reverse = Variable::new_from(goals.map(|(_,y)| (y,(y,0))).enter(inner), bound, 1);
+        let forward = Variable::new_from(goals.map(|(x,_)| (x,(x,0))).enter(inner), Product::new(Default::default(), 1));
+        let reverse = Variable::new_from(goals.map(|(_,y)| (y,(y,0))).enter(inner), Product::new(Default::default(), 1));
 
         let goals = goals.enter(inner);
         let forward_graph = forward_graph.enter(inner);

--- a/experiments/src/bin/graphs.rs
+++ b/experiments/src/bin/graphs.rs
@@ -8,17 +8,12 @@ use rand::{Rng, SeedableRng, StdRng};
 
 use timely::dataflow::*;
 
-use timely::progress::nested::product::Product;
-use timely::progress::timestamp::RootTimestamp;
-
 use differential_dataflow::input::Input;
 use differential_dataflow::Collection;
 use differential_dataflow::operators::*;
 use differential_dataflow::trace::Trace;
 use differential_dataflow::operators::arrange::ArrangeByKey;
 use differential_dataflow::operators::arrange::ArrangeBySelf;
-// use differential_dataflow::operators::group::GroupArranged;
-use differential_dataflow::operators::arrange::Arrange;
 
 use differential_dataflow::trace::implementations::spine_fueled::Spine;
 
@@ -27,8 +22,8 @@ type Node = usize;
 use differential_dataflow::trace::implementations::ord::OrdValBatch;
 // use differential_dataflow::trace::implementations::ord::OrdValSpine;
 
-// type GraphTrace<N> = Spine<usize, N, Product<RootTimestamp, ()>, isize, Rc<GraphBatch<N>>>;
-type GraphTrace = Spine<Node, Node, Product<RootTimestamp, ()>, isize, Rc<OrdValBatch<Node, Node, Product<RootTimestamp, ()>, isize>>>;
+// type GraphTrace<N> = Spine<usize, N, (), isize, Rc<GraphBatch<N>>>;
+type GraphTrace = Spine<Node, Node, (), isize, Rc<OrdValBatch<Node, Node, (), isize>>>;
 
 fn main() {
 
@@ -103,9 +98,9 @@ fn main() {
 // use differential_dataflow::trace::implementations::ord::OrdValSpine;
 use differential_dataflow::operators::arrange::TraceAgent;
 
-type TraceHandle = TraceAgent<Node, Node, Product<RootTimestamp, ()>, isize, GraphTrace>;
+type TraceHandle = TraceAgent<Node, Node, (), isize, GraphTrace>;
 
-fn reach<G: Scope<Timestamp = Product<RootTimestamp, ()>>> (
+fn reach<G: Scope<Timestamp = ()>> (
     graph: &mut TraceHandle,
     roots: Collection<G, Node>
 ) -> Collection<G, Node> {
@@ -127,7 +122,7 @@ fn reach<G: Scope<Timestamp = Product<RootTimestamp, ()>>> (
 }
 
 
-fn bfs<G: Scope<Timestamp = Product<RootTimestamp, ()>>> (
+fn bfs<G: Scope<Timestamp = ()>> (
     graph: &mut TraceHandle,
     roots: Collection<G, Node>
 ) -> Collection<G, (Node, u32)> {
@@ -146,7 +141,7 @@ fn bfs<G: Scope<Timestamp = Product<RootTimestamp, ()>>> (
     })
 }
 
-// fn connected_components<G: Scope<Timestamp = Product<RootTimestamp, ()>>>(
+// fn connected_components<G: Scope<Timestamp = ()>>(
 //     graph: &mut TraceHandle<Node>
 // ) -> Collection<G, (Node, Node)> {
 

--- a/experiments/src/bin/graspan-interactive.rs
+++ b/experiments/src/bin/graspan-interactive.rs
@@ -5,6 +5,7 @@ extern crate differential_dataflow;
 use std::io::{BufRead, BufReader};
 use std::fs::File;
 
+// use timely::progress::nested::product::Product;
 // use timely::dataflow::operators::{Accumulate, Inspect};
 use differential_dataflow::input::Input;
 // use differential_dataflow::trace::Trace;
@@ -99,7 +100,7 @@ fn main() {
                             "n" => {
 
                                 nodes.remove((src, dst));
-                                let round = nodes.time().inner;
+                                let round = nodes.time() + 0;
                                 nodes.advance_to(round + 1);
                                 nodes.flush();
 

--- a/src/operators/iterate.rs
+++ b/src/operators/iterate.rs
@@ -38,7 +38,7 @@ use timely::progress::nested::product::Product;
 
 use timely::dataflow::*;
 use timely::dataflow::scopes::child::Iterative;
-use timely::dataflow::operators::*;
+use timely::dataflow::operators::{Feedback, ConnectLoop, Map};
 use timely::dataflow::operators::feedback::Handle;
 
 use ::{Data, Collection, Diff};
@@ -155,7 +155,7 @@ impl<G: Scope, D: Data, R: Diff> Variable<G, D, R> where G::Timestamp: Lattice {
 
     /// Creates a new `Variable` from a supplied `source` stream.
     pub fn new_from(source: Collection<G, D, R>, step: <G::Timestamp as Timestamp>::Summary) -> Self {
-        let (feedback, updates) = source.inner.scope().loop_variable(step.clone());
+        let (feedback, updates) = source.inner.scope().feedback(step.clone());
         let collection = Collection::new(updates).concat(&source);
         Variable { collection, feedback, source, step }
     }


### PR DESCRIPTION
This tracks timely changes that generalize the feedback operator. These changes allow `iterate::Variable` instances in scopes that are not iterative scopes, for example a root scope. The complication, which we might tackle with ergonomic work-arounds, is that when creating a `Variable` the summary argument must be relative to the ambient timestamp. That is most commonly `Product::new(Default::default(), summary)`, which is a bit gross but perhaps something we can live with until we learn better.