### PR TITLE
Event driven

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,9 @@ serde_derive = "1.0"
 abomonation = "0.7"
 abomonation_derive = "0.3"
 timely_sort="0.1.6"
-timely = "0.8"
+#timely = "0.8"
+#timely = { git = "https://github.com/frankmcsherry/timely-dataflow", branch = "operate_rework" }
+timely = { path = "../timely-dataflow/" }
 fnv="1.0.2"
 graph_map = "0.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ abomonation = "0.7"
 abomonation_derive = "0.3"
 timely_sort="0.1.6"
 #timely = "0.8"
-#timely = { git = "https://github.com/frankmcsherry/timely-dataflow", branch = "operate_rework" }
-timely = { path = "../timely-dataflow/" }
+timely = { git = "https://github.com/frankmcsherry/timely-dataflow", branch = "operate_rework" }
+#timely = { path = "../timely-dataflow/" }
 fnv="1.0.2"
 graph_map = "0.1"
 

--- a/doop/Cargo.toml
+++ b/doop/Cargo.toml
@@ -5,5 +5,6 @@ authors = ["Frank McSherry <fmcsherry@me.com>"]
 
 [dependencies]
 indexmap = "1.0.1"
-timely = "0.8"
+#timely = "0.8"
+timely = { path = "../../timely-dataflow" }
 differential-dataflow = { path = "../" }

--- a/examples/arrange.rs
+++ b/examples/arrange.rs
@@ -38,7 +38,7 @@ fn main() {
     	let mut graph = worker.dataflow::<Product<(),usize>,_,_>(|scope| {
 
             // create a source operator which will produce random edges and delete them.
-            timely::dataflow::operators::generic::source(scope, "RandomGraph", |mut capability| {
+            timely::dataflow::operators::generic::source(scope, "RandomGraph", |mut capability, _info| {
 
                 let seed: &[_] = &[1, 2, 3, index];
                 let mut rng1: StdRng = SeedableRng::from_seed(seed);    // rng for edge additions

--- a/src/operators/arrange.rs
+++ b/src/operators/arrange.rs
@@ -265,7 +265,7 @@ where T: Lattice+Ord+Clone+'static, Tr: TraceReader<K,V,T,R> {
 
         let queue = self.new_listener();
 
-        let collection = source(scope, "ArrangedSource", move |capability| {
+        let collection = source(scope, "ArrangedSource", move |capability, _info| {
 
             // capabilities the source maintains.
             let mut capabilities = vec![capability];

--- a/src/operators/iterate.rs
+++ b/src/operators/iterate.rs
@@ -76,8 +76,9 @@ pub trait Iterate<G: Scope, D: Data, R: Diff> {
     /// }
     /// ```
     fn iterate<F>(&self, logic: F) -> Collection<G, D, R>
-        where G::Timestamp: Lattice,
-              for<'a> F: FnOnce(&Collection<Iterative<'a, G, u64>, D, R>)->Collection<Iterative<'a, G, u64>, D, R>;
+        where
+            G::Timestamp: Lattice,
+            for<'a> F: FnOnce(&Collection<Iterative<'a, G, u64>, D, R>)->Collection<Iterative<'a, G, u64>, D, R>;
 }
 
 impl<G: Scope, D: Ord+Data+Debug, R: Diff> Iterate<G, D, R> for Collection<G, D, R> {
@@ -140,7 +141,7 @@ impl<G: Scope, D: Ord+Data+Debug, R: Diff> Iterate<G, D, R> for Collection<G, D,
 pub struct Variable<G: Scope, D: Data, R: Diff>
 where G::Timestamp: Lattice {
     collection: Collection<G, D, R>,
-    feedback: Handle<G::Timestamp, (D, G::Timestamp, R)>,
+    feedback: Handle<G, (D, G::Timestamp, R)>,
     source: Collection<G, D, R>,
     step: <G::Timestamp as Timestamp>::Summary,
 }

--- a/tests/trace.rs
+++ b/tests/trace.rs
@@ -17,7 +17,7 @@ pub type OrdValSpine<K, V, T, R> = Spine<K, V, T, R, Rc<OrdValBatch<K, V, T, R>>
 type IntegerTrace = OrdValSpine<UnsignedWrapper<u64>, u64, usize, i64>;
 
 fn get_trace() -> Spine<UnsignedWrapper<u64>, u64, usize, i64, Rc<OrdValBatch<UnsignedWrapper<u64>, u64, usize, i64>>> {
-    let op_info = OperatorInfo::new(0, 0);
+    let op_info = OperatorInfo::new(0, 0, &[]);
     let mut trace = IntegerTrace::new(op_info, None);
     {
         let mut batcher = <<


### PR DESCRIPTION
This tracks timely dataflow's `event_driven` branch and corresponding changes.

The main modifications are that operators need to be aware enough to request activations when they have work to do. The two instances of this are `join` (which may yield with work remaining) and the trace `import` (which creates a source that should be activated as new batches arrive).

It is plausible that there are other operators that need additional help, but testing hasn't revealed any yet. Pushing this to master *should* get this exercised. :D