### PR TITLE
Rename Container to BatchContainer, use the columnation export from Timely

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ abomonation_derive = "0.5"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false }
 #timely = { path = "../timely-dataflow/timely/", default-features = false }
 fnv="1.0.2"
-columnation = { git = "http://github.com/frankmcsherry/columnation" }
 
 [features]
 default = ["timely/getopts"]

--- a/examples/capture-test.rs
+++ b/examples/capture-test.rs
@@ -153,7 +153,7 @@ pub mod kafka {
     use differential_dataflow::lattice::Lattice;
 
     /// Creates a Kafka source from supplied configuration information.
-    pub fn create_source<G, D, T, R>(scope: G, addr: &str, topic: &str, group: &str) -> (Box<dyn std::any::Any>, Stream<G, (D, T, R)>)
+    pub fn create_source<G, D, T, R>(scope: G, addr: &str, topic: &str, group: &str) -> (Box<dyn std::any::Any + Send + Sync>, Stream<G, (D, T, R)>)
     where
         G: Scope<Timestamp = T>,
         D: ExchangeData + Hash + for<'a> serde::Deserialize<'a>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,6 @@ impl<T: timely::ExchangeData + Ord + Debug> ExchangeData for T { }
 
 extern crate fnv;
 extern crate timely;
-extern crate columnation;
 
 #[macro_use]
 extern crate abomonation_derive;

--- a/src/trace/layers/ordered.rs
+++ b/src/trace/layers/ordered.rs
@@ -1,6 +1,6 @@
 //! Implementation using ordered keys and exponential search.
 
-use super::{Trie, Cursor, Builder, MergeBuilder, TupleBuilder, Container, advance};
+use super::{Trie, Cursor, Builder, MergeBuilder, TupleBuilder, BatchContainer, advance};
 use std::convert::{TryFrom, TryInto};
 use std::fmt::Debug;
 use std::ops::{Sub,Add,Deref};
@@ -23,7 +23,7 @@ where
 pub struct OrderedLayer<K, L, O=usize, C=Vec<K>>
 where
     K: Ord,
-    C: Container<Item=K>+Deref<Target=[K]>,
+    C: BatchContainer<Item=K>+Deref<Target=[K]>,
     O: OrdOffset, <O as TryFrom<usize>>::Error: Debug, <O as TryInto<usize>>::Error: Debug
 {
     /// The keys of the layer.
@@ -40,7 +40,7 @@ where
 impl<K, L, O, C> Trie for OrderedLayer<K, L, O, C>
 where
     K: Ord+Clone,
-    C: Container<Item=K>+Deref<Target=[K]>,
+    C: BatchContainer<Item=K>+Deref<Target=[K]>,
     L: Trie,
     O: OrdOffset, <O as TryFrom<usize>>::Error: Debug, <O as TryInto<usize>>::Error: Debug
 {
@@ -77,7 +77,7 @@ where
 pub struct OrderedBuilder<K, L, O=usize, C=Vec<K>>
 where
     K: Ord+Clone,
-    C: Container<Item=K>+Deref<Target=[K]>,
+    C: BatchContainer<Item=K>+Deref<Target=[K]>,
     O: OrdOffset, <O as TryFrom<usize>>::Error: Debug, <O as TryInto<usize>>::Error: Debug
 {
     /// Keys
@@ -91,7 +91,7 @@ where
 impl<K, L, O, C> Builder for OrderedBuilder<K, L, O, C>
 where
     K: Ord+Clone,
-    C: Container<Item=K>+Deref<Target=[K]>,
+    C: BatchContainer<Item=K>+Deref<Target=[K]>,
     L: Builder,
     O: OrdOffset, <O as TryFrom<usize>>::Error: Debug, <O as TryInto<usize>>::Error: Debug
 {
@@ -115,7 +115,7 @@ where
 impl<K, L, O, C> MergeBuilder for OrderedBuilder<K, L, O, C>
 where
     K: Ord+Clone,
-    C: Container<Item=K>+Deref<Target=[K]>,
+    C: BatchContainer<Item=K>+Deref<Target=[K]>,
     L: MergeBuilder,
     O: OrdOffset, <O as TryFrom<usize>>::Error: Debug, <O as TryInto<usize>>::Error: Debug
 {
@@ -162,7 +162,7 @@ where
 impl<K, L, O, C> OrderedBuilder<K, L, O, C>
 where
     K: Ord+Clone,
-    C: Container<Item=K>+Deref<Target=[K]>,
+    C: BatchContainer<Item=K>+Deref<Target=[K]>,
     L: MergeBuilder,
     O: OrdOffset, <O as TryFrom<usize>>::Error: Debug, <O as TryInto<usize>>::Error: Debug
 {
@@ -210,12 +210,12 @@ where
 impl<K, L, O, C> TupleBuilder for OrderedBuilder<K, L, O, C>
 where
     K: Ord+Clone,
-    C: Container<Item=K>+Deref<Target=[K]>,
+    C: BatchContainer<Item=K>+Deref<Target=[K]>,
     L: TupleBuilder,
     O: OrdOffset, <O as TryFrom<usize>>::Error: Debug, <O as TryInto<usize>>::Error: Debug
 {
     type Item = (K, L::Item);
-    fn new() -> Self { OrderedBuilder { keys: C::new(), offs: vec![O::try_from(0).unwrap()], vals: L::new() } }
+    fn new() -> Self { OrderedBuilder { keys: C::default(), offs: vec![O::try_from(0).unwrap()], vals: L::new() } }
     fn with_capacity(cap: usize) -> Self {
         let mut offs = Vec::with_capacity(cap + 1);
         offs.push(O::try_from(0).unwrap());
@@ -252,7 +252,7 @@ pub struct OrderedCursor<L: Trie> {
 impl<K, L, O, C> Cursor<OrderedLayer<K, L, O, C>> for OrderedCursor<L>
 where
     K: Ord+Clone,
-    C: Container<Item=K>+Deref<Target=[K]>,
+    C: BatchContainer<Item=K>+Deref<Target=[K]>,
     L: Trie,
     O: OrdOffset, <O as TryFrom<usize>>::Error: Debug, <O as TryInto<usize>>::Error: Debug
 {

--- a/src/trace/layers/ordered_leaf.rs
+++ b/src/trace/layers/ordered_leaf.rs
@@ -2,14 +2,14 @@
 
 use ::difference::Semigroup;
 
-use super::{Trie, Cursor, Builder, MergeBuilder, TupleBuilder, Container, advance};
+use super::{Trie, Cursor, Builder, MergeBuilder, TupleBuilder, BatchContainer, advance};
 use std::ops::Deref;
 
 /// A layer of unordered values.
 #[derive(Debug, Eq, PartialEq, Clone, Abomonation)]
 pub struct OrderedLeaf<K, R, C=Vec<(K,R)>>
 where
-    C: Container<Item=(K,R)>+Deref<Target=[(K,R)]>,
+    C: BatchContainer<Item=(K, R)>+Deref<Target=[(K, R)]>,
 {
     /// Unordered values.
     pub vals: C,
@@ -17,7 +17,7 @@ where
 
 impl<K: Ord+Clone, R: Semigroup+Clone, C> Trie for OrderedLeaf<K, R, C>
 where
-    C: Container<Item=(K,R)>+Deref<Target=[(K,R)]>,
+    C: BatchContainer<Item=(K, R)>+Deref<Target=[(K, R)]>,
 {
     type Item = (K, R);
     type Cursor = OrderedLeafCursor;
@@ -36,7 +36,7 @@ where
 /// A builder for unordered values.
 pub struct OrderedLeafBuilder<K, R, C=Vec<(K,R)>>
 where
-    C: Container<Item=(K,R)>+Deref<Target=[(K,R)]>,
+    C: BatchContainer<Item=(K, R)>+Deref<Target=[(K, R)]>,
 {
     /// Unordered values.
     pub vals: C,
@@ -44,7 +44,7 @@ where
 
 impl<K: Ord+Clone, R: Semigroup+Clone, C> Builder for OrderedLeafBuilder<K, R, C>
 where
-    C: Container<Item=(K,R)>+Deref<Target=[(K,R)]>,
+    C: BatchContainer<Item=(K, R)>+Deref<Target=[(K, R)]>,
 {
     type Trie = OrderedLeaf<K, R, C>;
     fn boundary(&mut self) -> usize { self.vals.len() }
@@ -53,7 +53,7 @@ where
 
 impl<K: Ord+Clone, R: Semigroup+Clone, C> MergeBuilder for OrderedLeafBuilder<K, R, C>
 where
-    C: Container<Item=(K,R)>+Deref<Target=[(K,R)]>,
+    C: BatchContainer<Item=(K, R)>+Deref<Target=[(K, R)]>,
 {
     fn with_capacity(other1: &Self::Trie, other2: &Self::Trie) -> Self {
         OrderedLeafBuilder {
@@ -112,10 +112,10 @@ where
 
 impl<K: Ord+Clone, R: Semigroup+Clone, C> TupleBuilder for OrderedLeafBuilder<K, R, C>
 where
-    C: Container<Item=(K,R)>+Deref<Target=[(K,R)]>,
+    C: BatchContainer<Item=(K, R)>+Deref<Target=[(K, R)]>,
 {
     type Item = (K, R);
-    fn new() -> Self { OrderedLeafBuilder { vals: C::new() } }
+    fn new() -> Self { OrderedLeafBuilder { vals: C::default() } }
     fn with_capacity(cap: usize) -> Self { OrderedLeafBuilder { vals: C::with_capacity(cap) } }
     #[inline] fn push_tuple(&mut self, tuple: (K, R)) { self.vals.push(tuple) }
 }
@@ -131,7 +131,7 @@ pub struct OrderedLeafCursor {
 
 impl<K: Clone, R: Clone, C> Cursor<OrderedLeaf<K, R, C>> for OrderedLeafCursor
 where
-    C: Container<Item=(K,R)>+Deref<Target=[(K,R)]>,
+    C: BatchContainer<Item=(K, R)>+Deref<Target=[(K, R)]>,
 {
     type Key = (K, R);
     fn key<'a>(&self, storage: &'a OrderedLeaf<K, R, C>) -> &'a Self::Key { &storage.vals[self.pos] }


### PR DESCRIPTION
Minor cleanup:
* Rename `Container` to `BatchContainer` to avoid name collisions with Timely's container.
* Switch to the columnation re-export from Timely instead of depending directly.